### PR TITLE
Enable to specify CEFVER via environment variable

### DIFF
--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -12,7 +12,9 @@
 @echo "+=====================================================+"
 
 set BASEDIR=%~dp0
-set CEFVER=cef_binary_98.2.1+g29d6e22+chromium-98.0.4758.109_windows32_minimal
+IF NOT DEFINED CEFVER (
+  set CEFVER=cef_binary_98.2.1+g29d6e22+chromium-98.0.4758.109_windows32_minimal
+)
 set CEFHOST=https://cef-builds.spotifycdn.com
 
 @REM -----------------

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -13,50 +13,54 @@
 
 set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
+  echo Use the default CEF version.
+  echo To build with a newer CEF version, set CEFVER explicitly.
   set CEFVER=cef_binary_98.2.1+g29d6e22+chromium-98.0.4758.109_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 
-@REM -----------------
-@REM Cleanup directory
-@REM -----------------
-cd "%BASEDIR%"
-cmake -E rm -rf include lib rlib D32 R32
-cmake -E make_directory include lib rlib D32 R32
-cmake -E make_directory cef-cache
+echo %CEFVER%
 
-@REM -------------------------
-@REM Download CEF distribution
-@REM -------------------------
-IF NOT EXIST "cef-cache\%CEFVER%" (
-	cd cef-cache
-	powershell -C "(New-Object Net.WebClient).DownloadFile('%CEFHOST%/%CEFVER%.tar.bz2', '%CEFVER%.tar.bz2')"
-	cmake -E tar -xjf %CEFVER%.tar.bz2%
-)
+@REM @REM -----------------
+@REM @REM Cleanup directory
+@REM @REM -----------------
+@REM cd "%BASEDIR%"
+@REM cmake -E rm -rf include lib rlib D32 R32
+@REM cmake -E make_directory include lib rlib D32 R32
+@REM cmake -E make_directory cef-cache
 
-@echo =========== Current CEF cache folder ==================
-@dir "%BASEDIR%\cef-cache"
-@echo =======================================================
+@REM @REM -------------------------
+@REM @REM Download CEF distribution
+@REM @REM -------------------------
+@REM IF NOT EXIST "cef-cache\%CEFVER%" (
+@REM 	cd cef-cache
+@REM 	powershell -C "(New-Object Net.WebClient).DownloadFile('%CEFHOST%/%CEFVER%.tar.bz2', '%CEFVER%.tar.bz2')"
+@REM 	cmake -E tar -xjf %CEFVER%.tar.bz2%
+@REM )
 
-@REM ------------------
-@REM Build CEF binaries
-@REM ------------------
-cd "%BASEDIR%\cef-cache\%CEFVER%"
-cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 .
-cmake --build build
-cmake --build build --config Release
+@REM @echo =========== Current CEF cache folder ==================
+@REM @dir "%BASEDIR%\cef-cache"
+@REM @echo =======================================================
 
-@REM ------------------
-@REM Install CEF assets
-@REM ------------------
-cd "%BASEDIR%"
-cmake -E copy_directory "cef-cache\%CEFVER%\include" include
-cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Release" rlib
-cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Debug" lib
-cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" rlib
-cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" lib
+@REM @REM ------------------
+@REM @REM Build CEF binaries
+@REM @REM ------------------
+@REM cd "%BASEDIR%\cef-cache\%CEFVER%"
+@REM cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 .
+@REM cmake --build build
+@REM cmake --build build --config Release
 
-cmake -E copy_directory "cef-cache\%CEFVER%\Release" D32
-cmake -E copy_directory "cef-cache\%CEFVER%\Release" R32
-cmake -E copy_directory "cef-cache\%CEFVER%\Resources" D32
-cmake -E copy_directory "cef-cache\%CEFVER%\Resources" R32
+@REM @REM ------------------
+@REM @REM Install CEF assets
+@REM @REM ------------------
+@REM cd "%BASEDIR%"
+@REM cmake -E copy_directory "cef-cache\%CEFVER%\include" include
+@REM cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Release" rlib
+@REM cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Debug" lib
+@REM cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" rlib
+@REM cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" lib
+
+@REM cmake -E copy_directory "cef-cache\%CEFVER%\Release" D32
+@REM cmake -E copy_directory "cef-cache\%CEFVER%\Release" R32
+@REM cmake -E copy_directory "cef-cache\%CEFVER%\Resources" D32
+@REM cmake -E copy_directory "cef-cache\%CEFVER%\Resources" R32

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -19,48 +19,46 @@ IF NOT DEFINED CEFVER (
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 
-echo %CEFVER%
+@REM -----------------
+@REM Cleanup directory
+@REM -----------------
+cd "%BASEDIR%"
+cmake -E rm -rf include lib rlib D32 R32
+cmake -E make_directory include lib rlib D32 R32
+cmake -E make_directory cef-cache
 
-@REM @REM -----------------
-@REM @REM Cleanup directory
-@REM @REM -----------------
-@REM cd "%BASEDIR%"
-@REM cmake -E rm -rf include lib rlib D32 R32
-@REM cmake -E make_directory include lib rlib D32 R32
-@REM cmake -E make_directory cef-cache
+@REM -------------------------
+@REM Download CEF distribution
+@REM -------------------------
+IF NOT EXIST "cef-cache\%CEFVER%" (
+	cd cef-cache
+	powershell -C "(New-Object Net.WebClient).DownloadFile('%CEFHOST%/%CEFVER%.tar.bz2', '%CEFVER%.tar.bz2')"
+	cmake -E tar -xjf %CEFVER%.tar.bz2%
+)
 
-@REM @REM -------------------------
-@REM @REM Download CEF distribution
-@REM @REM -------------------------
-@REM IF NOT EXIST "cef-cache\%CEFVER%" (
-@REM 	cd cef-cache
-@REM 	powershell -C "(New-Object Net.WebClient).DownloadFile('%CEFHOST%/%CEFVER%.tar.bz2', '%CEFVER%.tar.bz2')"
-@REM 	cmake -E tar -xjf %CEFVER%.tar.bz2%
-@REM )
+@echo =========== Current CEF cache folder ==================
+@dir "%BASEDIR%\cef-cache"
+@echo =======================================================
 
-@REM @echo =========== Current CEF cache folder ==================
-@REM @dir "%BASEDIR%\cef-cache"
-@REM @echo =======================================================
+@REM ------------------
+@REM Build CEF binaries
+@REM ------------------
+cd "%BASEDIR%\cef-cache\%CEFVER%"
+cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 .
+cmake --build build
+cmake --build build --config Release
 
-@REM @REM ------------------
-@REM @REM Build CEF binaries
-@REM @REM ------------------
-@REM cd "%BASEDIR%\cef-cache\%CEFVER%"
-@REM cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 .
-@REM cmake --build build
-@REM cmake --build build --config Release
+@REM ------------------
+@REM Install CEF assets
+@REM ------------------
+cd "%BASEDIR%"
+cmake -E copy_directory "cef-cache\%CEFVER%\include" include
+cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Release" rlib
+cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Debug" lib
+cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" rlib
+cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" lib
 
-@REM @REM ------------------
-@REM @REM Install CEF assets
-@REM @REM ------------------
-@REM cd "%BASEDIR%"
-@REM cmake -E copy_directory "cef-cache\%CEFVER%\include" include
-@REM cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Release" rlib
-@REM cmake -E copy_directory "cef-cache\%CEFVER%\build\libcef_dll_wrapper\Debug" lib
-@REM cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" rlib
-@REM cmake -E copy "cef-cache\%CEFVER%\Release\libcef.lib" lib
-
-@REM cmake -E copy_directory "cef-cache\%CEFVER%\Release" D32
-@REM cmake -E copy_directory "cef-cache\%CEFVER%\Release" R32
-@REM cmake -E copy_directory "cef-cache\%CEFVER%\Resources" D32
-@REM cmake -E copy_directory "cef-cache\%CEFVER%\Resources" R32
+cmake -E copy_directory "cef-cache\%CEFVER%\Release" D32
+cmake -E copy_directory "cef-cache\%CEFVER%\Release" R32
+cmake -E copy_directory "cef-cache\%CEFVER%\Resources" D32
+cmake -E copy_directory "cef-cache\%CEFVER%\Resources" R32


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

We are rewriting `CEFVER` with https://github.com/ThinBridge/Chronos/blob/master/.github/rewrite-cef-version.sh for CI.
However, it is better to specify `CEFVER` via environment variable.

# How to verify the fixed issue:

## The steps to verify:

*The step to verify to use default value*

1. `set CEFVER=`
2. `setup-cef.bat`
3. Check the target CEF version is `cef_binary_98.2.1+g29d6e22+chromium-98.0.4758.109_windows32_minimal` from results

*The step to varify to use environment variable*

1. `set CEFVER=cef_binary_111.2.1+g870da30+chromium-111.0.5563.64_windows32_minimal`
2. `setup-cef.bat`
3. Check the target CEF version is `cef_binary_111.2.1+g870da30+chromium-111.0.5563.64_windows32_minimal` form results


## Expected result:

Described with "The steps to verify:"
