### PR TITLE
Add support for prohibiting file upload and download

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -3,23 +3,21 @@
 #include "minhook\hook.hh"
 #include "Windows.h"
 
-#define API_H_TRY \
-	try       \
-	{
-#define API_H_CATCH \
-	}           \
-	catch (...) { ATLASSERT(0); }
+#define API_H_TRY try{
+#define API_H_CATCH }catch(...){ATLASSERT(0);}
+
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 //@@COM
 ///////////////////////////////////////////////////////////////////////////////////////////
 //TypeDef
 typedef HRESULT(WINAPI* ORG_CoCreateInstance)(
-    _In_ REFCLSID rclsid,
-    _In_ LPUNKNOWN pUnkOuter,
-    _In_ DWORD dwClsContext,
-    _In_ REFIID riid,
-    _Out_ LPVOID* ppv);
+      _In_ REFCLSID rclsid,
+      _In_ LPUNKNOWN pUnkOuter,
+      _In_ DWORD dwClsContext,
+      _In_ REFIID riid,
+      _Out_ LPVOID* ppv);
 static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 
 class ChronosFileOpenDialog : public IFileOpenDialog
@@ -751,18 +749,19 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 ///////////////////////////////////////////////////////////////////////////////////////////
 //TypeDef
 typedef BOOL(WINAPI* FuncGetSaveFileNameW)(LPOPENFILENAMEW lpofn);
-static FuncGetSaveFileNameW pORG_GetSaveFileNameW = NULL;
+static FuncGetSaveFileNameW	pORG_GetSaveFileNameW = NULL;
 
 typedef BOOL(WINAPI* FuncGetOpenFileNameW)(LPOPENFILENAMEW lpofn);
-static FuncGetSaveFileNameW pORG_GetOpenFileNameW = NULL;
+static FuncGetSaveFileNameW	pORG_GetOpenFileNameW = NULL;
 
 typedef PIDLIST_ABSOLUTE(WINAPI* FuncSHBrowseForFolderW)(LPBROWSEINFOW lpbi);
-static FuncSHBrowseForFolderW pORG_SHBrowseForFolderW = NULL;
+static FuncSHBrowseForFolderW	pORG_SHBrowseForFolderW = NULL;
 
 ////////////////////////////////////////////////////////////////
 //HookFunction
 static BOOL WINAPI Hook_GetSaveFileNameW(
-    LPOPENFILENAMEW lpofn)
+	LPOPENFILENAMEW lpofn
+)
 {
 	BOOL bRet = FALSE;
 	try
@@ -841,7 +840,8 @@ static BOOL WINAPI Hook_GetSaveFileNameW(
 }
 
 static BOOL WINAPI Hook_GetOpenFileNameW(
-    LPOPENFILENAMEW lpofn)
+	LPOPENFILENAMEW lpofn
+)
 {
 	BOOL bRet = FALSE;
 	try
@@ -946,8 +946,7 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 			if (strSelPath.IsEmpty())
 				return bRet;
 
-			if (theApp.IsSGMode())
-			{
+			if (theApp.IsSGMode()) {
 				CStringW strRoot(strRootPath);
 				strRoot.MakeUpper();
 				if (strSelPath.Find(strRoot) != 0)
@@ -980,7 +979,8 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 	return bRet;
 }
 static PIDLIST_ABSOLUTE WINAPI Hook_SHBrowseForFolderW(
-    LPBROWSEINFOW lpbi)
+	LPBROWSEINFOW lpbi
+)
 {
 	CStringW strCaption(theApp.m_strThisAppName);
 	CStringW strMsg;

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -13,11 +13,11 @@
 ///////////////////////////////////////////////////////////////////////////////////////////
 //TypeDef
 typedef HRESULT(WINAPI* ORG_CoCreateInstance)(
-      _In_ REFCLSID rclsid,
-      _In_ LPUNKNOWN pUnkOuter,
-      _In_ DWORD dwClsContext,
-      _In_ REFIID riid,
-      _Out_ LPVOID* ppv);
+		_In_ REFCLSID rclsid,
+		_In_ LPUNKNOWN pUnkOuter,
+		_In_ DWORD dwClsContext,
+		_In_ REFIID riid,
+		_Out_ LPVOID* ppv);
 static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 
 class ChronosFileOpenDialog : public IFileOpenDialog
@@ -709,11 +709,12 @@ private:
 ////////////////////////////////////////////////////////////////
 //HookFunction
 static HRESULT WINAPI Hook_CoCreateInstance(
-    _In_ REFCLSID rclsid,
-    _In_ LPUNKNOWN pUnkOuter,
-    _In_ DWORD dwClsContext,
-    _In_ REFIID riid,
-    _Out_ LPVOID* ppv)
+		_In_ REFCLSID rclsid,
+		_In_ LPUNKNOWN pUnkOuter,
+		_In_ DWORD dwClsContext,
+		_In_ REFIID riid,
+		_Out_ LPVOID* ppv
+)
 {
 	PROC_TIME(Hook_CoCreateInstance)
 	HRESULT hRet = {0};
@@ -742,6 +743,7 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 
 	return hRet;
 }
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -743,16 +743,16 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 
 	if (rclsid == CLSID_FileOpenDialog)
 	{
-		CComPtr<IFileOpenDialog> local_ppv;
+		CComPtr<IFileOpenDialog> fileOpenDialog;
 		hRet = pORG_CoCreateInstance(
 		    rclsid,
 		    pUnkOuter,
 		    dwClsContext,
 		    riid,
-		    (LPVOID *)&local_ppv);
+		    (LPVOID*)&fileOpenDialog);
 		if (SUCCEEDED(hRet))
 		{
-			ChronosFileOpenDialog *chronosFileOpenDialog = new ChronosFileOpenDialog(local_ppv);
+			ChronosFileOpenDialog* chronosFileOpenDialog = new ChronosFileOpenDialog(fileOpenDialog);
 			chronosFileOpenDialog->AddRef();
 			chronosFileOpenDialog->Initialize();
 			*ppv = chronosFileOpenDialog;
@@ -760,16 +760,16 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 	}
 	else if (rclsid == CLSID_FileSaveDialog)
 	{
-		CComPtr<IFileSaveDialog> local_ppv;
+		CComPtr<IFileSaveDialog> fileSaveDialog;
 		hRet = pORG_CoCreateInstance(
 		    rclsid,
 		    pUnkOuter,
 		    dwClsContext,
 		    riid,
-		    (LPVOID*)&local_ppv);
+		    (LPVOID*)&fileSaveDialog);
 		if (SUCCEEDED(hRet))
 		{
-			ChronosFileSaveDialog* chronosFileSaveDialog = new ChronosFileSaveDialog(local_ppv);
+			ChronosFileSaveDialog* chronosFileSaveDialog = new ChronosFileSaveDialog(fileSaveDialog);
 			chronosFileSaveDialog->AddRef();
 			chronosFileSaveDialog->Initialize();
 			*ppv = chronosFileSaveDialog;

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -340,7 +340,7 @@ public:
 				{
 					CString strCaption(theApp.m_strThisAppName);
 					CString strMsg;
-					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCTSTR)strRoot, (LPCTSTR)strSelPath);
+					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
 					::MessageBoxW(hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}
@@ -657,7 +657,7 @@ public:
 			if (strSelPath.Find(strRoot) != 0)
 			{
 				CString strMsg;
-				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", (LPCTSTR)strRoot, (LPCTSTR)strRoot, (LPCTSTR)strSelPath);
+				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRoot, (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
 				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 				continue;
 			}
@@ -666,7 +666,7 @@ public:
 			if (strSelPath.Find(strTSG_Upload) == 0)
 			{
 				CString strMsg;
-				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCTSTR)strTSG_Upload, (LPCTSTR)strSelPath);
+				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)strSelPath);
 				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 				continue;
 			}

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -25,11 +25,11 @@ static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 class ChronosFileOpenDialog : public IFileOpenDialog
 {
 public:
-	ChronosFileOpenDialog(IFileOpenDialog* originalDialog)
+	ChronosFileOpenDialog(CComPtr<IFileOpenDialog> originalDialog)
 	{
 		if (theApp.m_AppSettings.IsAdvancedLogMode())
 		{
-			theApp.WriteDebugTraceDateTime(_T("ChronosFileOpenDialog"), DEBUG_LOG_TYPE_DE);
+			theApp.WriteDebugTraceDateTime(_T("Construct ChronosFileOpenDialog"), DEBUG_LOG_TYPE_DE);
 		}
 
 		m_originalDialog = originalDialog;
@@ -37,9 +37,9 @@ public:
 
 	~ChronosFileOpenDialog()
 	{
-		if (m_originalDialog)
+		if (theApp.m_AppSettings.IsAdvancedLogMode())
 		{
-			delete m_originalDialog;
+			theApp.WriteDebugTraceDateTime(_T("Destruct ChronosFileOpenDialog"), DEBUG_LOG_TYPE_DE);
 		}
 	}
 
@@ -372,37 +372,43 @@ public:
 
 	ULONG STDMETHODCALLTYPE AddRef(void)
 	{
-		return m_originalDialog->AddRef();
+		return ++m_referenceCount;
 	}
 
-	ULONG STDMETHODCALLTYPE Release()
+	ULONG STDMETHODCALLTYPE Release(void)
 	{
-		return m_originalDialog->Release();
-	};
+		ULONG referenceCount = --m_referenceCount;
+		if (referenceCount <= 0)
+		{
+			delete this;
+		}
+		return referenceCount;
+	}
 
 private:
-	IFileOpenDialog* m_originalDialog = nullptr;
+	CComPtr<IFileOpenDialog> m_originalDialog = nullptr;
 	CString m_strRootPath;
+	ULONG m_referenceCount = 0;
 };
 
 class ChronosFileSaveDialog : public IFileSaveDialog
 {
 public:
-	ChronosFileSaveDialog(IFileSaveDialog* originalDialog)
+	ChronosFileSaveDialog(CComPtr<IFileSaveDialog> originalDialog)
 	{
 		if (theApp.m_AppSettings.IsAdvancedLogMode())
 		{
-			theApp.WriteDebugTraceDateTime(_T("ChronosFileSaveDialog"), DEBUG_LOG_TYPE_DE);
+			theApp.WriteDebugTraceDateTime(_T("Construct ChronosFileSaveDialog"), DEBUG_LOG_TYPE_DE);
 		}
-
 		m_originalDialog = originalDialog;
+		this->AddRef();
 	}
 
 	~ChronosFileSaveDialog()
 	{
-		if (m_originalDialog)
+		if (theApp.m_AppSettings.IsAdvancedLogMode())
 		{
-			delete m_originalDialog;
+			theApp.WriteDebugTraceDateTime(_T("Destruct ChronosFileSaveDialog"), DEBUG_LOG_TYPE_DE);
 		}
 	}
 
@@ -685,18 +691,22 @@ public:
 		return m_originalDialog->QueryInterface(riid, ppvObject);
 	}
 
-	ULONG STDMETHODCALLTYPE AddRef(void)
-	{
-		return m_originalDialog->AddRef();
+	ULONG STDMETHODCALLTYPE AddRef(void){
+		return ++m_referenceCount;
 	}
 
-	ULONG STDMETHODCALLTYPE Release()
-	{
-		return m_originalDialog->Release();
-	};
+	ULONG STDMETHODCALLTYPE Release(void){
+		ULONG referenceCount = --m_referenceCount;
+		if (referenceCount <= 0)
+		{
+			delete this;
+		}
+		return referenceCount;
+	}
 
 private:
-	IFileSaveDialog* m_originalDialog = nullptr;
+	CComPtr<IFileSaveDialog> m_originalDialog = nullptr;
+	ULONG m_referenceCount = 0;
 };
 
 ////////////////////////////////////////////////////////////////

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -370,13 +370,18 @@ public:
 
 	ULONG STDMETHODCALLTYPE AddRef(void)
 	{
-		return ++m_referenceCount;
+		InterlockedIncrement(&m_referenceCount);
+		return m_referenceCount;
 	}
 
 	ULONG STDMETHODCALLTYPE Release(void)
 	{
-		ULONG referenceCount = --m_referenceCount;
-		if (referenceCount <= 0)
+		if (m_referenceCount > 0)
+		{
+			InterlockedDecrement(&m_referenceCount);
+		}
+		ULONG referenceCount = m_referenceCount;
+		if (referenceCount == 0)
 		{
 			delete this;
 		}
@@ -384,7 +389,7 @@ public:
 	}
 
 private:
-	CComPtr<IFileOpenDialog> m_originalDialog = nullptr;
+	CComPtr<IFileOpenDialog> m_originalDialog;
 	CString m_strRootPath;
 	ULONG m_referenceCount = 0;
 };
@@ -689,12 +694,17 @@ public:
 	}
 
 	ULONG STDMETHODCALLTYPE AddRef(void){
-		return ++m_referenceCount;
+		InterlockedIncrement(&m_referenceCount);
+		return m_referenceCount;
 	}
 
 	ULONG STDMETHODCALLTYPE Release(void){
-		ULONG referenceCount = --m_referenceCount;
-		if (referenceCount <= 0)
+		if (m_referenceCount > 0)
+		{
+			InterlockedDecrement(&m_referenceCount);
+		}
+		ULONG referenceCount = m_referenceCount;
+		if (referenceCount == 0)
 		{
 			delete this;
 		}
@@ -702,7 +712,7 @@ public:
 	}
 
 private:
-	CComPtr<IFileSaveDialog> m_originalDialog = nullptr;
+	CComPtr<IFileSaveDialog> m_originalDialog;
 	ULONG m_referenceCount = 0;
 };
 

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -401,7 +401,6 @@ public:
 			theApp.WriteDebugTraceDateTime(_T("Construct ChronosFileSaveDialog"), DEBUG_LOG_TYPE_DE);
 		}
 		m_originalDialog = originalDialog;
-		this->AddRef();
 	}
 
 	~ChronosFileSaveDialog()

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -304,11 +304,9 @@ public:
 			}
 			else
 			{
-				CString strCaption(theApp.m_strThisAppName);
-				::MessageBoxW(hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
+				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 			}
-
-				return E_ACCESSDENIED;
+			return E_ACCESSDENIED;
 		}
 		
 		for (;;)
@@ -337,7 +335,7 @@ public:
 
 			if (theApp.IsSGMode())
 			{
-				CStringW strRoot(m_strRootPath);
+				CString strRoot(m_strRootPath);
 				strRoot.MakeUpper();
 				if (strSelPath.Find(strRoot) != 0)
 				{
@@ -387,6 +385,320 @@ private:
 	CString m_strRootPath;
 };
 
+class ChronosFileSaveDialog : public IFileSaveDialog
+{
+public:
+	ChronosFileSaveDialog(IFileSaveDialog* originalDialog)
+	{
+		if (theApp.m_AppSettings.IsAdvancedLogMode())
+		{
+			theApp.WriteDebugTraceDateTime(_T("ChronosFileSaveDialog"), DEBUG_LOG_TYPE_DE);
+		}
+
+		m_originalDialog = originalDialog;
+	}
+
+	~ChronosFileSaveDialog()
+	{
+		if (m_originalDialog)
+		{
+			delete m_originalDialog;
+		}
+	}
+
+	HRESULT Initialize()
+	{
+		if (!theApp.IsSGMode())
+		{
+			return S_OK;
+		}
+
+		FILEOPENDIALOGOPTIONS option = 0;
+
+		//フック関数を無効
+		option &= ~OFN_ENABLEHOOK;
+		//ダイアログテンプレート無効
+		option &= ~OFN_ENABLETEMPLATE;
+		//Longファイル名を強制
+		option |= OFN_LONGNAMES;
+		//ネットワークボタンを隠す
+		option |= OFN_NONETWORKBUTTON;
+		//最近使ったファイルを追加しない
+		option |= OFN_DONTADDTORECENT;
+		//プレースバーを無効
+		option |= OFN_EX_NOPLACESBAR;
+		//ファイルを上書きするかどうか確認するプロンプトを表示
+		option |= OFN_OVERWRITEPROMPT;
+
+		return this->SetOptions(option);
+	}
+
+    HRESULT STDMETHODCALLTYPE SetSaveAsItem(
+	    /* [in] */ __RPC__in_opt IShellItem* psi)
+	{
+	    return m_originalDialog->SetSaveAsItem(psi);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetProperties(
+	    /* [in] */ __RPC__in_opt IPropertyStore* pStore)
+	{
+		return m_originalDialog->SetProperties(pStore);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetCollectedProperties(
+	    /* [in] */ __RPC__in_opt IPropertyDescriptionList* pList,
+	    /* [in] */ BOOL fAppendDefault)
+	{
+		return m_originalDialog->SetCollectedProperties(pList, fAppendDefault);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetProperties(
+	    /* [out] */ __RPC__deref_out_opt IPropertyStore** ppStore)
+	{
+		return m_originalDialog->GetProperties(ppStore);
+	}
+
+	HRESULT STDMETHODCALLTYPE ApplyProperties(
+	    /* [in] */ __RPC__in_opt IShellItem* psi,
+	    /* [in] */ __RPC__in_opt IPropertyStore* pStore,
+	    /* [unique][in] */ __RPC__in_opt HWND hwnd,
+	    /* [unique][in] */ __RPC__in_opt IFileOperationProgressSink* pSink)
+	{
+		return m_originalDialog->ApplyProperties(psi, pStore, hwnd, pSink);
+
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileTypes(
+	    /* [in] */ UINT cFileTypes,
+	    /* [size_is][in] */ __RPC__in_ecount_full(cFileTypes) const COMDLG_FILTERSPEC* rgFilterSpec)
+	{
+		return m_originalDialog->SetFileTypes(cFileTypes, rgFilterSpec);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileTypeIndex(
+	    /* [in] */ UINT iFileType)
+	{
+		return m_originalDialog->SetFileTypeIndex(iFileType);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetFileTypeIndex(
+	    /* [out] */ __RPC__out UINT* piFileType)
+	{
+		return m_originalDialog->GetFileTypeIndex(piFileType);
+	}
+
+	HRESULT STDMETHODCALLTYPE Advise(
+	    /* [in] */ __RPC__in_opt IFileDialogEvents* pfde,
+	    /* [out] */ __RPC__out DWORD* pdwCookie)
+	{
+		return m_originalDialog->Advise(pfde, pdwCookie);
+	}
+
+	HRESULT STDMETHODCALLTYPE Unadvise(
+	    /* [in] */ DWORD dwCookie)
+	{
+		return m_originalDialog->Unadvise(dwCookie);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetOptions(
+	    /* [in] */ FILEOPENDIALOGOPTIONS fos)
+	{
+		return m_originalDialog->SetOptions(fos);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetOptions(
+	    /* [out] */ __RPC__out FILEOPENDIALOGOPTIONS* pfos)
+	{
+		return m_originalDialog->GetOptions(pfos);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetDefaultFolder(
+	    /* [in] */ __RPC__in_opt IShellItem* psi)
+	{
+		return m_originalDialog->SetDefaultFolder(psi);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFolder(
+	    /* [in] */ __RPC__in_opt IShellItem* psi)
+	{
+		return m_originalDialog->SetFolder(psi);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetFolder(
+	    /* [out] */ __RPC__deref_out_opt IShellItem** ppsi)
+	{
+		return m_originalDialog->GetFolder(ppsi);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetCurrentSelection(
+	    /* [out] */ __RPC__deref_out_opt IShellItem** ppsi)
+	{
+		return m_originalDialog->GetCurrentSelection(ppsi);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileName(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszName)
+	{
+		return m_originalDialog->SetFileName(pszName);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetFileName(
+	    /* [string][out] */ __RPC__deref_out_opt_string LPWSTR* pszName)
+	{
+		return m_originalDialog->GetFileName(pszName);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetTitle(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszTitle)
+	{
+		return m_originalDialog->SetTitle(pszTitle);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetOkButtonLabel(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszText)
+	{
+		return m_originalDialog->SetOkButtonLabel(pszText);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileNameLabel(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszLabel)
+	{
+		return m_originalDialog->SetFileNameLabel(pszLabel);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetResult(
+	    /* [out] */ __RPC__deref_out_opt IShellItem** ppsi)
+	{
+		return m_originalDialog->GetResult(ppsi);
+	}
+
+	HRESULT STDMETHODCALLTYPE AddPlace(
+	    /* [in] */ __RPC__in_opt IShellItem* psi, /* [in] */ FDAP fdap)
+	{
+		return m_originalDialog->AddPlace(psi, fdap);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetDefaultExtension(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszDefaultExtension)
+	{
+		return m_originalDialog->SetDefaultExtension(pszDefaultExtension);
+	}
+
+	HRESULT STDMETHODCALLTYPE Close(
+	    /* [in] */ HRESULT hr)
+	{
+		return m_originalDialog->Close(hr);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetClientGuid(
+	    /* [in] */ __RPC__in REFGUID guid)
+	{
+		return m_originalDialog->SetClientGuid(guid);
+	}
+
+	HRESULT STDMETHODCALLTYPE ClearClientData(
+	    void)
+	{
+		return m_originalDialog->ClearClientData();
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFilter(
+	    /* [in] */ __RPC__in_opt IShellItemFilter* pFilter)
+	{
+		return m_originalDialog->SetFilter(pFilter);
+	}
+
+	/* [local] */ 
+	HRESULT STDMETHODCALLTYPE Show(
+	    /* [annotation][unique][in] */ _In_opt_ HWND hwndOwner)
+	{
+		if (theApp.m_AppSettings.IsEnableDownloadRestriction())
+		{
+			return E_ACCESSDENIED;
+		}
+
+		if (!theApp.IsSGMode())
+		{
+			return m_originalDialog->Show(hwndOwner);
+		}
+
+		CString strRootPath(theApp.m_AppSettings.GetRootPath());
+		if (strRootPath.IsEmpty())
+		{
+			strRootPath = _T("B:\\");
+		}
+		strRootPath = strRootPath.TrimRight('\\');
+		strRootPath += _T("\\");
+
+		for (;;)
+		{
+			HRESULT hresult = m_originalDialog->Show(hwndOwner);
+			if (FAILED(hresult))
+			{
+				return hresult;
+			}
+
+			LPWSTR wstrSelPath;
+			IShellItem* psi;
+			hresult = this->GetResult(&psi);
+
+			if (FAILED(hresult))
+			{
+				return hresult;
+			}
+
+			psi->GetDisplayName(SIGDN_DESKTOPABSOLUTEEDITING, &wstrSelPath);
+
+			CString strSelPath(wstrSelPath);
+			strSelPath.MakeUpper();
+			if (strSelPath.IsEmpty())
+				return hresult;
+
+			CString strRoot(strRootPath);
+			strRoot.MakeUpper();
+			if (strSelPath.Find(strRoot) != 0)
+			{
+				CString strMsg;
+				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", strRoot, strRoot, (PCWSTR)strSelPath);
+				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
+				continue;
+			}
+
+			CString strTSG_Upload = strRoot + L"UPLOAD\\";
+			if (strSelPath.Find(strTSG_Upload) == 0)
+			{
+				CString strMsg;
+				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", strTSG_Upload, (PCWSTR)strSelPath);
+				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
+				continue;
+			}
+			return hresult;
+		}
+
+		return S_OK;
+	}
+
+	HRESULT STDMETHODCALLTYPE QueryInterface(
+	    /* [in] */ REFIID riid,
+	    /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject)
+	{
+		return m_originalDialog->QueryInterface(riid, ppvObject);
+	}
+
+	ULONG STDMETHODCALLTYPE AddRef(void)
+	{
+		return m_originalDialog->AddRef();
+	}
+
+	ULONG STDMETHODCALLTYPE Release()
+	{
+		return m_originalDialog->Release();
+	};
+
+private:
+	IFileSaveDialog* m_originalDialog = nullptr;
+};
+
 ////////////////////////////////////////////////////////////////
 //HookFunction
 static HRESULT WINAPI Hook_CoCreateInstance(
@@ -407,11 +719,17 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 
 	if (SUCCEEDED(hRet))
 	{
-		if (rclsid == CLSID_FileOpenDialog) // || rclsid == CLSID_FileSaveDialog)
+		if (rclsid == CLSID_FileOpenDialog)
 		{
 			ChronosFileOpenDialog* chronosFileOpenDialog = new ChronosFileOpenDialog(static_cast<IFileOpenDialog*>(*ppv));
 			chronosFileOpenDialog->Initialize();
 			*ppv = (LPVOID)chronosFileOpenDialog;
+		}
+		else if (rclsid == CLSID_FileSaveDialog)
+		{
+			ChronosFileSaveDialog* chronosFileSaveDialog = new ChronosFileSaveDialog(static_cast<IFileSaveDialog*>(*ppv));
+			chronosFileSaveDialog->Initialize();
+			*ppv = (LPVOID)chronosFileSaveDialog;
 		}
 	}
 

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -330,6 +330,7 @@ public:
 			}
 
 			CString strSelPath(wstrSelPath);
+			CoTaskMemFree(wstrSelPath);
 			if (strSelPath.IsEmpty())
 			{
 				return hresult;
@@ -643,15 +644,19 @@ public:
 			LPWSTR wstrSelPath;
 			IShellItem* psi;
 			hresult = this->GetResult(&psi);
-
 			if (FAILED(hresult))
 			{
 				return hresult;
 			}
 
-			psi->GetDisplayName(SIGDN_DESKTOPABSOLUTEEDITING, &wstrSelPath);
+			hresult = psi->GetDisplayName(SIGDN_DESKTOPABSOLUTEEDITING, &wstrSelPath);
+			if (FAILED(hresult))
+			{
+				return hresult;
+			}
 
 			CString strSelPath(wstrSelPath);
+			CoTaskMemFree(wstrSelPath);
 			strSelPath.MakeUpper();
 			if (strSelPath.IsEmpty())
 			{

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -23,38 +23,8 @@ static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 
 ////////////////////////////////////////////////////////////////
 //HookFunction
-static HRESULT WINAPI Hook_CoCreateInstance(
-	_In_  REFCLSID  rclsid,
-	_In_  LPUNKNOWN pUnkOuter,
-	_In_  DWORD     dwClsContext,
-	_In_  REFIID    riid,
-	_Out_ LPVOID    *ppv
-)
-{
-	PROC_TIME(Hook_CoCreateInstance)
-	API_H_TRY
-	if (theApp.IsSGMode())
-	{
-		if (rclsid == CLSID_FileOpenDialog || rclsid == CLSID_FileSaveDialog)
-		{
-			::SetLastError(ERROR_ACCESS_DENIED);
-			return REGDB_E_CLASSNOTREG;
-		}
-	}
-	API_H_CATCH
-	HRESULT hRet = {0};
-	hRet = pORG_CoCreateInstance(
-		rclsid,
-		pUnkOuter,
-		dwClsContext,
-		riid,
-		ppv
-	);
-	return hRet;
-}
-
-
 ///////////////////////////////////////////////////////////////////////////////////////////
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 //@@ComDlg32
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -373,15 +343,6 @@ void APIHookC::DoHookComDlgAPI()
 
 		if (pTargetW == NULL) return;
 		if (MH_EnableHook(pTargetW) != MH_OK)
-			return;
-	}
-	if (!pORG_CoCreateInstance)
-	{
-		if (MH_CreateHookApiEx(
-			L"ole32.dll", "CoCreateInstance", &Hook_CoCreateInstance, &pORG_CoCreateInstance) != MH_OK)
-			return;
-
-		if (MH_EnableHook(&CoCreateInstance) != MH_OK)
 			return;
 	}
 }

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -13,11 +13,12 @@
 ///////////////////////////////////////////////////////////////////////////////////////////
 //TypeDef
 typedef HRESULT(WINAPI* ORG_CoCreateInstance)(
-		_In_ REFCLSID rclsid,
-		_In_ LPUNKNOWN pUnkOuter,
-		_In_ DWORD dwClsContext,
-		_In_ REFIID riid,
-		_Out_ LPVOID* ppv);
+	_In_  REFCLSID  rclsid,
+	_In_  LPUNKNOWN pUnkOuter,
+	_In_  DWORD     dwClsContext,
+	_In_  REFIID    riid,
+	_Out_ LPVOID    *ppv
+	);
 static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 
 class ChronosFileOpenDialog : public IFileOpenDialog
@@ -29,7 +30,6 @@ public:
 		{
 			theApp.WriteDebugTraceDateTime(_T("Construct ChronosFileOpenDialog"), DEBUG_LOG_TYPE_DE);
 		}
-
 		m_originalDialog = originalDialog;
 	}
 
@@ -52,17 +52,23 @@ public:
 			{
 				strRootPath = theApp.m_AppSettings.GetRootPath();
 				if (strRootPath.IsEmpty())
+				{
 					strRootPath = _T("B:\\");
+				}
 				strRootPath += _T("UpLoad");
 				if (!theApp.IsFolderExists(strRootPath))
+				{
 					strRootPath = _T("B:\\");
+				}
 			}
 			//UploadTabÇégÇÌÇ»Ç¢èÍçáÇÕÅAO:\\Ç…Ç∑ÇÈ
 			else
 			{
 				strRootPath = theApp.m_AppSettings.GetUploadBasePath();
 				if (strRootPath.IsEmpty())
+				{
 					strRootPath = _T("B:\\");
+				}
 			}
 			m_strRootPath = strRootPath;
 			strPath = strRootPath;
@@ -329,7 +335,9 @@ public:
 			CString strSelPath(wstrSelPath);
 			strSelPath.MakeUpper();
 			if (strSelPath.IsEmpty())
+			{
 				return hresult;
+			}
 
 			if (theApp.IsSGMode())
 			{
@@ -660,7 +668,9 @@ public:
 			CString strSelPath(wstrSelPath);
 			strSelPath.MakeUpper();
 			if (strSelPath.IsEmpty())
+			{
 				return hresult;
+			}
 
 			CString strRoot(strRootPath);
 			strRoot.MakeUpper();
@@ -719,11 +729,11 @@ private:
 ////////////////////////////////////////////////////////////////
 //HookFunction
 static HRESULT WINAPI Hook_CoCreateInstance(
-		_In_ REFCLSID rclsid,
-		_In_ LPUNKNOWN pUnkOuter,
-		_In_ DWORD dwClsContext,
-		_In_ REFIID riid,
-		_Out_ LPVOID* ppv
+	_In_  REFCLSID  rclsid,
+	_In_  LPUNKNOWN pUnkOuter,
+	_In_  DWORD     dwClsContext,
+	_In_  REFIID    riid,
+	_Out_ LPVOID    *ppv
 )
 {
 	PROC_TIME(Hook_CoCreateInstance)
@@ -739,18 +749,17 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 	{
 		if (rclsid == CLSID_FileOpenDialog)
 		{
-			ChronosFileOpenDialog* chronosFileOpenDialog = new ChronosFileOpenDialog(static_cast<IFileOpenDialog*>(*ppv));
+			ChronosFileOpenDialog *chronosFileOpenDialog = new ChronosFileOpenDialog(static_cast<IFileOpenDialog*>(*ppv));
 			chronosFileOpenDialog->Initialize();
 			*ppv = (LPVOID)chronosFileOpenDialog;
 		}
 		else if (rclsid == CLSID_FileSaveDialog)
 		{
-			ChronosFileSaveDialog* chronosFileSaveDialog = new ChronosFileSaveDialog(static_cast<IFileSaveDialog*>(*ppv));
+			ChronosFileSaveDialog *chronosFileSaveDialog = new ChronosFileSaveDialog(static_cast<IFileSaveDialog*>(*ppv));
 			chronosFileSaveDialog->Initialize();
 			*ppv = (LPVOID)chronosFileSaveDialog;
 		}
 	}
-
 	return hRet;
 }
 

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -21,10 +21,225 @@ typedef HRESULT(WINAPI* ORG_CoCreateInstance)(
 	);
 static ORG_CoCreateInstance pORG_CoCreateInstance = NULL;
 
+class ChronosFileOpenDialog : public IFileOpenDialog
+{
+public:
+	ChronosFileOpenDialog(IFileOpenDialog* originalDialog)
+	{
+		originalDialog_ = originalDialog;
+	}
+
+	~ChronosFileOpenDialog() {
+		if (originalDialog_)
+		{
+			delete originalDialog_;
+		}
+	}
+
+	HRESULT STDMETHODCALLTYPE GetResults(/* [out] */  __RPC__deref_out_opt IShellItemArray** ppenum)
+	{
+		return originalDialog_->GetResults(ppenum);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetSelectedItems(/* [out] */ __RPC__deref_out_opt IShellItemArray** ppsai)
+	{
+		return originalDialog_->GetSelectedItems(ppsai);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileTypes(
+	    /* [in] */ UINT cFileTypes,
+	    /* [size_is][in] */ __RPC__in_ecount_full(cFileTypes) const COMDLG_FILTERSPEC* rgFilterSpec)
+	{
+		return originalDialog_->SetFileTypes(cFileTypes, rgFilterSpec);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileTypeIndex(
+	    /* [in] */ UINT iFileType)
+	{
+		return originalDialog_->SetFileTypeIndex(iFileType);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetFileTypeIndex(
+	    /* [out] */ __RPC__out UINT* piFileType)
+	{
+		return originalDialog_->GetFileTypeIndex(piFileType);
+	}
+
+	HRESULT STDMETHODCALLTYPE Advise(
+	    /* [in] */ __RPC__in_opt IFileDialogEvents* pfde,
+	    /* [out] */ __RPC__out DWORD* pdwCookie){
+		return originalDialog_->Advise(pfde, pdwCookie);
+	}
+
+	HRESULT STDMETHODCALLTYPE Unadvise(
+	    /* [in] */ DWORD dwCookie)
+	{
+		return originalDialog_->Unadvise(dwCookie);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetOptions(
+	    /* [in] */ FILEOPENDIALOGOPTIONS fos)
+	{
+		return originalDialog_->SetOptions(fos);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetOptions(
+	    /* [out] */ __RPC__out FILEOPENDIALOGOPTIONS* pfos)
+	{
+		return originalDialog_->GetOptions(pfos);
+	}
+
+    HRESULT STDMETHODCALLTYPE SetDefaultFolder(
+	    /* [in] */ __RPC__in_opt IShellItem* psi)
+	{
+		return originalDialog_->SetDefaultFolder(psi);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFolder(
+	    /* [in] */ __RPC__in_opt IShellItem* psi)
+	{
+		return originalDialog_->SetFolder(psi);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetFolder(
+	    /* [out] */ __RPC__deref_out_opt IShellItem** ppsi)
+	{
+		return originalDialog_->GetFolder(ppsi);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetCurrentSelection(
+	    /* [out] */ __RPC__deref_out_opt IShellItem** ppsi)
+	{
+		return originalDialog_->GetCurrentSelection(ppsi);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileName(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszName){
+		return originalDialog_->SetFileName(pszName);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetFileName(
+	    /* [string][out] */ __RPC__deref_out_opt_string LPWSTR* pszName)
+	{
+		return originalDialog_->GetFileName(pszName);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetTitle(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszTitle)
+	{
+		return originalDialog_->SetTitle(pszTitle);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetOkButtonLabel(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszText)
+	{
+		return originalDialog_->SetOkButtonLabel(pszText);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFileNameLabel(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszLabel)
+	{
+		return originalDialog_->SetFileNameLabel(pszLabel);
+	}
+
+	HRESULT STDMETHODCALLTYPE GetResult(
+	    /* [out] */ __RPC__deref_out_opt IShellItem** ppsi)
+	{
+		return originalDialog_->GetResult(ppsi);
+	}
+
+	HRESULT STDMETHODCALLTYPE AddPlace(
+	    /* [in] */ __RPC__in_opt IShellItem* psi, /* [in] */ FDAP fdap)
+	{
+		return originalDialog_->AddPlace(psi, fdap);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetDefaultExtension(
+	    /* [string][in] */ __RPC__in_string LPCWSTR pszDefaultExtension)
+	{
+		return originalDialog_->SetDefaultExtension(pszDefaultExtension);
+	}
+
+	HRESULT STDMETHODCALLTYPE Close(
+	    /* [in] */ HRESULT hr)
+	{
+		return originalDialog_->Close(hr);
+	}
+
+	HRESULT STDMETHODCALLTYPE SetClientGuid(
+	    /* [in] */ __RPC__in REFGUID guid)
+	{
+		return originalDialog_->SetClientGuid(guid);
+	}
+
+	HRESULT STDMETHODCALLTYPE ClearClientData(
+	    void)
+	{
+		return originalDialog_->ClearClientData();
+	}
+
+	HRESULT STDMETHODCALLTYPE SetFilter(
+	    /* [in] */ __RPC__in_opt IShellItemFilter* pFilter)
+	{
+		return originalDialog_->SetFilter(pFilter);
+	}
+
+	/* [local] */ HRESULT STDMETHODCALLTYPE Show(
+	    /* [annotation][unique][in] */
+	    _In_opt_ HWND hwndOwner)
+	{
+		return originalDialog_->Show(hwndOwner);
+	}
+
+	HRESULT STDMETHODCALLTYPE QueryInterface(
+	    /* [in] */ REFIID riid,
+	    /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject)
+	{
+		return originalDialog_->QueryInterface(riid, ppvObject);
+	}
+
+	ULONG STDMETHODCALLTYPE AddRef(void)
+	{
+		return originalDialog_->AddRef();
+	}
+
+	ULONG STDMETHODCALLTYPE Release(){
+		return originalDialog_->Release();
+	};
+
+private:
+	IFileOpenDialog* originalDialog_ = NULL;
+};
+
 ////////////////////////////////////////////////////////////////
 //HookFunction
-///////////////////////////////////////////////////////////////////////////////////////////
+static HRESULT WINAPI Hook_CoCreateInstance(
+	_In_  REFCLSID  rclsid,
+	_In_  LPUNKNOWN pUnkOuter,
+	_In_  DWORD     dwClsContext,
+	_In_  REFIID    riid,
+	_Out_ LPVOID    *ppv
+)
+{
+	PROC_TIME(Hook_CoCreateInstance)
+	HRESULT hRet = {0};
+	hRet = pORG_CoCreateInstance(
+		rclsid,
+		pUnkOuter,
+		dwClsContext,
+		riid,
+		ppv
+	);
+	if (rclsid == CLSID_FileOpenDialog)// || rclsid == CLSID_FileSaveDialog)
+	{
+		ChronosFileOpenDialog *chronosFileOpenDialog = new ChronosFileOpenDialog((IFileOpenDialog *)(*ppv));
+		*ppv = (LPVOID)chronosFileOpenDialog;
+	}
+	
+	return hRet;
+}
 
+///////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////
 //@@ComDlg32
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -343,6 +558,15 @@ void APIHookC::DoHookComDlgAPI()
 
 		if (pTargetW == NULL) return;
 		if (MH_EnableHook(pTargetW) != MH_OK)
+			return;
+	}
+	if (!pORG_CoCreateInstance)
+	{
+		if (MH_CreateHookApiEx(
+			L"ole32.dll", "CoCreateInstance", &Hook_CoCreateInstance, &pORG_CoCreateInstance) != MH_OK)
+			return;
+
+		if (MH_EnableHook(&CoCreateInstance) != MH_OK)
 			return;
 	}
 }

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -331,6 +331,7 @@ public:
 
 			CString strSelPath(wstrSelPath);
 			CoTaskMemFree(wstrSelPath);
+			strSelPath.MakeUpper();
 			if (strSelPath.IsEmpty())
 			{
 				return hresult;
@@ -338,15 +339,13 @@ public:
 
 			if (theApp.IsSGMode())
 			{
-				CString strRootUpper(m_strRootPath);
-				CString strSelPathUpper = strSelPath;
-				strSelPathUpper.MakeUpper();
-				strRootUpper.MakeUpper();
-				if (strSelPathUpper.Find(strRootUpper) != 0)
+				CString strRoot(m_strRootPath);
+				strRoot.MakeUpper();
+				if (strSelPath.Find(strRoot) != 0)
 				{
 					CString strCaption(theApp.m_strThisAppName);
 					CString strMsg;
-					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)m_strRootPath, (LPCWSTR)strSelPath);
+					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
 					::MessageBoxW(hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -340,7 +340,7 @@ public:
 				{
 					CString strCaption(theApp.m_strThisAppName);
 					CString strMsg;
-					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", strRoot, (PCWSTR)strSelPath);
+					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCTSTR)strRoot, (LPCTSTR)strSelPath);
 					::MessageBoxW(hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}
@@ -657,7 +657,7 @@ public:
 			if (strSelPath.Find(strRoot) != 0)
 			{
 				CString strMsg;
-				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", strRoot, strRoot, (PCWSTR)strSelPath);
+				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", (LPCTSTR)strRoot, (LPCTSTR)strRoot, (LPCTSTR)strSelPath);
 				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 				continue;
 			}
@@ -666,7 +666,7 @@ public:
 			if (strSelPath.Find(strTSG_Upload) == 0)
 			{
 				CString strMsg;
-				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", strTSG_Upload, (PCWSTR)strSelPath);
+				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCTSTR)strTSG_Upload, (LPCTSTR)strSelPath);
 				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 				continue;
 			}

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -109,7 +109,7 @@ public:
 			return hresult;
 		}
 
-		IShellItem* psi;
+		CComPtr<IShellItem> psi;
 		hresult = ::SHCreateShellItem(NULL, NULL, pidl, &psi);
 		if (SUCCEEDED(hresult))
 		{
@@ -315,7 +315,7 @@ public:
 			}
 
 			LPWSTR wstrSelPath;
-			IShellItem *psi;
+			CComPtr<IShellItem> psi;
 			hresult = this->GetResult(&psi);
 
 			if (FAILED(hresult))

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -641,7 +641,7 @@ public:
 			}
 
 			LPWSTR wstrSelPath;
-			IShellItem* psi;
+			CComPtr<IShellItem> psi;
 			hresult = this->GetResult(&psi);
 			if (FAILED(hresult))
 			{

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -41,7 +41,8 @@ public:
 		}
 	}
 
-	HRESULT Initialize() {
+	HRESULT Initialize() 
+	{
 		HRESULT hresult = S_OK;
 		CString strPath;
 		if (theApp.IsSGMode())

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -41,14 +41,13 @@ public:
 		}
 	}
 
-	HRESULT Initialize() 
+	HRESULT Initialize()
 	{
 		HRESULT hresult = S_OK;
 		CString strPath;
 		if (theApp.IsSGMode())
 		{
 			CString strRootPath;
-			//UploadTabを使う場合は、B:\\Uploadにする
 			if (theApp.m_AppSettings.IsShowUploadTab())
 			{
 				strRootPath = theApp.m_AppSettings.GetRootPath();
@@ -62,7 +61,6 @@ public:
 					strRootPath = _T("B:\\");
 				}
 			}
-			//UploadTabを使わない場合は、O:\\にする
 			else
 			{
 				strRootPath = theApp.m_AppSettings.GetUploadBasePath();
@@ -75,19 +73,12 @@ public:
 			strPath = strRootPath;
 
 			FILEOPENDIALOGOPTIONS option = 0;
-			// フック関数を無効
 			option &= ~OFN_ENABLEHOOK;
-			//ダイアログテンプレート無効
 			option &= ~OFN_ENABLETEMPLATE;
-			//Longファイル名を強制
 			option |= OFN_LONGNAMES;
-			//ネットワークボタンを隠す
 			option |= OFN_NONETWORKBUTTON;
-			//最近使ったファイルを追加しない
 			option |= OFN_DONTADDTORECENT;
-			//プレースバーを無効
 			option |= OFN_EX_NOPLACESBAR;
-			//ファイルを上書きするかどうか確認するプロンプトを表示
 			option |= OFN_OVERWRITEPROMPT;
 
 			hresult = this->SetOptions(option);
@@ -126,7 +117,7 @@ public:
 			this->SetDefaultFolder(psi);
 		}
 		ILFree(pidl);
-		
+
 		return hresult;
 	}
 
@@ -283,18 +274,19 @@ public:
 	/* [local] */ HRESULT STDMETHODCALLTYPE Show(
 	    /* [annotation][unique][in] */ _In_opt_ HWND hwndOwner)
 	{
-		//呼び出しもとを確認、親の親がNULLだったらChronosの設定画面から
+		//呼び出しもとを確認。親の親がNULLだったらChronosの設定画面からなので無条件で開いて良い。
 		if (!hwndOwner)
 		{
 			return m_originalDialog->Show(hwndOwner);
 		}
+
 		HWND hWindowOwner = GetParent(hwndOwner);
 		HWND hWindowParent = {0};
 		if (hWindowOwner)
 		{
 			hWindowParent = GetParent(hWindowOwner);
 		}
-		//hWindowParentがNULLの場合は、そのまま
+
 		if (!hWindowParent)
 		{
 			return m_originalDialog->Show(hwndOwner);
@@ -313,7 +305,7 @@ public:
 			}
 			return E_ACCESSDENIED;
 		}
-		
+
 		for (;;)
 		{
 			HRESULT hresult = m_originalDialog->Show(hwndOwner);
@@ -323,9 +315,9 @@ public:
 			}
 
 			LPWSTR wstrSelPath;
-			IShellItem *psi;
+			IShellItem* psi;
 			hresult = this->GetResult(&psi);
-			
+
 			if (FAILED(hresult))
 			{
 				return hresult;
@@ -427,28 +419,21 @@ public:
 
 		FILEOPENDIALOGOPTIONS option = 0;
 
-		//フック関数を無効
 		option &= ~OFN_ENABLEHOOK;
-		//ダイアログテンプレート無効
 		option &= ~OFN_ENABLETEMPLATE;
-		//Longファイル名を強制
 		option |= OFN_LONGNAMES;
-		//ネットワークボタンを隠す
 		option |= OFN_NONETWORKBUTTON;
-		//最近使ったファイルを追加しない
 		option |= OFN_DONTADDTORECENT;
-		//プレースバーを無効
 		option |= OFN_EX_NOPLACESBAR;
-		//ファイルを上書きするかどうか確認するプロンプトを表示
 		option |= OFN_OVERWRITEPROMPT;
 
 		return this->SetOptions(option);
 	}
 
-    HRESULT STDMETHODCALLTYPE SetSaveAsItem(
+	HRESULT STDMETHODCALLTYPE SetSaveAsItem(
 	    /* [in] */ __RPC__in_opt IShellItem* psi)
 	{
-	    return m_originalDialog->SetSaveAsItem(psi);
+		return m_originalDialog->SetSaveAsItem(psi);
 	}
 
 	HRESULT STDMETHODCALLTYPE SetProperties(
@@ -477,7 +462,6 @@ public:
 	    /* [unique][in] */ __RPC__in_opt IFileOperationProgressSink* pSink)
 	{
 		return m_originalDialog->ApplyProperties(psi, pStore, hwnd, pSink);
-
 	}
 
 	HRESULT STDMETHODCALLTYPE SetFileTypes(
@@ -620,7 +604,7 @@ public:
 		return m_originalDialog->SetFilter(pFilter);
 	}
 
-	/* [local] */ 
+	/* [local] */
 	HRESULT STDMETHODCALLTYPE Show(
 	    /* [annotation][unique][in] */ _In_opt_ HWND hwndOwner)
 	{
@@ -759,7 +743,7 @@ static HRESULT WINAPI Hook_CoCreateInstance(
 			*ppv = chronosFileOpenDialog;
 		}
 	}
-	else if (rclsid == CLSID_FileSaveDialog)
+	else
 	{
 		CComPtr<IFileSaveDialog> fileSaveDialog;
 		hRet = pORG_CoCreateInstance(


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#34

# What this PR does / why we need it:

To work the file upload/download prohibition.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Check "ファイルアップロードを禁止する" / "ファイルダウンロードを禁止する" in setting.
2. Try to upload/download files.

## Expected result:

* File uploading is prohibited if  "ファイルアップロードを禁止する"  is checked.
* File downloading is prohibited if "ファイルダウンロードを禁止する" is checked.

## Tests for checking regression

### ThinApp

#### File download dialog

* `B:\` ドライブのみが選択できること
* ルートドライブ以外を選択すると、ルートドライブしか選択できない旨の警告ダイアログがでること
  * 確認手順: 
    * 設定-> ファイルマネージャ設定 -> ダウンロード/アップロードアイテムの規定のパスを`C:\`にする
    * その状態でダウンロードダイアログを開くと`B:\`しか選択できないので、適当なファイルをダウンロードしようとする
* `B:\Upload` フォルダを選択すると、アップロードフォルダはダウンロードの対象にできない旨の警告ダイアログがでること

#### File upload dialog

* `B:\` 以外が表示されていないこと
* 前回選択したフォルダがない場合、`B:\Upload` がデフォルトで選択されること
* 前回選択したフォルダがある場合、そのフォルダがデフォルトで選択されること
* ルートに指定しているドライブ以外を選択すると、ルートに指定しているドライブしか選択できない旨の警告ダイアログがでること
  * 確認手順: 
    * 設定-> ファイルマネージャ設定 -> ダウンロード/アップロードアイテムの規定のパスを`C:\`にする
    * その状態でアップロードダイアログを開くと`B:\`しか選択できないので、適当なファイルをアップロードしようとする
* トレースログが有効な時、アップロードしたファイルがログに記録されること
### ThinApp

### Native

#### File download dialog

* デフォルトで「ダウンロード」フォルダが選択されること
* `B:\` ドライブ以外が選択できること
* `B:\` ドライブ以外を選択しても問題なくダウンロードできること

#### File upload dialog

* 前回選択したフォルダがない場合、「ダウンロード」フォルダが選択されること
* 前回選択したフォルダがある場合、そのフォルダがデフォルトで選択されること
* `B:\` ドライブ以外を選択しても問題なくダウンロードできること
* トレースログが有効な時、アップロードしたファイルがログに記録されること