### PR TITLE
Specify Windows SDK version explicitly

### DIFF
--- a/Sazabi.vcxproj
+++ b/Sazabi.vcxproj
@@ -15,7 +15,7 @@
     <SccLocalPath />
     <Keyword>MFCProj</Keyword>
     <ProjectGuid>{83410426-0B15-352C-4BC5-CCD2A7EF1930}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='D64_CSG|Win32'" Label="Configuration">


### PR DESCRIPTION
When `10.0` is specified, latest version of Windows SDK is used but Windows SDK 10.0.22621.0 causes following error:

```
2022-09-14T02:33:16.7678454Z          C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\bin\HostX86\x86\CL.exe /c /Zi /nologo /W3 /WX- /diagnostics:column /O2 /Ob2 /Oi /Ot /Oy /GT /GL /D WIN32 /D NDEBUG /D _WINDOWS /D _VC80_UPGRADE=0x0600 /D _UNICODE /D UNICODE /GF /Gm- /EHa /MT /GS /Gy /arch:SSE2 /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Yc"stdafx.h" /Fp".\ChronosRelease\Sazabi.pch" /Fo".\ChronosRelease\\" /Fd".\ChronosRelease\vc142.pdb" /external:W3 /Gd /TP /analyze- /FC /errorReport:queue /source-charset:.932 StdAfx.cpp
2022-09-14T02:33:17.8157394Z          StdAfx.cpp
2022-09-14T02:33:28.4727484Z      2>C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\Winhttp.h(256,21): error C3646: 'ProxyScheme': unknown override specifier [D:\a\Chronos\Chronos\Sazabi.vcxproj]
2022-09-14T02:33:28.4728662Z      2>C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\Winhttp.h(256,32): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int [D:\a\Chronos\Chronos\Sazabi.vcxproj]
2022-09-14T02:33:28.5033965Z      2>C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\Winhttp.h(1589,13): error C2061: syntax error: identifier 'LPURL_COMPONENTS_ANOTHER' [D:\a\Chronos\Chronos\Sazabi.vcxproj]
2022-09-14T02:33:28.5035633Z      2>C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\Winhttp.h(1598,10): error C2065: 'LPURL_COMPONENTS_ANOTHER': undeclared identifier [D:\a\Chronos\Chronos\Sazabi.vcxproj]
2022-09-14T02:33:28.5041110Z      2>C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\Winhttp.h(1598,27): error C2146: syntax error: missing ')' before identifier 'lpUrlComponents' [D:\a\Chronos\Chronos\Sazabi.vcxproj]
2022-09-14T02:33:28.5042240Z      2>C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\Winhttp.h(1760,10): error C2061: syntax error: identifier 'INTERNET_SCHEME_ANOTHER' [D:\a\Chronos\Chronos\Sazabi.vcxproj]
2022-09-14T02:33:30.1023691Z      2>Done Building Project "D:\a\Chronos\Chronos\Sazabi.vcxproj" (default targets) -- FAILED.
2022-09-14T02:33:30.1024239Z      1>Done Building Project "D:\a\Chronos\Chronos\Sazabi.sln" (default targets) -- FAILED.
```

So use 10.0.20348.0 instead. 10.0.20348.0 is the latest version we confirmed.