### PR TITLE
Try to build stable and beta

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xe
+
+TOP_DIR=$(dirname $0)/..
+CEF_BAT=$TOP_DIR/setup-cef.bat
+
+VERSION=96.0.16+g89c902b+chromium-96.0.4664.55
+case $1 in
+    stable)
+	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows64.versions[] | select(.channel == "stable").cef_version' | head -n 1)
+	echo $TARGET_VERSION
+	;;
+    beta)
+	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows64.versions[] | select(.channel =="beta").cef_version' | head -n 1)
+	echo $TARGET_VERSION
+	sed -i'' -e s/windows32_minimal/windows32_beta_minimal/ $CEF_BAT
+	;;
+esac
+sed -i'' -e s/$VERSION/$TARGET_VERSION/ $CEF_BAT
+cat $CEF_BAT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,3 +22,57 @@ jobs:
         with:
           name: Chronos
           path: Chronos
+
+  stable:
+    runs-on: [ windows-2019 ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: microsoft/setup-msbuild@v1
+      - name: Use stable version of CEF
+        run: |
+          bash .github/rewrite-cef-version.sh stable
+      - name: Setup cache for CEF
+        uses: actions/cache@v3
+        with:
+          path: cef-cache/*/
+          key: cef-${{ runner.os }}-${{ hashFiles('setup-cef.bat') }}
+      - name: Setup CEF
+        run: .\setup-cef.bat
+      - name: Compile Chronos
+        run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG
+        # Aimed to watch build error, and not to bother build: job, ignore error here.
+        continue-on-error: true
+      # - name: Prepare upload
+      #   run: move R32 Chronos
+      # - name: Upload Build
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: Chronos-stable
+      #     path: Chronos-stable
+
+  beta:
+    runs-on: [ windows-2019 ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: microsoft/setup-msbuild@v1
+      - name: Use beta version of CEF
+        run: |
+          bash .github/rewrite-cef-version.sh beta
+      - name: Setup cache for CEF
+        uses: actions/cache@v3
+        with:
+          path: cef-cache/*/
+          key: cef-${{ runner.os }}-${{ hashFiles('setup-cef.bat') }}
+      - name: Setup CEF
+        run: .\setup-cef.bat
+      - name: Compile Chronos
+        run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG
+        # Aimed to watch build error, and not to bother build: job, ignore error here.
+        continue-on-error: true
+      # - name: Prepare upload
+      #   run: move R32 Chronos
+      # - name: Upload Build
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: Chronos-beta
+      #     path: Chronos-beta


### PR DESCRIPTION
The current version is bound to 96.x, but the current version of stable and beta is newer than it.

To keep up with the stable and beta continuously, it is better to watch the build log.

Note that for stable and beta, the build error is marked as continue-on-error: true, because 
the failing build is a KNOWN error. it is intentional to just watch the current build status.


