### PR TITLE
Use heap for large string

### DIFF
--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -588,11 +588,12 @@ int CLogDispatcher::SendLogThread(int iLogType, LPCTSTR lpFileName, LPCTSTR lpTa
 		URL_COMPONENTS urlcomponents = {0};
 		ZeroMemory(&urlcomponents, sizeof(URL_COMPONENTS));
 		urlcomponents.dwStructSize = sizeof(URL_COMPONENTS);
-		TCHAR szHostName[URLBUFFER_SIZE] = {0};
-		TCHAR szUrlPath[URLBUFFER_SIZE] = {0};
 
-		urlcomponents.lpszHostName = szHostName;
-		urlcomponents.lpszUrlPath = szUrlPath;
+		std::unique_ptr<TCHAR> szHostName(new TCHAR[URLBUFFER_SIZE]());
+		std::unique_ptr<TCHAR> szUrlPath(new TCHAR[URLBUFFER_SIZE]());
+
+		urlcomponents.lpszHostName = szHostName.get();
+		urlcomponents.lpszUrlPath = szUrlPath.get();
 		urlcomponents.dwHostNameLength = URLBUFFER_SIZE;
 		urlcomponents.dwUrlPathLength = URLBUFFER_SIZE;
 

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -791,17 +791,20 @@ namespace SBUtil
 	static CString GetCommandLineData(DWORD dwPID)
 	{
 		CString strRet;
-		WCHAR szCommandLine[8192] = {0};
+
 		if (dwPID == 0) return strRet;
 		try
 		{
 			HANDLE processHandle = {0};
+			std::unique_ptr<WCHAR> szCommandLine(new WCHAR[8192]());
+
 			processHandle = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, dwPID);
 			if (processHandle)
 			{
-				GetRemoteCommandLineW(processHandle, szCommandLine, 8192);
+				LPWSTR rawSzCommandLine = szCommandLine.get();
+				GetRemoteCommandLineW(processHandle, rawSzCommandLine, 8192);
 				CloseHandle(processHandle);
-				CStringW strW(szCommandLine);
+				CStringW strW(rawSzCommandLine);
 				strW.TrimLeft();
 				strW.TrimRight();
 				if (!strW.IsEmpty())
@@ -3314,21 +3317,21 @@ public:
 				ZeroMemory(&urlcomponents, sizeof(URL_COMPONENTS));
 				urlcomponents.dwStructSize = sizeof(URL_COMPONENTS);
 
-				TCHAR szSchme[64] = {0};
-				TCHAR szHostName[URLBUFFER_SIZE] = {0};
-				TCHAR szUrlPath[URLBUFFER_SIZE] = {0};
-				TCHAR szUrlExtra[URLBUFFER_SIZE] = {0};
+				std::unique_ptr<TCHAR> szSchme(new TCHAR[64]());
+				std::unique_ptr<TCHAR> szHostName(new TCHAR[URLBUFFER_SIZE]());
+				std::unique_ptr<TCHAR> szUrlPath(new TCHAR[URLBUFFER_SIZE]());
+				std::unique_ptr<TCHAR> szUrlExtra(new TCHAR[URLBUFFER_SIZE]());
 
-				urlcomponents.lpszScheme = szSchme;
+				urlcomponents.lpszScheme = szSchme.get();
 				urlcomponents.dwSchemeLength = 64;
 
-				urlcomponents.lpszHostName = szHostName;
+				urlcomponents.lpszHostName = szHostName.get();
 				urlcomponents.dwHostNameLength = URLBUFFER_SIZE;
 
-				urlcomponents.lpszUrlPath = szUrlPath;
+				urlcomponents.lpszUrlPath = szUrlPath.get();
 				urlcomponents.dwUrlPathLength = URLBUFFER_SIZE;
 
-				urlcomponents.lpszExtraInfo = szUrlExtra;
+				urlcomponents.lpszExtraInfo = szUrlExtra.get();
 				urlcomponents.dwExtraInfoLength = URLBUFFER_SIZE;
 
 				InternetCrackUrl(strURL, 0, 0, &urlcomponents);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下のようなC6262の警告を解消。

```
重大度レベル	コード	説明	プロジェクト	ファイル	行	抑制状態
警告	C6262	関数はスタックの '16400' バイトを使用します: /analyze:stacksize '16384' を超えています。 データの一部をヒープに移動することを考慮してください。	Sazabi	C:\gitdir\Chronos2\sbcommon.h	791	
```

大きな文字列を格納するための配列により上記の警告が出ていたので、配列をスタック領域ではなくヒープ領域に確保するように変更。

# How to verify the fixed issue:

## The steps to verify:

* ビルド/分析を実行
* 何でもよいのでリダイレクトスクリプトを作成し、何かのページを表示
  * ExecScriptの動作確認
* ログ出力設定の監査ログ設定->ログサーバーURL に適当なURLを入力し（ http://localhost ）、何かのページを表示
  * SendLogThreadの動作確認
* ※GetCommandLineDataは現在どこからも参照されていなかったので動作確認できていない。使われていないのならこの関数自体消しても良いかも。

## Expected result:

* ビルド、分析の結果でC6262の警告が出ないこと
* リダイレクトスクリプトが問題なく実行できること（クラッシュしなければ良い）、メモリリークしていないこと
  * デバッガーで確認した
* ログサーバーURLに対するログ出力ができること（クラッシュしなければ良い）、メモリリークしないこと
  * デバッガーで確認した
