### PR TITLE
Resolve warnings about CString.Format

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -533,7 +533,7 @@ int CBrowserFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 	{
 		CString strAppendMenu;
 		pSysMenu->AppendMenu(MF_SEPARATOR);
-		strAppendMenu.Format(_T("About %s ..."), theApp.m_strThisAppName);
+		strAppendMenu.Format(_T("About %s ..."), (LPCTSTR)theApp.m_strThisAppName);
 		pSysMenu->AppendMenu(MF_STRING, IDM_ABOUTBOX, strAppendMenu);
 
 		if (theApp.InVirtualEnvironment() != VE_NA && theApp.IsSGMode())
@@ -1169,7 +1169,7 @@ LRESULT CBrowserFrame::OnNewAddressEnter(WPARAM wParam, LPARAM lParam)
 		SearchAndNavigate(str);
 		m_pwndAddress->AppendString(str.GetBuffer(0));
 		CString logmsg;
-		logmsg.Format(_T("BF_WND:0x%08x OnNewAddressEnter:%s"), theApp.SafeWnd(this->m_hWnd), str);
+		logmsg.Format(_T("BF_WND:0x%08p OnNewAddressEnter:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)str);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	}
 	return 0;
@@ -1184,7 +1184,7 @@ LRESULT CBrowserFrame::OnNewAddress(WPARAM wParam, LPARAM lParam)
 		if (ExP == m_pwndAddress)
 		{
 			CString logmsg;
-			logmsg.Format(_T("BF_WND:0x%08x OnNewAddress:%s"), theApp.SafeWnd(this->m_hWnd), str);
+			logmsg.Format(_T("BF_WND:0x%08p OnNewAddress:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)str);
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 			m_pwndAddress->GetLBText(m_pwndAddress->GetCurSel(), str);
 			SearchAndNavigate(str);
@@ -1345,7 +1345,7 @@ BOOL CBrowserFrame::OnSetUrlString(LPCTSTR lParam)
 	strURL = (LPCTSTR)lParam;
 	CString logmsg;
 	DebugWndLogData dwLogData;
-	dwLogData.mHWND.Format(_T("BF_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+	dwLogData.mHWND.Format(_T("BF_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 	dwLogData.mFUNCTION_NAME = _T("OnSetUrlString");
 	dwLogData.mMESSAGE1 = strURL;
 	theApp.AppendDebugViewLog(dwLogData);
@@ -1708,11 +1708,11 @@ LRESULT CBrowserFrame::OnFavoriteAddSendMsg(WPARAM wParam, LPARAM lParam)
 		if (iLen > INTERNET_MAX_URL_LENGTH)
 			return 0;
 
-		strCommand.Format(_T("\"%s\" -AddFav \"%s|@@|%s\""), theApp.m_strDBL_EXE_FullPath, str1, str2);
-		strParam.Format(_T("-AddFav \"%s|@@|%s\""), str1, str2);
+		strCommand.Format(_T("\"%s\" -AddFav \"%s|@@|%s\""), (LPCTSTR)theApp.m_strDBL_EXE_FullPath, (LPCTSTR)str1, (LPCTSTR)str2);
+		strParam.Format(_T("-AddFav \"%s|@@|%s\""), (LPCTSTR)str1, (LPCTSTR)str2);
 
 		CString logmsg;
-		logmsg.Format(_T("BF_WND:0x%08x OnFavoriteAddSendMsg %s"), theApp.SafeWnd(this->m_hWnd), strCommand);
+		logmsg.Format(_T("BF_WND:0x%08p OnFavoriteAddSendMsg %s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strCommand);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 		STARTUPINFO si = {0};
@@ -1721,18 +1721,18 @@ LRESULT CBrowserFrame::OnFavoriteAddSendMsg(WPARAM wParam, LPARAM lParam)
 		unsigned long ecode = 0;
 		if (!CreateProcess(NULL, (LPTSTR)(LPCTSTR)strCommand, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi))
 		{
-			logmsg.Format(_T("BF_WND:0x%08x OnFavoriteAddSendMsg CreateProcess Failed"), theApp.SafeWnd(this->m_hWnd));
+			logmsg.Format(_T("BF_WND:0x%08p OnFavoriteAddSendMsg CreateProcess Failed"), theApp.SafeWnd(this->m_hWnd));
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 			SetLastError(NO_ERROR);
 			//Retry
 			if (!CreateProcess(theApp.m_strDBL_EXE_FullPath, (LPTSTR)(LPCTSTR)strParam, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi))
 			{
-				logmsg.Format(_T("BF_WND:0x%08x OnFavoriteAddSendMsg CreateProcess Failed2"), theApp.SafeWnd(this->m_hWnd));
+				logmsg.Format(_T("BF_WND:0x%08p OnFavoriteAddSendMsg CreateProcess Failed2"), theApp.SafeWnd(this->m_hWnd));
 				theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 				SetLastError(NO_ERROR);
 				if (::ShellExecute(NULL, _T("open"), theApp.m_strDBL_EXE_FullPath, strParam, NULL, SW_SHOW) <= HINSTANCE(32))
 				{
-					logmsg.Format(_T("BF_WND:0x%08x OnFavoriteAddSendMsg ShellExecute Failed3"), theApp.SafeWnd(this->m_hWnd));
+					logmsg.Format(_T("BF_WND:0x%08p OnFavoriteAddSendMsg ShellExecute Failed3"), theApp.SafeWnd(this->m_hWnd));
 					theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 					::ShellExecute(NULL, NULL, strCommand, NULL, NULL, SW_SHOW);
 				}
@@ -1756,7 +1756,7 @@ void CBrowserFrame::OnFavoriteAdd()
 {
 	OnFavoriteRefresh();
 	CString logmsg;
-	logmsg.Format(_T("BF_WND:0x%08x OnFavoriteAdd"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("BF_WND:0x%08p OnFavoriteAdd"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (this->m_wndView)
 		OnFavoriteAddSendMsg(((WPARAM)(LPCTSTR)m_wndView.m_strTitle), ((WPARAM)(LPCTSTR)m_wndView.GetLocationURL()));
@@ -1766,7 +1766,7 @@ void CBrowserFrame::OnFavoriteOrganize()
 {
 	OnFavoriteRefresh();
 	CString logmsg;
-	logmsg.Format(_T("BF_WND:0x%08x OnFavoriteOrganize"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("BF_WND:0x%08p OnFavoriteOrganize"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	BOOL retval = FALSE;
 	TCHAR szFolder[MAX_PATH] = {0};
@@ -1776,7 +1776,7 @@ void CBrowserFrame::OnFavoriteOrganize()
 	CString strParam;
 	theApp.CopyDBLEXEToTempEx();
 
-	strCommand.Format(_T("\"%s\" -FavOrganize"), theApp.m_strDBL_EXE_FullPath);
+	strCommand.Format(_T("\"%s\" -FavOrganize"), (LPCTSTR)theApp.m_strDBL_EXE_FullPath);
 	strParam.Format(_T("-FavOrganize"));
 	STARTUPINFO si = {0};
 	PROCESS_INFORMATION pi = {0};
@@ -1814,7 +1814,7 @@ void CBrowserFrame::OnFullScreen()
 	if (m_bFullScreen)
 	{
 		ChangeNomalWindow();
-		logmsg.Format(_T("BF_WND:0x%08x OnFullScreen_OFF"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("BF_WND:0x%08p OnFullScreen_OFF"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	}
 	//fullscreen mode に変更
@@ -1826,7 +1826,7 @@ void CBrowserFrame::OnFullScreen()
 			if (!m_wndView.IsPopupWindow())
 			{
 				ChangeFullScreenWindow();
-				logmsg.Format(_T("BF_WND:0x%08x OnFullScreen_ON"), theApp.SafeWnd(this->m_hWnd));
+				logmsg.Format(_T("BF_WND:0x%08p OnFullScreen_ON"), theApp.SafeWnd(this->m_hWnd));
 				theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 			}
 		}
@@ -1979,7 +1979,7 @@ UINT CBrowserFrame::GetWindowStyleSB()
 	if (!theApp.IsWnd(this))
 		return iRet;
 	CString logmsg;
-	logmsg.Format(_T("BF_WND:0x%08x GetWindowStyleSB"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("BF_WND:0x%08p GetWindowStyleSB"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 	if (m_pwndReBar)
@@ -2039,7 +2039,7 @@ void CBrowserFrame::SetWindowStyleSB(UINT iParam)
 		return;
 
 	CString logmsg;
-	logmsg.Format(_T("BF_WND:0x%08x SetWindowStyleSB(%d)"), theApp.SafeWnd(this->m_hWnd), iParam);
+	logmsg.Format(_T("BF_WND:0x%08p SetWindowStyleSB(%d)"), theApp.SafeWnd(this->m_hWnd), iParam);
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 	if (m_pwndReBar)
@@ -2175,7 +2175,7 @@ BOOL CBrowserFrame::OnShowPopupMenu(CMFCPopupMenu* pMenuPopup)
 				// 文字のカット
 				SBUtil::GetDivChar(strTempStr, 80, strTempStr2);
 				strTempStr2.Replace(_T("&"), _T("&&"));
-				strTitle.Format(_T("&%X  %s"), iCnt, strTempStr2);
+				strTitle.Format(_T("&%X  %s"), iCnt, (LPCTSTR)strTempStr2);
 				Menu.AppendMenu(MF_BYPOSITION | MF_STRING | MF_ENABLED, ID_CLOSE_WINDOW_START + iCnt, strTitle);
 				iCnt++;
 			}
@@ -2216,13 +2216,13 @@ BOOL CBrowserFrame::OnShowPopupMenu(CMFCPopupMenu* pMenuPopup)
 			if (bBack)
 			{
 				menu2.LoadMenu(IDR_MENU_BACK);
-				logmsg.Format(_T("BF_WND:0x%08x TravelLog_Back"), theApp.SafeWnd(this->m_hWnd));
+				logmsg.Format(_T("BF_WND:0x%08p TravelLog_Back"), theApp.SafeWnd(this->m_hWnd));
 				theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 			}
 			else
 			{
 				menu2.LoadMenu(IDR_MENU_FORWARD);
-				logmsg.Format(_T("BF_WND:0x%08x TravelLog_Forward"), theApp.SafeWnd(this->m_hWnd));
+				logmsg.Format(_T("BF_WND:0x%08p TravelLog_Forward"), theApp.SafeWnd(this->m_hWnd));
 				theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 			}
 			CMenu* pPopup;
@@ -2559,7 +2559,7 @@ void CBrowserFrame::OnStatusBarZoomClick()
 		return;
 
 	CString logmsg;
-	logmsg.Format(_T("BF_WND:0x%08x OnStatusBarZoomClick"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("BF_WND:0x%08p OnStatusBarZoomClick"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 	long lResult = 0;
@@ -2593,7 +2593,7 @@ void CBrowserFrame::OnStatusBarZoomClick()
 	CString strNowZoom;
 	strNowZoom = m_pwndStatusBar->GetPaneText(nStatusZoom);
 
-	logmsg.Format(_T("BF_WND:0x%08x OnStatusBarZoomClick Now_%s"), theApp.SafeWnd(this->m_hWnd), strNowZoom);
+	logmsg.Format(_T("BF_WND:0x%08p OnStatusBarZoomClick Now_%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strNowZoom);
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 	CString strName;
@@ -2688,7 +2688,7 @@ void CBrowserFrame::OnStatusBarZoomClick()
 					break;
 				}
 				m_wndView.ZoomTo(dZoom);
-				logmsg.Format(_T("BF_WND:0x%08x OnStatusBarZoomClick %s"), theApp.SafeWnd(this->m_hWnd), strRet);
+				logmsg.Format(_T("BF_WND:0x%08p OnStatusBarZoomClick %s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strRet);
 				theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 			}
 		}

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -232,7 +232,7 @@ BOOL CChildView::Create(LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwS
 			m_dbZoomSizeDefault = dZoom;
 		}
 		CString logmsg;
-		logmsg.Format(_T("ChildView::Create BF_WND:0x%08x CV_WND:0x%08x"), theApp.SafeWnd(m_pwndFrame), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("ChildView::Create BF_WND:0x%08p CV_WND:0x%08p"), theApp.SafeWnd(m_pwndFrame), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 	catch (...)
@@ -385,7 +385,7 @@ BOOL CChildView::IsFileURINavigation(const CString& strURL)
 		return FALSE;
 
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x IsFileURINavigation:%s"), theApp.SafeWnd(this->m_hWnd), strURL);
+	logmsg.Format(_T("CV_WND:0x%08p IsFileURINavigation:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strURL);
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 	LockSetForegroundWindow(LSFW_UNLOCK);
 	theApp.OpenFileExplorer(strURL);
@@ -429,8 +429,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 
 	if (strRet.CompareNoCase(_T("IE")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageIE, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageIE, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -442,8 +442,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 
 	if (strRet.CompareNoCase(_T("Custom")) == 0 || strRet.CompareNoCase(_T("Custom1")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageCustom, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageCustom, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -454,8 +454,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 	}
 	if (strRet.CompareNoCase(_T("Custom2")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageCustom, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageCustom, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -466,8 +466,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 	}
 	if (strRet.CompareNoCase(_T("Custom3")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageCustom, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageCustom, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -478,8 +478,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 	}
 	if (strRet.CompareNoCase(_T("Custom4")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageCustom, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageCustom, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -490,8 +490,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 	}
 	if (strRet.CompareNoCase(_T("Custom5")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageCustom, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageCustom, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -503,8 +503,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 
 	if (strRet.CompareNoCase(_T("Block")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageNG, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:<BLOCK> %s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageNG, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:<BLOCK> %s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -515,8 +515,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 
 	if (strRet.CompareNoCase(_T("Default")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageDBL, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageDBL, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -528,8 +528,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 
 	if (strRet.CompareNoCase(_T("Firefox")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageFF, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageFF, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -541,8 +541,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 
 	if (strRet.CompareNoCase(_T("Chrome")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageCHR, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageCHR, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -554,8 +554,8 @@ BOOL CChildView::IsRedirectScriptEx(LPCTSTR sURL, LPCTSTR sChkURLNoQuery, BOOL b
 
 	if (strRet.CompareNoCase(_T("Edge")) == 0)
 	{
-		strTimeoutMessage.Format(_T("%s\n%s"), theApp.m_strZoneMessageEDG, strURLMid);
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), strTimeoutMessage);
+		strTimeoutMessage.Format(_T("%s\n%s"), (LPCTSTR)theApp.m_strZoneMessageEDG, (LPCTSTR)strURLMid);
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectScript:%s"), theApp.SafeWnd(this->m_hWnd), (LPCTSTR)strTimeoutMessage);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_DE);
 
 		if (theApp.m_AppSettings.GetRedirectMsgTimeout() > 0)
@@ -602,7 +602,7 @@ BOOL CChildView::IsRedirectURLChk(const CString& strURL, BOOL bTop)
 			strPath = _T("/");
 
 		CString strURLChk; //Queryを除く。無駄な情報を省く。
-		strURLChk.Format(_T("%s://%s%s"), strScheme, strHost, strPath);
+		strURLChk.Format(_T("%s://%s%s"), (LPCTSTR)strScheme, (LPCTSTR)strHost, (LPCTSTR)strPath);
 
 		//除外にHitした。
 		if (theApp.IsCacheRedirectFilterNone(strURLChk))
@@ -634,7 +634,7 @@ void CChildView::IsRedirectWndAutoCloseChk()
 	//Shiftキー / ESCが押されている場合は、閉じない。
 	if (::GetKeyState(VK_SHIFT) < 0 || ::GetKeyState(VK_ESCAPE) < 0)
 	{
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectWndAutoCloseChk :AutoClose Shift Key Skip"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectWndAutoCloseChk :AutoClose Shift Key Skip"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_TR);
 		return;
 	}
@@ -642,7 +642,7 @@ void CChildView::IsRedirectWndAutoCloseChk()
 	if (m_bFirstCallDontClose)
 	{
 		m_bFirstCallDontClose = FALSE;
-		logmsg.Format(_T("CV_WND:0x%08x IsRedirectWndAutoCloseChk :AutoClose First Call GoHome Skip"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p IsRedirectWndAutoCloseChk :AutoClose First Call GoHome Skip"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_TR);
 		return;
 	}
@@ -749,7 +749,7 @@ void CChildView::ResizeWindowPopupInpl()
 	try
 	{
 		CString logmsg;
-		logmsg.Format(_T("CV_WND:0x%08x ResizeWindowPopupInpl"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p ResizeWindowPopupInpl"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 		if (!theApp.IsWnd(m_pwndFrame))
 			return;
@@ -903,7 +903,7 @@ void CChildView::OnStatusTextChange(LPCTSTR lpszText)
 		}
 
 		DebugWndLogData dwLogData;
-		dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+		dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 		dwLogData.mFUNCTION_NAME = _T("OnStatusTextChange");
 		dwLogData.mMESSAGE1 = strTemp;
 		theApp.AppendDebugViewLog(dwLogData);
@@ -1274,7 +1274,7 @@ void CChildView::OnNew()
 	try
 	{
 		CString logmsg;
-		logmsg.Format(_T("CV_WND:0x%08x OnNew"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnNew"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 		if (!IsBrowserNull())
@@ -1300,7 +1300,7 @@ void CChildView::OnReopenCloseTab()
 	try
 	{
 		CString logmsg;
-		logmsg.Format(_T("CV_WND:0x%08x OnReopenCloseTab"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnReopenCloseTab"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 		if (!IsBrowserNull())
@@ -1334,7 +1334,7 @@ void CChildView::OnNewBlank()
 	try
 	{
 		CString logmsg;
-		logmsg.Format(_T("CV_WND:0x%08x OnNewBlank"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnNewBlank"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 
 		if (!IsBrowserNull())
@@ -1365,7 +1365,7 @@ void CChildView::OnNewSession()
 		startingMsg.LoadString(IDS_STRING_STARTING_NEW_SESSION);
 		FRM->SetMessage_MsgDlg(startingMsg);
 		CString logmsg;
-		logmsg.Format(_T("CV_WND:0x%08x OnNew"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnNew"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 		if (!IsBrowserNull())
 		{
@@ -1389,7 +1389,7 @@ void CChildView::OnNewSession()
 void CChildView::OnPrintPDF()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnPrintPDF"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnPrintPDF"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (m_cefBrowser)
 	{
@@ -1442,7 +1442,7 @@ void CChildView::OnPrintPDF()
 		CString szFilter;
 		szFilter.LoadString(ID_FILE_TYPE_PDF);
 		CString strFullPath;
-		strFullPath.Format(_T("%s%s"), strPath, strFileName);
+		strFullPath.Format(_T("%s%s"), (LPCTSTR)strPath, (LPCTSTR)strFileName);
 		CString strTitle;
 		strTitle.LoadString(ID_PRINT_TO_PDF_FILE_CHOOSER_TITLE);
 		CStringW strCaption(theApp.m_strThisAppName);
@@ -1536,7 +1536,7 @@ void CChildView::OnPrintPDF()
 void CChildView::ShowDevTools()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x ShowDevTools"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p ShowDevTools"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (m_cefBrowser)
 	{
@@ -1555,7 +1555,7 @@ void CChildView::ShowDevTools()
 void CChildView::OnPrint()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnPrint"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnPrint"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (m_cefBrowser)
 	{
@@ -1565,7 +1565,7 @@ void CChildView::OnPrint()
 void CChildView::OnGoBack()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnGoBack"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnGoBack"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (!IsBrowserNull())
 		GoBack();
@@ -1580,7 +1580,7 @@ void CChildView::OnUpdateGoBack(CCmdUI* pCmdUI)
 void CChildView::OnGoForward()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnGoForward"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnGoForward"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (!IsBrowserNull())
 		GoForward();
@@ -1597,7 +1597,7 @@ void CChildView::OnGoStartPage()
 	if (!IsBrowserNull())
 	{
 		CString logmsg;
-		logmsg.Format(_T("CV_WND:0x%08x OnGoStartPage"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnGoStartPage"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 		this->GoHome();
 	}
@@ -1610,7 +1610,7 @@ void CChildView::OnUpdateGoStartPage(CCmdUI* pCmdUI)
 void CChildView::OnViewRefresh()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnViewRefresh"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnViewRefresh"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (::GetAsyncKeyState(VK_CONTROL) < 0 &&
 	    ::GetKeyState(VK_SHIFT) >= 0 &&
@@ -1628,7 +1628,7 @@ void CChildView::OnUpdateViewRefresh(CCmdUI* pCmdUI)
 void CChildView::OnViewStop()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnViewStop"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnViewStop"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (!IsBrowserNull())
 		Stop();
@@ -1760,7 +1760,7 @@ LRESULT CChildView::OnFindDialogMessage(WPARAM wParam, LPARAM lParam)
 void CChildView::OnFindPage()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnFindPage"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnFindPage"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (m_cefBrowser)
 	{
@@ -1816,7 +1816,7 @@ void CChildView::OnAppAbout()
 void CChildView::OnSettings()
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnSettings"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnSettings"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	theApp.m_strCurrentURL4DlgSetting = m_strURL;
 	theApp.ShowSettingDlg(m_pwndFrame);
@@ -1824,7 +1824,7 @@ void CChildView::OnSettings()
 void CChildView::OnBroBack(UINT nID)
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnBroBack"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnBroBack"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	int max = nID - ID_BF_BACK1 + 1;
 	for (int i = 0; i < max; i++)
@@ -1833,14 +1833,14 @@ void CChildView::OnBroBack(UINT nID)
 void CChildView::OnZoom(UINT nID)
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnZoom"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnZoom"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	int max = nID - ID_ZOOM_START + 1;
 }
 void CChildView::OnBroForward(UINT nID)
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnBroForward"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnBroForward"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	int max = nID - ID_BF_FORWARD1 + 1;
 	for (int i = 0; i < max; i++)
@@ -1860,7 +1860,7 @@ void CChildView::OnKillFocus(CWnd* pNewWnd)
 void CChildView::OnFullScreen(BOOL bFlg)
 {
 	CString logmsg;
-	logmsg.Format(_T("CV_WND:0x%08x OnFullScreen"), theApp.SafeWnd(this->m_hWnd));
+	logmsg.Format(_T("CV_WND:0x%08p OnFullScreen"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
 	if (bFlg)
 	{
@@ -1886,7 +1886,7 @@ void CChildView::OnAddressBar(BOOL bFlg)
 		//非表示
 		if (!bFlg)
 		{
-			logmsg.Format(_T("CV_WND:0x%08x OnAddressBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
+			logmsg.Format(_T("CV_WND:0x%08p OnAddressBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 			if (theApp.IsWnd(m_pwndFrame))
 			{
@@ -1910,7 +1910,7 @@ void CChildView::OnAddressBar(BOOL bFlg)
 		}
 		else
 		{
-			logmsg.Format(_T("CV_WND:0x%08x OnAddressBar"), theApp.SafeWnd(this->m_hWnd));
+			logmsg.Format(_T("CV_WND:0x%08p OnAddressBar"), theApp.SafeWnd(this->m_hWnd));
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 		}
 	}
@@ -1926,7 +1926,7 @@ void CChildView::OnToolBar(BOOL bFlg)
 	//非表示
 	if (!bFlg)
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnToolBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnToolBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 		if (theApp.IsWnd(m_pwndFrame))
 		{
@@ -1949,7 +1949,7 @@ void CChildView::OnToolBar(BOOL bFlg)
 	}
 	else
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnToolBar"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnToolBar"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 	}
 }
@@ -1960,7 +1960,7 @@ void CChildView::OnMenuBar(BOOL bFlg)
 	//非表示
 	if (!bFlg)
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnMenuBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnMenuBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 		if (theApp.IsWnd(m_pwndFrame))
 		{
@@ -1982,7 +1982,7 @@ void CChildView::OnMenuBar(BOOL bFlg)
 	}
 	else
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnMenuBar"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnMenuBar"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 	}
 }
@@ -1993,7 +1993,7 @@ void CChildView::OnStatusBar(BOOL bFlg)
 	//非表示
 	if (!bFlg)
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnStatusBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnStatusBar_HIDE"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 		if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndStatusBar))
 		{
@@ -2002,7 +2002,7 @@ void CChildView::OnStatusBar(BOOL bFlg)
 	}
 	else
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnStatusBar"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnStatusBar"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 	}
 }
@@ -2013,13 +2013,13 @@ void CChildView::OnVisible(BOOL bFlg)
 	//表示
 	if (bFlg)
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnVisible"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnVisible"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 	}
 	//非表示
 	else
 	{
-		logmsg.Format(_T("CV_WND:0x%08x OnVisible_HIDE"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p OnVisible_HIDE"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 		this->EnableWindow(FALSE);
 		if (theApp.IsWnd(m_pwndFrame))
@@ -2038,7 +2038,7 @@ void CChildView::OnWindowSetResizable(BOOL bFlg)
 		//サイズ変更可能
 		if (bFlg)
 		{
-			logmsg.Format(_T("CV_WND:0x%08x OnWindowSetResizable_TRUE"), theApp.SafeWnd(this->m_hWnd));
+			logmsg.Format(_T("CV_WND:0x%08p OnWindowSetResizable_TRUE"), theApp.SafeWnd(this->m_hWnd));
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 
 			nNewStyle = nOldStyle | WS_THICKFRAME | WS_MAXIMIZEBOX;
@@ -2048,7 +2048,7 @@ void CChildView::OnWindowSetResizable(BOOL bFlg)
 		//サイズ変更不可
 		else
 		{
-			logmsg.Format(_T("CV_WND:0x%08x OnWindowSetResizable_FALSE"), theApp.SafeWnd(this->m_hWnd));
+			logmsg.Format(_T("CV_WND:0x%08p OnWindowSetResizable_FALSE"), theApp.SafeWnd(this->m_hWnd));
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_JS);
 
 			nNewStyle = nOldStyle & ~WS_THICKFRAME & ~WS_MAXIMIZEBOX;
@@ -2073,7 +2073,7 @@ void CChildView::CreateNewBrowserWindow(LPCTSTR lpszUrl, BOOL bActive)
 				DWORD bFlags = bActive ? 0 : NWMF_FORCETAB;
 
 				DebugWndLogData dwLogData;
-				dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+				dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 				dwLogData.mFUNCTION_NAME = _T("CreateNewBrowserWindow");
 				dwLogData.mMESSAGE1 = strURL;
 				dwLogData.mMESSAGE2.Format(_T("bActive:%s"), bActive ? _T("TRUE") : _T("FALSE"));
@@ -2241,7 +2241,7 @@ void CChildView::OnDestroy()
 			this->SafeWindowCloseFunction();
 		}
 		CString logmsg;
-		logmsg.Format(_T("CV_WND:0x%08x CChildView::OnDestroy"), theApp.SafeWnd(this->m_hWnd));
+		logmsg.Format(_T("CV_WND:0x%08p CChildView::OnDestroy"), theApp.SafeWnd(this->m_hWnd));
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_CL);
 		ViewBaseClass::OnDestroy();
 	}
@@ -2284,7 +2284,7 @@ LRESULT CChildView::OnBeforeBrowse(WPARAM wParam, LPARAM lParam)
 				}
 			}
 			DebugWndLogData dwLogData;
-			dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+			dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 			dwLogData.mFUNCTION_NAME = _T("OnBeforeBrowse");
 			dwLogData.mMESSAGE1 = strURL;
 			dwLogData.mMESSAGE2.Format(_T("TopPage:%s"), bTopPage ? _T("TRUE") : _T("FALSE"));
@@ -2361,7 +2361,7 @@ LRESULT CChildView::OnBeforeResourceLoad(WPARAM wParam, LPARAM lParam)
 		return S_OK;
 
 	DebugWndLogData dwLogData;
-	dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+	dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 	dwLogData.mFUNCTION_NAME = _T("OnBeforeResourceLoad");
 	dwLogData.mMESSAGE1 = strURL;
 	theApp.AppendDebugViewLog(dwLogData);
@@ -2384,7 +2384,7 @@ LRESULT CChildView::OnLoadStart(WPARAM wParam, LPARAM lParam)
 	FRM->m_pwndStatusBar->EnablePaneProgressBar(nStatusProgress, 100);
 
 	DebugWndLogData dwLogData;
-	dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+	dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 	dwLogData.mFUNCTION_NAME = _T("OnLoadStart");
 	theApp.AppendDebugViewLog(dwLogData);
 	CString logmsg = dwLogData.GetString();
@@ -2403,7 +2403,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 			FRM->SetProgress(0, -1);
 
 			DebugWndLogData dwLogData;
-			dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+			dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 			dwLogData.mFUNCTION_NAME = _T("OnLoadEnd");
 			theApp.AppendDebugViewLog(dwLogData);
 			CString logmsg = dwLogData.GetString();
@@ -2507,7 +2507,7 @@ LRESULT CChildView::OnProgressChange(WPARAM wParam, LPARAM lParam)
 				FRM->m_pwndStatusBar->SetPaneProgress(nStatusProgress, min(100, max(0, dwProgress)));
 
 				DebugWndLogData dwLogData;
-				dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+				dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 				dwLogData.mFUNCTION_NAME = _T("OnProgressChange");
 				dwLogData.mMESSAGE1.Format(_T("%d"), dwProgress);
 				theApp.AppendDebugViewLog(dwLogData);
@@ -2534,7 +2534,7 @@ LRESULT CChildView::OnStateChange(WPARAM wParam, LPARAM lParam)
 		return S_OK;
 
 	DebugWndLogData dwLogData;
-	dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), theApp.SafeWnd(this->m_hWnd));
+	dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), theApp.SafeWnd(this->m_hWnd));
 	dwLogData.mFUNCTION_NAME = _T("OnStateChange");
 	dwLogData.mMESSAGE1 = strURL;
 	dwLogData.mMESSAGE2.Format(_T("Loading:%s"), FRM->m_nBrowserState & CEF_BIT_IS_LOADING ? _T("TRUE") : _T("FALSE"));

--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -2151,9 +2151,9 @@ LRESULT CDlgSetDomainFilter::Set_OK(WPARAM wParam, LPARAM lParam)
 				CString allowLabel;
 				allowLabel.LoadString(ID_ACTION_LABEL_ALLOW);
 				if (bEnable)
-					strLineData.Format(_T("%s\t%s\n"), strURL, strMode == allowLabel ? _T("A") : _T("D"));
+					strLineData.Format(_T("%s\t%s\n"), (LPCTSTR)strURL, strMode == allowLabel ? _T("A") : _T("D"));
 				else
-					strLineData.Format(_T(";%s\t%s\n"), strURL, strMode == allowLabel ? _T("A") : _T("D"));
+					strLineData.Format(_T(";%s\t%s\n"), (LPCTSTR)strURL, strMode == allowLabel ? _T("A") : _T("D"));
 				out.WriteString(strLineData);
 			}
 		}
@@ -2793,9 +2793,9 @@ LRESULT CDlgSetCustomScript::Set_OK(WPARAM wParam, LPARAM lParam)
 				strEnable = m_List.GetItemText(iSelCount, ENABLE);
 				bEnable = strEnable == _T("Åõ") ? TRUE : FALSE;
 				if (bEnable)
-					strLineData.Format(_T("%s\t%s\n"), strURL, strFileName);
+					strLineData.Format(_T("%s\t%s\n"), (LPCTSTR)strURL, (LPCTSTR)strFileName);
 				else
-					strLineData.Format(_T(";%s\t%s\n"), strURL, strFileName);
+					strLineData.Format(_T(";%s\t%s\n"), (LPCTSTR)strURL, (LPCTSTR)strFileName);
 				out.WriteString(strLineData);
 			}
 		}

--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -78,7 +78,7 @@ LRESULT CMainFrame::OnNewInstance(WPARAM nAtom, LPARAM lParam)
 		if (theApp.m_AppSettings.IsAdvancedLogMode())
 		{
 			CString logmsg;
-			logmsg.Format(_T("MAIN_WND:0x%08x OnNewInstance"), theApp.SafeWnd(this));
+			logmsg.Format(_T("MAIN_WND:0x%08p OnNewInstance"), theApp.SafeWnd(this));
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 		}
 		CString strCommandLine;
@@ -208,7 +208,7 @@ BOOL CMainFrame::CheckRecovery()
 		CString logmsg;
 		if (bTraceLog)
 		{
-			logmsg.Format(_T("MAIN_WND:0x%08x CheckRecovery %s"), theApp.SafeWnd(this), strPathName);
+			logmsg.Format(_T("MAIN_WND:0x%08p CheckRecovery %s"), theApp.SafeWnd(this), (LPCTSTR)strPathName);
 			theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_CL);
 		}
 
@@ -273,7 +273,7 @@ BOOL CMainFrame::CheckRecovery()
 								{
 									if (bTraceLog)
 									{
-										logmsg.Format(_T("MAIN_WND:0x%08x CheckRecovery_FIND %s"), theApp.SafeWnd(this), strChkFile);
+										logmsg.Format(_T("MAIN_WND:0x%08p CheckRecovery_FIND %s"), theApp.SafeWnd(this), (LPCTSTR)strChkFile);
 										theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_CL);
 									}
 
@@ -356,7 +356,7 @@ BOOL CMainFrame::CheckRecovery()
 				if (bTraceLog)
 				{
 					//restore
-					logmsg.Format(_T("MAIN_WND:0x%08x CheckRecovery_RESTORE %s"), theApp.SafeWnd(this), strChkFile);
+					logmsg.Format(_T("MAIN_WND:0x%08p CheckRecovery_RESTORE %s"), theApp.SafeWnd(this), (LPCTSTR)strChkFile);
 					theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_CL);
 				}
 				CString strTemp;
@@ -521,7 +521,7 @@ BOOL CMainFrame::ParseCommandLineAndNewWnd(CString strCommandLine)
 
 	if (bTraceLog)
 	{
-		logmsg.Format(_T("MAIN_WND:0x%08x ParseCommandLineAndNewWnd [%s]"), theApp.SafeWnd(this), strCommandLine);
+		logmsg.Format(_T("MAIN_WND:0x%08p ParseCommandLineAndNewWnd [%s]"), theApp.SafeWnd(this), (LPCTSTR)strCommandLine);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 
@@ -588,7 +588,7 @@ BOOL CMainFrame::ParseCommandLineAndNewWnd(CString strCommandLine)
 	}
 	if (bTraceLog)
 	{
-		logmsg.Format(_T("MAIN_WND:0x%08x ParseCommandLineAndNewWnd CommandParam[%s] OptionParam[%s]"), theApp.SafeWnd(this), CommandParam, OptionParam);
+		logmsg.Format(_T("MAIN_WND:0x%08p ParseCommandLineAndNewWnd CommandParam[%s] OptionParam[%s]"), theApp.SafeWnd(this), (LPCTSTR)CommandParam, (LPCTSTR)OptionParam);
 		theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 
@@ -2717,7 +2717,7 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 
 			CString strWriteTime;
 			CTime time = CTime::GetCurrentTime();
-			strWriteTime.Format(_T("%s\n"), time.Format(_T("%Y-%m-%d %H:%M:%S")));
+			strWriteTime.Format(_T("%s\n"), (LPCTSTR)time.Format(_T("%Y-%m-%d %H:%M:%S")));
 			int iCnt = 0;
 			if (bAppendMode)
 			{
@@ -2754,7 +2754,7 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 						//ì˙éûÇèâÇﬂÇÃçsÇ…èoóÕÇ∑ÇÈÅB
 						out.WriteString(strWriteTime);
 					}
-					strData.Format(_T("%s\t%s\n"), strTitle, strURL);
+					strData.Format(_T("%s\t%s\n"), (LPCTSTR)strTitle, (LPCTSTR)strURL);
 					out.WriteString(strData);
 					iCnt++;
 				}

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -83,20 +83,20 @@ BOOL CSazabi::InitFunc_ExecOnVOS()
 			CString strCommandParam;
 			if (!m_strCommandParam.IsEmpty() && !m_strOptionParam.IsEmpty())
 			{
-				strCommandParam.Format(_T("\"%s\" %s"), m_strCommandParam, m_strOptionParam);
+				strCommandParam.Format(_T("\"%s\" %s"), (LPCTSTR)m_strCommandParam, (LPCTSTR)m_strOptionParam);
 			}
 			else
 			{
 				if (!m_strCommandParam.IsEmpty())
-					strCommandParam.Format(_T("\"%s\""), m_strCommandParam);
+					strCommandParam.Format(_T("\"%s\""), (LPCTSTR)m_strCommandParam);
 				if (!m_strOptionParam.IsEmpty())
-					strCommandParam.Format(_T("%s"), m_strOptionParam);
+					strCommandParam.Format(_T("%s"), (LPCTSTR)m_strOptionParam);
 			}
 			CString strCommandC;
 			if (strCommandParam.IsEmpty())
-				strCommandC.Format(_T("\"%s\""), strChronosVirtAppPath);
+				strCommandC.Format(_T("\"%s\""), (LPCTSTR)strChronosVirtAppPath);
 			else
-				strCommandC.Format(_T("\"%s\" %s"), strChronosVirtAppPath, strCommandParam);
+				strCommandC.Format(_T("\"%s\" %s"), (LPCTSTR)strChronosVirtAppPath, (LPCTSTR)strCommandParam);
 
 			STARTUPINFO siC = {0};
 			PROCESS_INFORMATION piC = {0};
@@ -341,7 +341,7 @@ BOOL CSazabi::InitFunc_SGMode()
 
 	CString strRegKeyBase;
 	strRegKeyBase = _T("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\MyComputer\\NameSpace\\");
-	strRegKey.Format(_T("%s%s"), strRegKeyBase, _T("{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}"));
+	strRegKey.Format(_T("%s%s"), (LPCTSTR)strRegKeyBase, _T("{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}"));
 	SHDeleteKey(HKEY_LOCAL_MACHINE, strRegKey);
 	lResult = RegCreateKeyEx(HKEY_LOCAL_MACHINE, strRegKey,
 				 0, _T(""), REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, &hKey, &dwDisposition);
@@ -362,8 +362,8 @@ BOOL CSazabi::InitFunc_SGMode()
 		CString strCommandC;
 		CString strParam;
 
-		strCommandC.Format(_T("\"%s\" \"%s\""), strSpCAppPath, m_AppSettings.GetRootPath());
-		strParam.Format(_T("\"%s\""), m_AppSettings.GetRootPath());
+		strCommandC.Format(_T("\"%s\" \"%s\""), (LPCTSTR)strSpCAppPath, (LPCTSTR)m_AppSettings.GetRootPath());
+		strParam.Format(_T("\"%s\""), (LPCTSTR)m_AppSettings.GetRootPath());
 		STARTUPINFO siC = {0};
 		PROCESS_INFORMATION piC = {0};
 		siC.cb = sizeof(siC);
@@ -574,9 +574,9 @@ BOOL CSazabi::InitInstance()
 	{
 		if (IsFirstInstance())
 		{
-			logmsg.Format(_T("CommandParam:[%s]"), m_lpCmdLine);
+			logmsg.Format(_T("CommandParam:[%s]"), (LPCTSTR)m_lpCmdLine);
 			WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
-			logmsg.Format(_T("AtomParam:[%s]"), m_strAtomParam);
+			logmsg.Format(_T("AtomParam:[%s]"), (LPCTSTR)m_strAtomParam);
 			WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 		}
 	}
@@ -1154,7 +1154,7 @@ void CSazabi::InitParseCommandLine()
 	//両方セットされている場合
 	if (!m_strCommandParam.IsEmpty() && !m_strOptionParam.IsEmpty())
 	{
-		m_strAtomParam.Format(_T("%s|@@|%s"), m_strCommandParam, m_strOptionParam);
+		m_strAtomParam.Format(_T("%s|@@|%s"), (LPCTSTR)m_strCommandParam, (LPCTSTR)m_strOptionParam);
 	}
 	else
 	{
@@ -1177,7 +1177,7 @@ void CSazabi::ExitKillZombieProcess()
 		CString strCommand;
 		CString strParam;
 		CopyDBLEXEToTempEx();
-		strCommand.Format(_T("\"%s\" -ClosePWait"), m_strDBL_EXE_FullPath);
+		strCommand.Format(_T("\"%s\" -ClosePWait"), (LPCTSTR)m_strDBL_EXE_FullPath);
 		strParam = _T("-ClosePWait");
 		SetLastError(NO_ERROR);
 		if (::ShellExecute(NULL, _T("open"), m_strDBL_EXE_FullPath, strParam, NULL, SW_SHOW) <= HINSTANCE(32))
@@ -1200,14 +1200,14 @@ void CSazabi::OpenChFiler(LPCTSTR lpOpenPath)
 		if (lpOpenPath)
 		{
 			strOpenPath = lpOpenPath;
-			strCommand.Format(_T("\"%sChFiler.exe\""), m_strExeFolderPath);
-			strExecCommand.Format(_T("\"%sChFiler.exe\" \"%s\""), m_strExeFolderPath, strOpenPath);
-			strParam.Format(_T("\"%s\""), strOpenPath);
+			strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
+			strExecCommand.Format(_T("\"%sChFiler.exe\" \"%s\""), (LPCTSTR)m_strExeFolderPath, (LPCTSTR)strOpenPath);
+			strParam.Format(_T("\"%s\""), (LPCTSTR)strOpenPath);
 		}
 		else
 		{
-			strCommand.Format(_T("\"%sChFiler.exe\""), m_strExeFolderPath);
-			strExecCommand.Format(_T("\"%sChFiler.exe\""), m_strExeFolderPath);
+			strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
+			strExecCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
 			strParam = _T("");
 		}
 
@@ -1399,7 +1399,7 @@ void CSazabi::OpenChTaskMgr()
 	}
 	CString strCommand;
 	CString strParam;
-	strCommand.Format(_T("\"%s\" /RESIDENT"), strtSGPathResult);
+	strCommand.Format(_T("\"%s\" /RESIDENT"), (LPCTSTR)strtSGPathResult);
 	strParam = _T("/RESIDENT");
 	STARTUPINFO si = {0};
 	PROCESS_INFORMATION pi = {0};
@@ -1435,9 +1435,9 @@ void CSazabi::InitLogWrite()
 	WriteDebugTraceDateTime(_T("===================================================================================================="), DEBUG_LOG_TYPE_GE);
 	WriteDebugTraceDateTime(_T("InitInstance"), DEBUG_LOG_TYPE_GE);
 	WriteDebugTraceDateTime(m_strThisAppVersionString, DEBUG_LOG_TYPE_GE);
-	logmsg.Format(_T("ThisAppName:%s"), m_strThisAppName);
+	logmsg.Format(_T("ThisAppName:%s"), (LPCTSTR)m_strThisAppName);
 	WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
-	logmsg.Format(_T("ExeName:%s"), m_strExeFileName);
+	logmsg.Format(_T("ExeName:%s"), (LPCTSTR)m_strExeFileName);
 	WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 
 #ifndef _WIN64
@@ -1446,26 +1446,26 @@ void CSazabi::InitLogWrite()
 	WriteDebugTraceDateTime(_T("WIN64 App"), DEBUG_LOG_TYPE_GE);
 #endif //WIN64
 
-	logmsg.Format(_T("OS:%s"), GetOSInfo());
+	logmsg.Format(_T("OS:%s"), (LPCTSTR)GetOSInfo());
 	WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 
-	logmsg.Format(_T("Kernel:%s"), GetOSKernelVersion());
+	logmsg.Format(_T("Kernel:%s"), (LPCTSTR)GetOSKernelVersion());
 	WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 
-	logmsg.Format(_T("%s"), GetCefVersionStr());
+	logmsg.Format(_T("%s"), (LPCTSTR)GetCefVersionStr());
 	WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 
-	logmsg.Format(_T("%s"), GetChromiumVersionStr());
+	logmsg.Format(_T("%s"), (LPCTSTR)GetChromiumVersionStr());
 	WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 
 	if (InVirtualEnvironment() == VE_THINAPP)
 	{
-		logmsg.Format(_T("VOSInfo:%s"), GetVOSInfo());
+		logmsg.Format(_T("VOSInfo:%s"), (LPCTSTR)GetVOSInfo());
 		WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 	else if (InVirtualEnvironment() == VE_TURBO)
 	{
-		logmsg.Format(_T("TurboVMInfo:%s"), GetTurboVMInfo());
+		logmsg.Format(_T("TurboVMInfo:%s"), (LPCTSTR)GetTurboVMInfo());
 		WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 	//設定値を出力
@@ -1871,13 +1871,13 @@ CString CSazabi::GetVOSProcessString(BOOL bCurrent, DWORD* pdwCnt, BOOL bNeedCmd
 						//自身のプロセスも含める
 						if (bCurrent)
 						{
-							strTemp.Format(_T("PID[*]:%s \"%s\" %s\r\n"), strValueName, strValue, strCommandLine);
+							strTemp.Format(_T("PID[*]:%s \"%s\" %s\r\n"), (LPCTSTR)strValueName, (LPCTSTR)strValue, (LPCTSTR)strCommandLine);
 							strRet += strTemp;
 						}
 					}
 					else
 					{
-						strTemp.Format(_T("PID:%s \"%s\" %s\r\n"), strValueName, strValue, strCommandLine);
+						strTemp.Format(_T("PID:%s \"%s\" %s\r\n"), (LPCTSTR)strValueName, (LPCTSTR)strValue, (LPCTSTR)strCommandLine);
 						strRet += strTemp;
 					}
 					dwCount++;
@@ -1912,7 +1912,7 @@ void CSazabi::CloseVOSProcessOther()
 		return;
 	CString strThinFilerPath;
 
-	strThinFilerPath.Format(_T("%sChFiler.exe"), m_strExeFolderPath);
+	strThinFilerPath.Format(_T("%sChFiler.exe"), (LPCTSTR)m_strExeFolderPath);
 
 	DWORD dwValueNameSize = 256;
 	TCHAR szValueName[256] = {0};
@@ -2098,7 +2098,7 @@ BOOL CSazabi::CloseVOSProc()
 		CString confirmMsg;
 		confirmMsg.LoadString(IDS_STRING_CONFIRM_CLOSE_VOS_PROCESS);
 		CString strMsg;
-		strMsg.Format(_T("%s\n%s"), confirmMsg, strString);
+		strMsg.Format(_T("%s\n%s"), (LPCTSTR)confirmMsg, (LPCTSTR)strString);
 		int iRet = AfxMessageBox(strMsg, MB_ICONQUESTION | MB_YESNO);
 		if (iRet != IDYES)
 			return FALSE;
@@ -2388,23 +2388,23 @@ void CSazabi::OpenDefaultBrowser(const CString& strURL, DWORD iType, const CStri
 		CopyDBLEXEToTempEx();
 		if (iType == 1)
 		{
-			strCommand.Format(_T("\"%s\" \"%s\" -IE"), m_strDBL_EXE_FullPath, strURL);
-			strParam.Format(_T("\"%s\" -IE"), strURL);
+			strCommand.Format(_T("\"%s\" \"%s\" -IE"), (LPCTSTR)m_strDBL_EXE_FullPath, (LPCTSTR)strURL);
+			strParam.Format(_T("\"%s\" -IE"), (LPCTSTR)strURL);
 		}
 		else if (iType == 2)
 		{
-			strCommand.Format(_T("\"%s\" \"%s\" -Firefox"), m_strDBL_EXE_FullPath, strURL);
-			strParam.Format(_T("\"%s\" -Firefox"), strURL);
+			strCommand.Format(_T("\"%s\" \"%s\" -Firefox"), (LPCTSTR)m_strDBL_EXE_FullPath, (LPCTSTR)strURL);
+			strParam.Format(_T("\"%s\" -Firefox"), (LPCTSTR)strURL);
 		}
 		else if (iType == 3)
 		{
-			strCommand.Format(_T("\"%s\" \"%s\" -Chrome"), m_strDBL_EXE_FullPath, strURL);
-			strParam.Format(_T("\"%s\" -Chrome"), strURL);
+			strCommand.Format(_T("\"%s\" \"%s\" -Chrome"), (LPCTSTR)m_strDBL_EXE_FullPath, (LPCTSTR)strURL);
+			strParam.Format(_T("\"%s\" -Chrome"), (LPCTSTR)strURL);
 		}
 		else if (iType == 4)
 		{
-			strCommand.Format(_T("\"%s\" \"%s\" -Edge"), m_strDBL_EXE_FullPath, strURL);
-			strParam.Format(_T("\"%s\" -Edge"), strURL);
+			strCommand.Format(_T("\"%s\" \"%s\" -Edge"), (LPCTSTR)m_strDBL_EXE_FullPath, (LPCTSTR)strURL);
+			strParam.Format(_T("\"%s\" -Edge"), (LPCTSTR)strURL);
 		}
 		else if (iType == 5)
 		{
@@ -2491,8 +2491,8 @@ void CSazabi::OpenDefaultBrowser(const CString& strURL, DWORD iType, const CStri
 				return;
 			}
 
-			strCommand.Format(_T("\"%s\" -Custom /Path:\"%s\" \"%s\""), m_strDBL_EXE_FullPath, strPath, strURL);
-			strParam.Format(_T("-Custom /Path:\"%s\" \"%s\""), strPath, strURL);
+			strCommand.Format(_T("\"%s\" -Custom /Path:\"%s\" \"%s\""), (LPCTSTR)m_strDBL_EXE_FullPath, (LPCTSTR)strPath, (LPCTSTR)strURL);
+			strParam.Format(_T("-Custom /Path:\"%s\" \"%s\""), (LPCTSTR)strPath, (LPCTSTR)strURL);
 
 			TCHAR FrmWndClassName[256] = {0};
 			CString strFrmWndClass = strPath;
@@ -2527,8 +2527,8 @@ void CSazabi::OpenDefaultBrowser(const CString& strURL, DWORD iType, const CStri
 		}
 		else
 		{
-			strCommand.Format(_T("\"%s\" \"%s\""), m_strDBL_EXE_FullPath, strURL);
-			strParam.Format(_T("\"%s\""), strURL);
+			strCommand.Format(_T("\"%s\" \"%s\""), (LPCTSTR)m_strDBL_EXE_FullPath, (LPCTSTR)strURL);
+			strParam.Format(_T("\"%s\""), (LPCTSTR)strURL);
 		}
 		DebugWndLogData dwLogData;
 		dwLogData.mHWND.Format(_T("APP_WND:0x%08x"), 0);
@@ -2588,12 +2588,12 @@ void CSazabi::ExecNewInstance(const CString strURL)
 
 	if (!strURL.IsEmpty())
 	{
-		strCommand.Format(_T("\"%s\" \"%s\" -NEW"), m_strExeFullPath, strURL);
-		strParam.Format(_T("\"%s\" -NEW"), strURL);
+		strCommand.Format(_T("\"%s\" \"%s\" -NEW"), (LPCTSTR)m_strExeFullPath, (LPCTSTR)strURL);
+		strParam.Format(_T("\"%s\" -NEW"), (LPCTSTR)strURL);
 	}
 	else
 	{
-		strCommand.Format(_T("\"%s\" -NEW"), m_strExeFullPath);
+		strCommand.Format(_T("\"%s\" -NEW"), (LPCTSTR)m_strExeFullPath);
 		strParam = _T("-NEW");
 	}
 	STARTUPINFO si = {0};
@@ -2632,8 +2632,8 @@ void CSazabi::OpenFileExplorer(const CString& strURL)
 	CString strCommand;
 	CString strParam;
 	CopyDBLEXEToTempEx();
-	strCommand.Format(_T("\"%s\" \"%s\""), m_strDBL_EXE_FullPath, strURL);
-	strParam.Format(_T("\"%s\""), strURL);
+	strCommand.Format(_T("\"%s\" \"%s\""), (LPCTSTR)m_strDBL_EXE_FullPath, (LPCTSTR)strURL);
+	strParam.Format(_T("\"%s\""), (LPCTSTR)strURL);
 	STARTUPINFO si = {0};
 	PROCESS_INFORMATION pi = {0};
 	si.cb = sizeof(si);
@@ -2740,7 +2740,7 @@ void CSazabi::SetRecoveryFilePath()
 	strPrx.Replace(_T(".exe"), _T(""));
 
 	m_strRestoreFileFullPath.Format(_T("%s\\CSG_SaveWnd_%s.dat"),
-					m_strDBL_EXE_FolderPath, strPrx);
+					(LPCTSTR)m_strDBL_EXE_FolderPath, (LPCTSTR)strPrx);
 }
 
 BOOL CSazabi::DeleteDirectory(LPCTSTR lpPathName, LPCTSTR lpPat)
@@ -3548,7 +3548,7 @@ CString CSazabi::GetCefVersionStr()
 				if (VerQueryValue(pData, name, &pvVersion, &VersionLen))
 				{
 					CString strVersionStr((LPCTSTR)pvVersion);
-					strRet.Format(_T("Chromium Embedded Framework Version %s"), strVersionStr);
+					strRet.Format(_T("Chromium Embedded Framework Version %s"), (LPCTSTR)strVersionStr);
 					break;
 				}
 			}
@@ -3597,7 +3597,7 @@ CString CSazabi::GetChromiumVersionStr()
 				if (VerQueryValue(pData, name, &pvVersion, &VersionLen))
 				{
 					CString strVersionStr((LPCTSTR)pvVersion);
-					strRet.Format(_T("Chromium(Blink) Version %s"), strVersionStr);
+					strRet.Format(_T("Chromium(Blink) Version %s"), (LPCTSTR)strVersionStr);
 					break;
 				}
 			}
@@ -3799,21 +3799,24 @@ CString CSazabi::GetVOSInfo()
 						szHH = strDateTimeTmp.Mid(4 + 2 + 2 + 1, 2);
 						sz24M = strDateTimeTmp.Mid(4 + 2 + 2 + 1 + 2, 2);
 						szSS = strDateTimeTmp.Mid(4 + 2 + 2 + 1 + 2 + 2, 2);
-						strDateTime.Format(_T("%s-%s-%s %s:%s:%s"), szYYYY, szMM, szDD, szHH, sz24M, szSS);
+						strDateTime.Format(_T("%s-%s-%s %s:%s:%s"), 
+							(LPCTSTR)szYYYY, (LPCTSTR)szMM, 
+							(LPCTSTR)szDD, (LPCTSTR)szHH, 
+							(LPCTSTR)sz24M, (LPCTSTR)szSS);
 					}
 				}
 			}
 		}
 		strRet.Format(_T("%s\r\n%s %s"),
-			      GetVOSVersionFromNT0_DLLStr(),
-			      _T("TS_ORIGIN"), szTargetPath);
+			      (LPCTSTR)GetVOSVersionFromNT0_DLLStr(),
+			      _T("TS_ORIGIN"), (LPCTSTR)szTargetPath);
 		CString strTmp;
 		if (!szThinAppVersion.IsEmpty())
 		{
 			strTmp.Format(_T("\r\n%s %s\r\n%s %s\r\n%s %s"),
-				      _T("ThinAppVersion"), szThinAppVersion,
-				      _T("ThinAppLicense"), szThinAppLicense,
-				      _T("ThinAppBuildDateTime"), strDateTime);
+				      _T("ThinAppVersion"), (LPCTSTR)szThinAppVersion,
+				      _T("ThinAppLicense"), (LPCTSTR)szThinAppLicense,
+				      _T("ThinAppBuildDateTime"), (LPCTSTR)strDateTime);
 			strRet += strTmp;
 		}
 		break;
@@ -3841,11 +3844,11 @@ CString CSazabi::GetOSInfo(void)
 
 	if (SBUtil::Is64BitWindows())
 	{
-		strBuff.Format(_T("%s x64"), strOS);
+		strBuff.Format(_T("%s x64"), (LPCTSTR)strOS);
 	}
 	else
 	{
-		strBuff.Format(_T("%s x86"), strOS);
+		strBuff.Format(_T("%s x86"), (LPCTSTR)strOS);
 	}
 
 	if ((ovi.wSuiteMask & VER_SUITE_TERMINAL) == VER_SUITE_TERMINAL)
@@ -3888,7 +3891,7 @@ CString CSazabi::GetAllModules()
 				if (GetModuleFileNameEx(hProcess, hMods[i], szModName,
 							sizeof(szModName) / sizeof(TCHAR)))
 				{
-					strTemp.Format(_T("%s (0x%08x)\n"), szModName, hMods[i]);
+					strTemp.Format(_T("%s (0x%08p)\n"), (LPCTSTR)szModName, hMods[i]);
 					strRet += strTemp;
 				}
 			}
@@ -4710,10 +4713,10 @@ void CAboutDlg::SetDetailString(BOOL bEnableDetail)
 	strEditValue = theApp.m_strThisAppName + _T("\r\n");
 
 	CString verstr;
-	verstr.Format(_T("Version %s  "), theApp.m_strThisAppVersionString);
+	verstr.Format(_T("Version %s  "), (LPCTSTR)theApp.m_strThisAppVersionString);
 
 	CString strTitle;
-	strTitle.Format(_T("%s %s"), theApp.m_strThisAppName, verstr);
+	strTitle.Format(_T("%s %s"), (LPCTSTR)theApp.m_strThisAppName, (LPCTSTR)verstr);
 	this->SetWindowText(strTitle);
 	strEditValue += verstr;
 
@@ -4780,7 +4783,7 @@ void CAboutDlg::SetDetailString(BOOL bEnableDetail)
 	GetProcessTimes(hProcess, &ftMakeTime, &ftExitTime, &ftKernTime, &ftUserTime);
 	CString strTimeFmt;
 	getTimeString(&ftMakeTime, TRUE, strTimeFmt);
-	verstr.Format(_T("ProcessStart:%s\r\n"), strTimeFmt);
+	verstr.Format(_T("ProcessStart:%s\r\n"), (LPCTSTR)strTimeFmt);
 	strEditValue += verstr;
 
 	int iMinute = theApp.GetProcessRunningTime();
@@ -4848,7 +4851,7 @@ void CAboutDlg::SetDetailString(BOOL bEnableDetail)
 		RenPID = ptrAPID.GetAt(ii);
 		iMemRen = theApp.GetMemoryUsageSizeFromPID(RenPID);
 		::StrFormatByteSize(iMemRen, memorysize, 24);
-		strPIDTitleTemp.Format(_T("[PID:%d] [%s] [%s]\r\n"), RenPID, memorysize, strATitle.GetAt(ii));
+		strPIDTitleTemp.Format(_T("[PID:%d] [%s] [%s]\r\n"), RenPID, memorysize, (LPCTSTR)strATitle.GetAt(ii));
 		strPIDTitle += strPIDTitleTemp;
 	}
 	if (!strPIDTitle.IsEmpty())

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1232,7 +1232,7 @@ void ClientHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
 
 									//ç≈èâÇæÇØ
 									if (i == 0)
-										strJSsrc.Format(_T("const ChronosExtParentWnd=\"%d\";\r\ntry{ChronosExt_AppActive(ChronosExtParentWnd);console.log('##CSG_Script:ChronosExtParentWnd:'+ChronosExtParentWnd);}catch(e){}\r\n"), (long)hWindow);
+										strJSsrc.Format(_T("const ChronosExtParentWnd=\"%ld\";\r\ntry{ChronosExt_AppActive(ChronosExtParentWnd);console.log('##CSG_Script:ChronosExtParentWnd:'+ChronosExtParentWnd);}catch(e){}\r\n"), (long)hWindow);
 
 									strJSsrc += cScriptSrc.m_strSrc;
 									CefString strCefJsStr(strJSsrc);

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -699,7 +699,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 		if (SafeWnd(hWindow))
 		{
 			DebugWndLogData dwLogData;
-			dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), hWindow);
+			dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 			dwLogData.mFUNCTION_NAME = _T("ConsoleMessage");
 			dwLogData.mMESSAGE1 = message.c_str();
 			dwLogData.mMESSAGE2 = strLogLevel;
@@ -1058,7 +1058,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	if (SafeWnd(hWindow))
 	{
 		DebugWndLogData dwLogData;
-		dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), hWindow);
+		dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 		dwLogData.mFUNCTION_NAME = _T("OnBeforeResourceLoad");
 		dwLogData.mMESSAGE1 = strTranURL;
 		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().c_str());
@@ -1140,7 +1140,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 
 		CString strURLChk; //QueryÇèúÇ≠ÅBñ≥ë Ç»èÓïÒÇè»Ç≠ÅB
 		//strURLChk.Format(_T("%s://%s%s"), strScheme, strHost, strPath);
-		strURLChk.Format(_T("%s://%s"), strScheme, strHost);
+		strURLChk.Format(_T("%s://%s"), (LPCTSTR)strScheme, (LPCTSTR)strHost);
 
 		if (theApp.IsURLFilterAllow(strURLChk, strScheme, strHost, strPath))
 		{
@@ -1216,23 +1216,23 @@ void ClientHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
 									HWND hWindowFrm = GetParent(hWindow);
 									if (SafeWnd(hWindowFrm))
 									{
-										dwLogData.mHWND.Format(_T("BF_WND:0x%08x"), hWindowFrm);
+										dwLogData.mHWND.Format(_T("BF_WND:0x%08p"), hWindowFrm);
 										hWindow = hWindowFrm;
 									}
 									else
 									{
-										dwLogData.mHWND.Format(_T("CV_WND:0x%08x"), hWindow);
+										dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 									}
 									dwLogData.mFUNCTION_NAME = _T("ExcuteCustomJS");
 									dwLogData.mMESSAGE1 = strURL;
-									dwLogData.mMESSAGE2.Format(_T("FileName:%s"), strRetFileName);
+									dwLogData.mMESSAGE2.Format(_T("FileName:%s"), (LPCTSTR)strRetFileName);
 									theApp.AppendDebugViewLog(dwLogData);
 									logmsg = dwLogData.GetString();
 									theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_URL);
 
 									//ç≈èâÇæÇØ
 									if (i == 0)
-										strJSsrc.Format(_T("const ChronosExtParentWnd=\"%d\";\r\ntry{ChronosExt_AppActive(ChronosExtParentWnd);console.log('##CSG_Script:ChronosExtParentWnd:'+ChronosExtParentWnd);}catch(e){}\r\n"), hWindow);
+										strJSsrc.Format(_T("const ChronosExtParentWnd=\"%d\";\r\ntry{ChronosExt_AppActive(ChronosExtParentWnd);console.log('##CSG_Script:ChronosExtParentWnd:'+ChronosExtParentWnd);}catch(e){}\r\n"), (long)hWindow);
 
 									strJSsrc += cScriptSrc.m_strSrc;
 									CefString strCefJsStr(strJSsrc);
@@ -1993,7 +1993,7 @@ bool MyV8Handler::Execute(const CefString& name,
 				strPW.Replace(_T("\""), _T("\\\""));
 				strPW.Replace(_T("/"), _T("\\/"));
 
-				strFmt.Format(_T("{\"username\": \"%s\",\"password\": \"%s\"}"), strID, strPW);
+				strFmt.Format(_T("{\"username\": \"%s\",\"password\": \"%s\"}"), (LPCTSTR)strID, (LPCTSTR)strPW);
 				retval = CefV8Value::CreateString(strFmt.GetString());
 				if (pWnd)
 				{
@@ -2064,7 +2064,7 @@ bool MyV8Handler::Execute(const CefString& name,
 				//strPW_New2.Replace(_T("\""), _T("\\\""));
 				//strPW_New2.Replace(_T("/"), _T("\\/"));
 
-				strFmt.Format(_T("{\"username\": \"%s\",\"current_password\": \"%s\",\"new_password\": \"%s\"}"), strID, strPW_Current, strPW_New);
+				strFmt.Format(_T("{\"username\": \"%s\",\"current_password\": \"%s\",\"new_password\": \"%s\"}"), (LPCTSTR)strID, (LPCTSTR)strPW_Current, (LPCTSTR)strPW_New);
 				retval = CefV8Value::CreateString(strFmt.GetString());
 				if (pWnd)
 				{

--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -152,7 +152,7 @@ STDMETHODIMP CActiveScriptSite::OnScriptError(IActiveScriptError* pscripterror)
 		dwLogData.mHWND.Format(_T("APP_WND:0x%08x"), 0);
 		dwLogData.mFUNCTION_NAME = _T("CSG_Script");
 		dwLogData.mMESSAGE1 = desc;
-		dwLogData.mMESSAGE2.Format(_T("Src:%s"), src);
+		dwLogData.mMESSAGE2.Format(_T("Src:%s"), (LPCTSTR)src);
 		dwLogData.mMESSAGE3.Format(_T("Line:%d"), ulLine);
 		dwLogData.mMESSAGE4.Format(_T("Error:%d"), (int)ei.wCode);
 		dwLogData.mMESSAGE5.Format(_T("Scode:%x"), ei.scode);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

CString.Formatについて、 #43 で未解決のものがまだあったので対応。

* ファイルハンドルの出力に`%x`を使用している箇所があったので、`%p`に変更
* `_T(...)` に対しては `LPCTSTR` にキャストするように変更
  * ここで、Chronosの既存のスタイルに合わせて `static_cast<...>` は使っていない。
  * `static_cast<...>` にしたい場合、あとで一括置換なり何かをする方が良さそうである。


# How to verify the fixed issue:

## The steps to verify:

* ビルド / 分析をする

## Expected result:

* 正常にビルドでき、C6011などのCString.Formatに関する警告が出ないこと。
