### PR TITLE
Fix mismatched message id

### DIFF
--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -2603,7 +2603,7 @@ void CMainFrame::OnAppExitTimeLimit()
 		m_colBrowserWindows.GetNext(pos1);
 	}
 	CString alertMsg;
-	alertMsg.LoadString(IDS_STRING_LOW_SYSTEM_RESOURCE_EXIT);
+	alertMsg.LoadString(IDS_STRING_ALERT_OVER_RUNNING_TIME_LIMIT);
 	logmsg.Format(alertMsg, iLimitTimeBase);
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_EX);
 	if (::IsWindow(ptdFirst->m_hWnd))


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Chronos has a timer to exit it automatically, but it won't work as expected for now.
Moreover, after the timer is fired, browser windows are closed but there is one left process.

# How to verify the fixed issue:

Setup Chronos and configure it to exit with a timer.

## The steps to verify:

1. Start Chronos.
2. Go to Tools => Preferences => Restriction.
3. Check "Restrict running time".
4. Set the input field below the checkbox to "1" or "2".
5. Press "OK".
6. Wait for a while.

## Expected result:

A message dialog is shown and Chronos exits itself completely.