### PR TITLE
Update prebuilt CEF version to 112

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=98.2.1+g29d6e22+chromium-98.0.4758.109
+VERSION=112.2.6+gaad7246+chromium-112.0.5615.29
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
 name: Build Chronos
 jobs:
   build:
+    continue-on-error: true
     strategy:
       matrix:
         version: [current, stable, beta]

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -576,8 +576,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 12,111,98,3
- PRODUCTVERSION 12,111,98,3
+ FILEVERSION 12,111,112,0
+ PRODUCTVERSION 12,111,112,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -593,12 +593,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "12.111.98.3"
+            VALUE "FileVersion", "12.111.112.0"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "12.111.98.3"
+            VALUE "ProductVersion", "12.111.112.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_98.2.1+g29d6e22+chromium-98.0.4758.109_windows32_minimal
+  set CEFVER=cef_binary_112.2.6+gaad7246+chromium-112.0.5615.29_windows32_beta_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

We are going to apply CEF112 for the next version which is developed in the master branch.
So the default CEF version to download should be 112 to align the development base among developers.

CI will be failed on stable channel since it's not released yet.

# How to verify the fixed issue:

* Check embedded CEF version

## The steps to verify:

1. Build Chronos as usual
2. Run Chronos
3. Open Help -> Version

## Expected result:

```
Version 12.111.112.0  WIN32(x86)
...
Chromium Embedded Framework Version 112.2.6+gaad7246+chromium-112.0.5615.29
Chromium(Blink) Version 112.0.5615.29
```
