### PR TITLE
github: kick scheduled build to verify

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+  schedule:
+    - cron:  '0 0 * * 1'
 name: Build Chronos
 jobs:
   build:


### PR DESCRIPTION

# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Currently, workflow is kicked on every push event, but 
to monitor build failure periodically, it is not enough.

This PR add scheduled build to do it.
(build workflow will be executed on every Monday.)

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

# How to verify the fixed issue:

Monitor scheduled build will be fired on every Monday.

## Expected result:

We can recognize build failure as soon as possible.
