### PR TITLE
github: add release note template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: 前回からの互換性のない変更点 🛠
+      labels:
+        - breaking-change
+    - title: 新機能 🎉
+      labels:
+        - enhancement
+    - title: 不具合の修正
+      labels:
+        - bug
+    - title: ドキュメントの更新
+      labels:
+        - documentation
+    - title: その他の変更点
+      labels:
+        - "*"


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

It aims to create a template for release.

https://docs.github.com/ja/repositories/releasing-projects-on-github/automatically-generated-release-notes

# How to verify the fixed issue:

## The steps to verify:

1. Create a new release via [Draft a new release]
2. Confirm auto generated release note.

## Expected result:

It helps to collect fixed issues for release notes.
