### PR TITLE
Enable logging with milliseconds timestamp

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -2321,8 +2321,12 @@ void CSazabi::WriteDebugTraceDateTime(LPCTSTR msg, int iLogType)
 	if (_tcslen(msg) == 0) return;
 
 	CString strWriteLine;
-	CTime time = CTime::GetCurrentTime();
-	strWriteLine.Format(_T("%s\t%s\t%s\n"), time.Format(_T("%Y-%m-%d %H:%M:%S")), sDEBUG_LOG_TYPE[iLogType], msg);
+	SYSTEMTIME time;
+	GetLocalTime(&time);
+	strWriteLine.Format(_T("%u-%02u-%02u %02u:%02u:%02u.%03u\t%s\t%s\n"),
+			    time.wYear, time.wMonth, time.wDay,
+			    time.wHour, time.wMinute, time.wSecond,
+			    time.wMilliseconds, sDEBUG_LOG_TYPE[iLogType], msg);
 
 	_wsetlocale(LC_ALL, _T("jpn"));
 	CStdioFile stdFile;


### PR DESCRIPTION

# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

There is a case that logging with second timestamp is not enough resolution to investigate delayed or performance issue.

Before:

```
  2023-02-15 10:44:41	GE	CommandParam:[]
  2023-02-15 10:44:41	GE	AtomParam:[/NORMAL]
  2023-02-15 10:44:41	URL	CV_WND:0x00050260	OnBeforeBrowse	https://www.google.co.jp/	TopPage:TRUE
```

After:

```
  2023-02-15 10:44:41.690	GE	CommandParam:[]
  2023-02-15 10:44:41.690	GE	AtomParam:[/NORMAL]
  2023-02-15 10:44:41.725	URL	CV_WND:0x00050260	OnBeforeBrowse	https://www.google.co.jp/	TopPage:TRUE
```


# How to verify the fixed issue:


1. Launch Chronos
2. Enable debug logging option
3. Browse web site
4. Quit Chronos
5. See Chronos_trace.log

## Expected result:

Timestamp resolution is changed to milliseconds.

> Describe the obvious situation to verify.
