### PR TITLE
Fix a bug that download doesn't work after failing to download

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -942,8 +942,7 @@ void ClientHandler::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
 			m_bDownLoadStartFlg = FALSE;
 			return;
 		}
-
-		if (values.bIsInProgress)
+		else if (values.bIsInProgress)
 		{
 			if (values.bIsValid)
 			{
@@ -1023,21 +1022,19 @@ void ClientHandler::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
 				//}
 				return;
 			}
-			if (values.bIsCanceled)
-			{
-				if (theApp.m_DlMgr.IsCanceld(nBrowserId))
-				{
-					theApp.m_DlMgr.SetDlProgress(nBrowserId, FALSE);
-					::SendMessageTimeout(hWindow, WM_APP_CEF_DOWNLOAD_UPDATE, (WPARAM)FALSE, NULL, SMTO_NORMAL, 1000, NULL);
+		}
+		else
+		{
+			// values.bIsCanceled ‚Ü‚½‚Í DownloadItem::INTERRUPTE
+			theApp.m_DlMgr.SetDlProgress(nBrowserId, FALSE);
+			::SendMessageTimeout(hWindow, WM_APP_CEF_DOWNLOAD_UPDATE, (WPARAM)FALSE, NULL, SMTO_NORMAL, 1000, NULL);
 
-					callback->Cancel();
-					theApp.m_DlMgr.Release_DLDlg(nBrowserId);
-					EmptyWindowClose(browser);
-					m_bDownLoadStartFlg = FALSE;
-					return;
-				}
-				return;
-			}
+			callback->Cancel();
+
+			theApp.m_DlMgr.Release_DLDlg(nBrowserId);
+			EmptyWindowClose(browser);
+			m_bDownLoadStartFlg = FALSE;
+			return;
 		}
 	}
 }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/41

# What this PR does / why we need it:

ファイルのダウンロードに失敗した後、同じタブでダウンロードができなくなる問題を修正

# How to verify the fixed issue:

## The steps to verify:

1. リンク切れのリンクがあるページを開く。 
2. リンク切れのリンクを右クリック -> 名前を付けて保存 で保存する
3. その後、同じタブで何か別のダウンロードを実行する

添付のtest.zipを展開したtest.htmlが、リンク切れのあるページがあるサンプルhtml。
このファイルをChronosのアドレスバーから指定することで確認可能。
[test.zip](https://github.com/ThinBridge/Chronos/files/11246239/test.zip)

## Expected result:

別のダウンロードが実行できること