### PR TITLE
Support CEF112

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,8 @@ jobs:
         run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG
       - name: Prepare upload
         run: move R32 Chronos
+      - name: Prepare Chronos.exe to launch easily
+        run: echo F | xcopy /V /F /Y Chronos\ChronosN.exe Chronos\Chronos.exe
       - if: matrix.version == 'current'
         name: Upload Build
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,21 @@ on:
 name: Build Chronos
 jobs:
   build:
+    strategy:
+      matrix:
+        version: [current, stable, beta]
     runs-on: [ windows-2019 ]
     steps:
       - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1
+      - if: matrix.version == 'stable'
+        name: Use stable version of CEF
+        run: |
+          bash .github/rewrite-cef-version.sh ${{ matrix.version }}
+      - if: matrix.version == 'beta'
+        name: Use beta version of CEF
+        run: |
+          bash .github/rewrite-cef-version.sh ${{ matrix.version }}
       - name: Setup cache for CEF
         uses: actions/cache@v3
         with:
@@ -20,62 +31,21 @@ jobs:
         run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG
       - name: Prepare upload
         run: move R32 Chronos
-      - name: Upload Build
+      - if: matrix.version == 'current'
+        name: Upload Build
         uses: actions/upload-artifact@v3
         with:
           name: Chronos
           path: Chronos
-
-  stable:
-    runs-on: [ windows-2019 ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: microsoft/setup-msbuild@v1
-      - name: Use stable version of CEF
-        run: |
-          bash .github/rewrite-cef-version.sh stable
-      - name: Setup cache for CEF
-        uses: actions/cache@v3
+      - if: matrix.version == 'stable'
+        name: Upload Build (stable)
+        uses: actions/upload-artifact@v3
         with:
-          path: cef-cache/*/
-          key: cef-${{ runner.os }}-${{ hashFiles('setup-cef.bat') }}
-      - name: Setup CEF
-        run: .\setup-cef.bat
-      - name: Compile Chronos
-        run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG
-        # Aimed to watch build error, and not to bother build: job, ignore error here.
-        continue-on-error: true
-      # - name: Prepare upload
-      #   run: move R32 Chronos
-      # - name: Upload Build
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: Chronos-stable
-      #     path: Chronos-stable
-
-  beta:
-    runs-on: [ windows-2019 ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: microsoft/setup-msbuild@v1
-      - name: Use beta version of CEF
-        run: |
-          bash .github/rewrite-cef-version.sh beta
-      - name: Setup cache for CEF
-        uses: actions/cache@v3
+          name: Chronos-stable
+          path: Chronos
+      - if: matrix.version == 'beta'
+        name: Upload Build (beta)
+        uses: actions/upload-artifact@v3
         with:
-          path: cef-cache/*/
-          key: cef-${{ runner.os }}-${{ hashFiles('setup-cef.bat') }}
-      - name: Setup CEF
-        run: .\setup-cef.bat
-      - name: Compile Chronos
-        run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG
-        # Aimed to watch build error, and not to bother build: job, ignore error here.
-        continue-on-error: true
-      # - name: Prepare upload
-      #   run: move R32 Chronos
-      # - name: Upload Build
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: Chronos-beta
-      #     path: Chronos-beta
+          name: Chronos-beta
+          path: Chronos

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1628,8 +1628,13 @@ LRESULT CChildView::OnFindDialogMessage(WPARAM wParam, LPARAM lParam)
 			CefString csFind = FindName;
 			if (m_cefBrowser)
 			{
+#if CHROME_VERSION_MAJOR >= 99
+				// Since CEF99, no need to specify identifier for Find API
+				m_cefBrowser->GetHost()->Find(csFind, bSearchDown, bMatchCase, m_bFindNext);
+#else
 				INT nBrowserId = m_cefBrowser->GetIdentifier();
 				m_cefBrowser->GetHost()->Find(nBrowserId, csFind, bSearchDown, bMatchCase, m_bFindNext);
+#endif
 			}
 			if (!m_bFindNext)
 				m_bFindNext = TRUE;

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -2042,7 +2042,20 @@ LRESULT CChildView::OnNewWindow(WPARAM wParam, LPARAM lParam)
 	if (popupFeatures)
 	{
 		pCreateView->m_popupFeatures = new CefPopupFeatures;
+#if CHROME_VERSION_MAJOR >= 105
+		// Since CEF105, inheritance is changed to cef_popup_features_t,
+		// so CefPopupFeaturesTraits->Set is not available anymore.
+		pCreateView->m_popupFeatures->x = popupFeatures->x;
+		pCreateView->m_popupFeatures->xSet = popupFeatures->xSet;
+		pCreateView->m_popupFeatures->y = popupFeatures->y;
+		pCreateView->m_popupFeatures->ySet = popupFeatures->ySet;
+		pCreateView->m_popupFeatures->width = popupFeatures->width;
+		pCreateView->m_popupFeatures->widthSet = popupFeatures->widthSet;
+		pCreateView->m_popupFeatures->height = popupFeatures->height;
+		pCreateView->m_popupFeatures->heightSet = popupFeatures->heightSet;
+#else
 		pCreateView->m_popupFeatures->Set(*popupFeatures, true);
+#endif
 		pCreateView->ResizeWindowPopup();
 	}
 	HWND hWnd = pCreateView->GetSafeHwnd();

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1380,19 +1380,34 @@ void CChildView::OnPrintPDF()
 				theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, m_strURL);
 			}
 
+#if CHROME_VERSION_MAJOR >= 108
+			// Since CEF108, cef_pdf_print_settings_t is refactored.
+			CefString(&stPDFSetting.header_template) = CefString(this->m_strTitle);
+			CefString(&stPDFSetting.footer_template) = CefString(this->m_strURL);
+			stPDFSetting.paper_width = 0;
+			stPDFSetting.paper_height = 0;
+#else
 			CefString(&stPDFSetting.header_footer_title) = CefString(this->m_strTitle);
 			CefString(&stPDFSetting.header_footer_url) = CefString(this->m_strURL);
 			stPDFSetting.page_width = 0;
 			stPDFSetting.page_height = 0;
+#endif
 			stPDFSetting.margin_top = 0;
 			stPDFSetting.margin_right = 0;
 			stPDFSetting.margin_bottom = 0;
 			stPDFSetting.margin_left = 0;
 			stPDFSetting.margin_type = PDF_PRINT_MARGIN_DEFAULT;
+#if CHROME_VERSION_MAJOR >= 108
+			stPDFSetting.display_header_footer = 1;
+			CefString(&stPDFSetting.page_ranges) = CefString("");
+			stPDFSetting.landscape = 0;
+			stPDFSetting.print_background = 1;
+#else
 			stPDFSetting.header_footer_enabled = 1;
 			stPDFSetting.selection_only = 0;
 			stPDFSetting.landscape = 0;
 			stPDFSetting.backgrounds_enabled = 1;
+#endif
 			CefRefPtr<CefPdfPrintCallback> callback;
 
 			m_cefBrowser->GetHost()->PrintToPDF(strPDFPath, stPDFSetting, callback);

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4087,7 +4087,9 @@ void CSazabi::InitializeCef()
 	PROC_TIME(InitializeCef)
 
 	m_cefApp = new ClientApp();
+#if CHROME_VERSION_MAJOR < 112
 	CefEnableHighDPISupport();
+#endif
 
 	CefMainArgs mainargs(m_hInstance);
 	void* sandbox_info = NULL;
@@ -5064,7 +5066,9 @@ int AFXAPI AfxWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmd
 	strCommandLineData = ::GetCommandLine();
 	if (strCommandLineData.Find(_T("--type=")) > 0)
 	{
+#if CHROME_VERSION_MAJOR < 112
 		CefEnableHighDPISupport();
+#endif
 		CefMainArgs mainargs(hInstance);
 		void* sandbox_info = NULL;
 		if (strCommandLineData.Find(_T("--type=renderer")) > 0)

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -190,6 +190,16 @@ bool ClientHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser,
 			}
 			case cef_window_open_disposition_t::WOD_NEW_FOREGROUND_TAB:
 			{
+#if CHROME_VERSION_MAJOR >= 110
+				if (popupFeatures.isPopup)
+				{
+					// Since CEF110, toolBarVisible and menuBarVisible was removed.
+					// When isPopup is true, browser interface elements is hidden,
+					// then create new browser window.
+					lRet = ::SendMessage(hWindow, WM_APP_CEF_NEW_WINDOW, (WPARAM)&popupFeatures, (LPARAM)&windowInfo);
+					return false;
+				}
+#else
 				if (popupFeatures.toolBarVisible)
 				{
 					if (//popupFeatures.locationBarVisible==false
@@ -200,6 +210,7 @@ bool ClientHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser,
 						return false;
 					}
 				}
+#endif
 				lRet = ::SendMessage(hWindow, WM_APP_CEF_NEW_WINDOW, (WPARAM)NULL, (LPARAM)&windowInfo);
 				return false;
 			}

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1673,6 +1673,8 @@ CefRefPtr<CefResourceHandler> ClientHandler::GetResourceHandler(CefRefPtr<CefBro
 	return nullptr;
 }
 
+#if CHROME_VERSION_MAJOR < 109
+// Since CEF109, OnQuotaRequest is not available anymore.
 bool ClientHandler::OnQuotaRequest(CefRefPtr<CefBrowser> browser, const CefString& origin_url, int64 new_size, CefRefPtr<CefCallback> callback)
 {
 	static const int64 max_size = 1024 * 1024 * 20; // 20mb.
@@ -1683,6 +1685,7 @@ bool ClientHandler::OnQuotaRequest(CefRefPtr<CefBrowser> browser, const CefStrin
 	// call parent
 	return CefRequestHandler::OnQuotaRequest(browser, origin_url, new_size, callback);
 }
+#endif
 
 bool ClientHandler::OnCertificateError(CefRefPtr<CefBrowser> browser,
 				       ErrorCode cert_error, const CefString& request_url, CefRefPtr<CefSSLInfo> ssl_info, CefRefPtr<CefCallback> callback)

--- a/client_handler.h
+++ b/client_handler.h
@@ -102,7 +102,9 @@ public:
 	virtual bool GetAuthCredentials(CefRefPtr<CefBrowser> browser, const CefString& origin_url, bool isProxy, const CefString& host, int paort, const CefString& realm, const CefString& scheme, CefRefPtr<CefAuthCallback> callback) override;
 
 	virtual CefRefPtr<CefResourceHandler> GetResourceHandler(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request) override;
+#if CHROME_VERSION_MAJOR < 109
 	virtual bool OnQuotaRequest(CefRefPtr<CefBrowser> browser, const CefString& origin_url, int64 new_size, CefRefPtr<CefCallback> callback) override;
+#endif
 	virtual void OnProtocolExecution(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool& allow_os_execution) override;
 	virtual void OnRenderViewReady(CefRefPtr<CefBrowser> browser) override;
 	virtual bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool user_gesture, bool is_redirect) override;

--- a/client_handler.h
+++ b/client_handler.h
@@ -48,7 +48,10 @@ public:
 	virtual ~ClientHandler();
 
 	typedef cef_window_open_disposition_t WindowOpenDisposition;
+#if CHROME_VERSION_MAJOR <= 98
+	// Since CEF99, cef_plugin_policy_t is not available anymore.
 	typedef cef_plugin_policy_t PluginPolicy;
+#endif
 
 	// CefClient methods
 	virtual CefRefPtr<CefContextMenuHandler> GetContextMenuHandler() override { return this; }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

Recreated version of #20.

# What this PR does / why we need it:

Currently, the adopted CEF version is 98.2.1, a bit older version.
The stable version is CEF 110 and the beta version is now CEF 111.

This PR follows up to a newer version.

![chronos110](https://user-images.githubusercontent.com/225841/223919015-357ec5cd-80eb-4d80-b984-08db1aa769ad.png)

![chronos111](https://user-images.githubusercontent.com/225841/223919027-9066609e-eeea-4ec9-ada7-a06871ee903e.png)

# How to verify the fixed issue:

1. Download the archive from GitHub action for stable and beta job.
2. Extract archives and run Chronos.exe
3. Check the behavior of Chronos.exe

## Expected result:

master branch is ready for CEF 110 and CEF 110.
