### PR TITLE
Update to stable version of CEF 112

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=112.2.6+gaad7246+chromium-112.0.5615.29
+VERSION=112.2.7+gef29713+chromium-112.0.5615.49
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_112.2.6+gaad7246+chromium-112.0.5615.29_windows32_beta_minimal
+  set CEFVER=cef_binary_112.2.7+gef29713+chromium-112.0.5615.49_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:
N/A

# What this PR does / why we need it:

Update to stable version of CEF 112:
112.2.7+gef29713+chromium-112.0.5615.49

# How to verify the fixed issue:

* Check embedded CEF version

## The steps to verify:

1. Build Chronos as usual
2. Run Chronos
3. Open Help -> Version

## Expected result:

```
Version 12.111.112.0  WIN32(x86)
...
Chromium Embedded Framework Version 112.2.7+gef29713+chromium-112.0.5615.49
Chromium(Blink) Version 112.0.5615.49
```
