### PR TITLE
github: check windows32 build

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -8,11 +8,11 @@ CEF_BAT=$TOP_DIR/setup-cef.bat
 VERSION=98.2.1+g29d6e22+chromium-98.0.4758.109
 case $1 in
     stable)
-	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows64.versions[] | select(.channel == "stable").cef_version' | head -n 1)
+	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)
 	echo $TARGET_VERSION
 	;;
     beta)
-	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows64.versions[] | select(.channel =="beta").cef_version' | head -n 1)
+	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel =="beta").cef_version' | head -n 1)
 	echo $TARGET_VERSION
 	sed -i'' -e s/windows32_minimal/windows32_beta_minimal/ $CEF_BAT
 	;;


### PR DESCRIPTION

# Which issue(s) this PR fixes:

Follow up of #9.

# What this PR does / why we need it:

In production, we use windows32 minimal build, so it should be "windows32" instead of "windows64".

# How to verify the fixed issue:

See github action logs.

## Expected result:

Use windows32 build information to setup CEF.
