### PR TITLE
Fix a bug that a process is remainined after exit timer is fired

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -2250,7 +2250,7 @@ BOOL CSazabi::PumpMessage()
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
-		return TRUE;
+		return FALSE;
 	}
 }
 ///////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A
(From #21)

# What this PR does / why we need it:

Chronos has a timer to exit it automatically, but it won't work as expected for now.
After the timer is fired and accepting a dialog, browser windows are closed but there is one left process.

# How to verify the fixed issue:

Setup Chronos and configure it to exit with a timer.

## The steps to verify:

1. Start Chronos.
2. Go to Tools => Preferences => Restriction.
3. Check "Restrict running time".
4. Set the input field below the checkbox to "1" or "2".
5. Press "OK".
6. Wait for a while.
    * A dialog will be shown
7. Press OK on the dialog

## Expected result:

Chronos exits itself completely.
