### PR TITLE
Add support FileDialog for CEF102+

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -23,38 +23,8 @@ static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 
 ////////////////////////////////////////////////////////////////
 //HookFunction
-static HRESULT WINAPI Hook_CoCreateInstance(
-	_In_  REFCLSID  rclsid,
-	_In_  LPUNKNOWN pUnkOuter,
-	_In_  DWORD     dwClsContext,
-	_In_  REFIID    riid,
-	_Out_ LPVOID    *ppv
-)
-{
-	PROC_TIME(Hook_CoCreateInstance)
-	API_H_TRY
-	if (theApp.IsSGMode())
-	{
-		if (rclsid == CLSID_FileOpenDialog || rclsid == CLSID_FileSaveDialog)
-		{
-			::SetLastError(ERROR_ACCESS_DENIED);
-			return REGDB_E_CLASSNOTREG;
-		}
-	}
-	API_H_CATCH
-	HRESULT hRet = {0};
-	hRet = pORG_CoCreateInstance(
-		rclsid,
-		pUnkOuter,
-		dwClsContext,
-		riid,
-		ppv
-	);
-	return hRet;
-}
-
-
 ///////////////////////////////////////////////////////////////////////////////////////////
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 //@@ComDlg32
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -373,15 +343,6 @@ void APIHookC::DoHookComDlgAPI()
 
 		if (pTargetW == NULL) return;
 		if (MH_EnableHook(pTargetW) != MH_OK)
-			return;
-	}
-	if (!pORG_CoCreateInstance)
-	{
-		if (MH_CreateHookApiEx(
-			L"ole32.dll", "CoCreateInstance", &Hook_CoCreateInstance, &pORG_CoCreateInstance) != MH_OK)
-			return;
-
-		if (MH_EnableHook(&CoCreateInstance) != MH_OK)
 			return;
 	}
 }

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -23,8 +23,38 @@ static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 
 ////////////////////////////////////////////////////////////////
 //HookFunction
-///////////////////////////////////////////////////////////////////////////////////////////
+static HRESULT WINAPI Hook_CoCreateInstance(
+	_In_  REFCLSID  rclsid,
+	_In_  LPUNKNOWN pUnkOuter,
+	_In_  DWORD     dwClsContext,
+	_In_  REFIID    riid,
+	_Out_ LPVOID    *ppv
+)
+{
+	PROC_TIME(Hook_CoCreateInstance)
+	API_H_TRY
+	if (theApp.IsSGMode())
+	{
+		if (rclsid == CLSID_FileOpenDialog || rclsid == CLSID_FileSaveDialog)
+		{
+			::SetLastError(ERROR_ACCESS_DENIED);
+			return REGDB_E_CLASSNOTREG;
+		}
+	}
+	API_H_CATCH
+	HRESULT hRet = {0};
+	hRet = pORG_CoCreateInstance(
+		rclsid,
+		pUnkOuter,
+		dwClsContext,
+		riid,
+		ppv
+	);
+	return hRet;
+}
 
+
+///////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 //@@ComDlg32
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -343,6 +373,15 @@ void APIHookC::DoHookComDlgAPI()
 
 		if (pTargetW == NULL) return;
 		if (MH_EnableHook(pTargetW) != MH_OK)
+			return;
+	}
+	if (!pORG_CoCreateInstance)
+	{
+		if (MH_CreateHookApiEx(
+			L"ole32.dll", "CoCreateInstance", &Hook_CoCreateInstance, &pORG_CoCreateInstance) != MH_OK)
+			return;
+
+		if (MH_EnableHook(&CoCreateInstance) != MH_OK)
 			return;
 	}
 }

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -32,16 +32,6 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 )
 {
 	PROC_TIME(Hook_CoCreateInstance)
-	API_H_TRY
-	if (theApp.IsSGMode())
-	{
-		if (rclsid == CLSID_FileOpenDialog || rclsid == CLSID_FileSaveDialog)
-		{
-			::SetLastError(ERROR_ACCESS_DENIED);
-			return REGDB_E_CLASSNOTREG;
-		}
-	}
-	API_H_CATCH
 	HRESULT hRet = {0};
 	hRet = pORG_CoCreateInstance(
 		rclsid,


### PR DESCRIPTION
# Which issue(s) this PR fixes:

The issue that the file upload dialog is not displayed, which is mentiond in #34.

# What this PR does / why we need it:

CEF calls `CLSID_FileOpenDialog` and `CLSID_FileSaveDialog` when opening dialogs from CEF102.
So I modified Chronos to not ignore them.

# How to verify the fixed issue:

## The steps to verify:

1. Build ChronosN.exe to Chronos.exe with ThinApp.
2. Open the file upload dialog
  * e.g. https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/file 

## Expected result:

The file upload dialog is opened.

# Note

The function to prohibition uploading / downloading doesn't work for now.
We should add permission check and mode designation like `Hook_GetOpenFileNameW` after this.