### PR TITLE
Fix logging format for OnNewAddress

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -1172,7 +1172,7 @@ LRESULT CBrowserFrame::OnNewAddressEnter(WPARAM wParam, LPARAM lParam)
 		SearchAndNavigate(str);
 		m_pwndAddress->AppendString(str.GetBuffer(0));
 		CString logmsg;
-		logmsg.Format(_T("BF_WND:0x%08x OnNewAddressEnter:%s"), theApp.SafeWnd(this->m_hWnd), str);
+		logmsg.Format(_T("BF_WND:0x%08x\tOnNewAddressEnter\t%s"), theApp.SafeWnd(this->m_hWnd), str);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	}
 	return 0;
@@ -1187,7 +1187,7 @@ LRESULT CBrowserFrame::OnNewAddress(WPARAM wParam, LPARAM lParam)
 		if (ExP == m_pwndAddress)
 		{
 			CString logmsg;
-			logmsg.Format(_T("BF_WND:0x%08x OnNewAddress:%s"), theApp.SafeWnd(this->m_hWnd), str);
+			logmsg.Format(_T("BF_WND:0x%08x\tOnNewAddress\t%s"), theApp.SafeWnd(this->m_hWnd), str);
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 			m_pwndAddress->GetLBText(m_pwndAddress->GetCurSel(), str);
 			SearchAndNavigate(str);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

OnNewAddressEnter, OnNewAddress events should be logged with a tab as a separator for Chronos_trace.log

Before:

```
TIMESTAMP\tTYPE\tHANDLE EVENT:MESSAGE
```

After:

```
TIMESTAMP\tTYPE\tHANDLE\tEVENT\tMESSAGE
```

# How to verify the fixed issue:

1. Launch Chronos.exe
2. Type any URL in addressbar

## Expected result:

The logging message should be seperated with tab.

```
2023-01-26 11:46:45	AC	BF_WND:0x000507a8	OnNewAddressEnter	https://google.co.jp
```
