### PR TITLE
Disable needless gathering facts

### DIFF
--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -267,6 +267,7 @@ resource "local_file" "playbook" {
   content  = <<EOL
 - hosts: windows
   become_method: runas
+  gather_facts: no
   vars:
     ansible_become_password: "${var.windows-password}"
   tasks:


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

As ansible facts variable `{{ ansible_... }}` are not used in ansible playbook, there is no need to do gathering facts in beforehand.

As a side effect, it reduces a bootstrap time.


# How to verify the fixed issue:

1. apply and make && make apply-playbook

## Expected result:

Boot verification VM correctly.
