### PR TITLE
Add cast for calculation

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4319,7 +4319,7 @@ BOOL CSazabi::IsLimitChkEx()
 		unsigned long long iMemSize = GetMemoryUsageSize();
 		size_t iMemL = m_AppSettings.GetMemoryUsageLimit();
 		//GDI/ User /Mamory Limits
-		if (iMemSize > iMemL * 1024 * 1024)
+		if (iMemSize > (unsigned long long)iMemL * 1024 * 1024)
 		{
 			CString alertMsg;
 			alertMsg.LoadString(IDS_STRING_LOW_SYSTEM_RESOURCE_SHUTDOWN);
@@ -4337,13 +4337,13 @@ BOOL CSazabi::IsLimitChkEx()
 		else
 		{
 			//WARNING
-			if (iMemSize > (iMemL - 250) * 1024 * 1024)
+			if (iMemSize > (unsigned long long)(iMemL - 250) * 1024 * 1024)
 			{
 				//一旦ワーキングセットをクリアして開放してしまう。
 				EmptyWorkingSetAll();
 			}
 			iMemSize = GetMemoryUsageSize();
-			if (iMemSize > (iMemL - 250) * 1024 * 1024)
+			if (iMemSize > (unsigned long long)(iMemL - 250) * 1024 * 1024)
 			{
 				CString alertMsg;
 				alertMsg.LoadString(IDS_STRING_LOW_SYSTEM_RESOURCE_SUGGEST);


### PR DESCRIPTION


# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

C26451 の警告を解消

```
演算のオーバーフロー: 4 バイトの値に演算子 '*' を使用し、結果を 8 バイトの値にキャストしています。オーバーフローを避けるため、演算子 '*' を呼び出す前に値を幅の広い型にキャストしてください (io.2)。	Sazabi	C:\gitdir\Chronos\Sazabi.cpp	4346	
```

# How to verify the fixed issue:

## The steps to verify:

* ビルドまたは分析を行う

## Expected result:

* C26451の警告がでないこと