### PR TITLE
Resolve warning C26495 "A member variable isn't initialized by a cons…

### DIFF
--- a/DlgDebugWnd.cpp
+++ b/DlgDebugWnd.cpp
@@ -548,6 +548,9 @@ IMPLEMENT_DYNAMIC(CDlgSCEditor, CDialogEx)
 CDlgSCEditor::CDlgSCEditor(CWnd* pParent /*=NULL*/)
     : CDialogEx(CDlgSCEditor::IDD, pParent)
 {
+	bFirstFlg = FALSE;
+	m_SelPosE = 0;
+	m_SelPosS = 0;
 }
 
 CDlgSCEditor::~CDlgSCEditor()

--- a/DlgDomainDetail.cpp
+++ b/DlgDomainDetail.cpp
@@ -6,6 +6,8 @@ IMPLEMENT_DYNAMIC(CDlgDomainDetail, CDialogEx)
 CDlgDomainDetail::CDlgDomainDetail(CWnd* pParent /*=NULL*/)
     : CDialogEx(IDD_DIALOG5, pParent)
 {
+	m_ActionType = 0;
+	m_bEnable = FALSE;
 }
 
 CDlgDomainDetail::~CDlgDomainDetail()
@@ -94,6 +96,7 @@ IMPLEMENT_DYNAMIC(CDlgCustomScriptDetail, CDialogEx)
 CDlgCustomScriptDetail::CDlgCustomScriptDetail(CWnd* pParent /*=NULL*/)
     : CDialogEx(IDD_DIALOG6, pParent)
 {
+	m_bEnable = FALSE;
 }
 
 CDlgCustomScriptDetail::~CDlgCustomScriptDetail()

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -5,10 +5,10 @@ typedef class _PageInfo PAGE_INFO;
 class _PageInfo
 {
 public:
-	BOOL bViewClass;
-	UINT nID;
-	CWnd* pWnd;
-	CWnd* pWndParent;
+	BOOL bViewClass = FALSE;
+	UINT nID = 0;
+	CWnd* pWnd = nullptr;
+	CWnd* pWndParent = nullptr;
 	CString csCaption;
 	CString csParentCaption;
 };
@@ -27,7 +27,7 @@ namespace autoresize
 	struct ResizeSpec
 	{
 		HWND m_hwnd = nullptr;
-		CRect m_rc = nullptr;
+		CRect m_rc;
 		UINT m_resizeSpec = 0;
 	};
 

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -26,9 +26,9 @@ namespace autoresize
 
 	struct ResizeSpec
 	{
-		HWND m_hwnd;
-		CRect m_rc;
-		UINT m_resizeSpec;
+		HWND m_hwnd = nullptr;
+		CRect m_rc = nullptr;
+		UINT m_resizeSpec = 0;
 	};
 
 	class CAutoResize
@@ -211,6 +211,7 @@ public:
 		m_textClr = ::GetSysColor(COLOR_3DFACE);
 		m_fontWeight = FW_NORMAL;
 		m_fontSize = 12;
+		m_grayText = FALSE;
 	}
 
 public:
@@ -308,7 +309,7 @@ public:
 
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV supportk
-	//}}AFX_VIRTUAL
+							 //}}AFX_VIRTUAL
 
 	// Implementation
 protected:
@@ -348,7 +349,7 @@ public:
 	//{{AFX_VIRTUAL(CDlgSetTab1)
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV サポート
-	//}}AFX_VIRTUAL
+							 //}}AFX_VIRTUAL
 
 	// インプリメンテーション
 protected:

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -309,7 +309,7 @@ public:
 
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV supportk
-							 //}}AFX_VIRTUAL
+	//}}AFX_VIRTUAL
 
 	// Implementation
 protected:
@@ -349,7 +349,7 @@ public:
 	//{{AFX_VIRTUAL(CDlgSetTab1)
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV サポート
-							 //}}AFX_VIRTUAL
+	//}}AFX_VIRTUAL
 
 	// インプリメンテーション
 protected:

--- a/MyComboBoxEx.h
+++ b/MyComboBoxEx.h
@@ -73,6 +73,7 @@ public:
 	CMyComboEdit()
 	{
 		m_pParentFrmWnd = NULL;
+		m_bIME = FALSE;
 	};
 	virtual ~CMyComboEdit(){};
 	CWnd* m_pParentFrmWnd;

--- a/client_app.h
+++ b/client_app.h
@@ -96,7 +96,7 @@ public:
 					     CefRefPtr<CefImage> image);
 
 public:
-	CBrowserFrame* m_pwndFrame;
+	CBrowserFrame* m_pwndFrame = nullptr;
 	void SetFramePtr(CBrowserFrame* pwndFrame) { m_pwndFrame = pwndFrame; }
 	void AddRef() const override
 	{

--- a/fav.h
+++ b/fav.h
@@ -170,10 +170,7 @@ public:
 class CFavoriteItem
 {
 public:
-	CFavoriteItem() : CFavoriteItem(IEFavURL)
-	{
-	}
-	CFavoriteItem(int iType)
+	CFavoriteItem(int iType = IEFavURL)
 	{
 		bType = iType;
 		commandID = 0;

--- a/fav.h
+++ b/fav.h
@@ -170,14 +170,13 @@ public:
 class CFavoriteItem
 {
 public:
-	CFavoriteItem()
+	CFavoriteItem() : CFavoriteItem(IEFavURL)
 	{
-		bType = IEFavURL;
-		commandID = 0;
 	}
 	CFavoriteItem(int iType)
 	{
 		bType = iType;
+		commandID = 0;
 	}
 	virtual ~CFavoriteItem()
 	{
@@ -426,6 +425,9 @@ public:
 	{
 		m_FavRootItem = NULL;
 		m_iRet = 0;
+		iindex = 0;
+		iLinkCnt = 0;
+		bIEOrder = FALSE;
 	}
 	virtual ~CFavoriteItemManager()
 	{

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -3621,7 +3621,10 @@ class CTaskbarList3
 protected:
 	ATL::CComPtr<ITaskbarList3> m_pTaskbarList3;
 	HWND m_hWnd;
-	CTaskbarList3(const CTaskbarList3& obj) {}
+	CTaskbarList3(const CTaskbarList3& obj)
+	{
+		m_hWnd = nullptr;
+	}
 
 public:
 	CTaskbarList3()

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -3620,17 +3620,14 @@ class CTaskbarList3
 {
 protected:
 	ATL::CComPtr<ITaskbarList3> m_pTaskbarList3;
-	HWND m_hWnd;
-	CTaskbarList3(const CTaskbarList3& obj)
-	{
-		m_hWnd = nullptr;
-	}
+	HWND m_hWnd = nullptr;
+	CTaskbarList3(const CTaskbarList3& obj) {}
 
 public:
 	CTaskbarList3()
 	{
-		m_pTaskbarList3 = NULL;
-		m_hWnd = NULL;
+		m_pTaskbarList3 = nullptr;
+		m_hWnd = nullptr;
 	}
 	virtual ~CTaskbarList3() { Uninitialize(); }
 	BOOL Initialize(HWND hWnd)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42 
警告 C26495の解決。

```
C:\gitdir\Chronos\fav.h(178): warning C26495: 変数 'CFavoriteItem::commandID' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\fav.h(425): warning C26495: 変数 'CFavoriteItemManager::bIEOrder' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\sbcommon.h(3624): warning C26495: 変数 'CTaskbarList3::m_hWnd' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\DlgSetting.h(32): warning C26495: 変数 'autoresize::ResizeSpec::m_resizeSpec' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\DlgSetting.h(209): warning C26495: 変数 'CPrefsStatic::m_grayText' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\DlgSetting.h(14): warning C26495: 変数 '_PageInfo::bViewClass' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\MyComboBoxEx.h(73): warning C26495: 変数 'CMyComboEdit::m_bIME' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\client_app.h(116): warning C26495: 変数 'DownloadFaviconCB::m_pwndFrame' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\DlgDebugWnd.cpp(548): warning C26495: 変数 'CDlgSCEditor::bFirstFlg' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\DlgDomainDetail.cpp(6): warning C26495: 変数 'CDlgDomainDetail::m_ActionType' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
C:\gitdir\Chronos\DlgDomainDetail.cpp(94): warning C26495: 変数 'CDlgCustomScriptDetail::m_bEnable' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。
```

# What this PR does / why we need it:

初期化漏れのため、潜在的な危険性がある。
そもそも論として、警告は出ないべきである。

# How to verify the fixed issue:

## The steps to verify:
## Expected result:

* ビルドできること
* C26495の警告がでないこと
* Chronosが起動できること
* お気に入り関係のメニュー等が従来と差異なく表示されること
* 設定画面のダイアログが従来と差異なく表示されること
* タスクバーが従来と差異なく表示されること
* URLフィルター設定のドメインフィルター設定のダイアログが従来と差異なく表示されること
* ログ出力設定のデバッグトレースログのダイアログが従来と差異なく表示されること
