### PR TITLE
Use unique_ptr and new instead of _alloca

### DIFF
--- a/fav.h
+++ b/fav.h
@@ -143,12 +143,17 @@ public:
 		if (lRet != ERROR_SUCCESS || dwSize < s_unknownOffset)
 			return;
 
-		BYTE* pByte = (BYTE*)_alloca((dwSize + 10) * sizeof(BYTE));
+		BYTE* pByte = (BYTE*)_malloca((dwSize + 10) * sizeof(BYTE));
+		if (!pByte)
+			return;
 		::memset(pByte, 0, dwSize + 10);
 
 		lRet = ::RegQueryValueEx(rkOrder, _T("Order"), NULL, &dwType, pByte, &dwSize);
 		if (lRet != ERROR_SUCCESS)
+		{
+			_freea(pByte);
 			return;
+		}
 
 		BYTE* pBegin = pByte + ((_CFavoritesOrderData*)pByte)->size + s_unknownOffset;
 		BYTE* pEnd = pByte + dwSize;
@@ -165,6 +170,7 @@ public:
 
 			pBegin += pData->size;
 		}
+		_freea(pByte);
 	}
 };
 class CFavoriteItem

--- a/fav.h
+++ b/fav.h
@@ -150,9 +150,7 @@ public:
 
 		lRet = ::RegQueryValueEx(rkOrder, _T("Order"), NULL, &dwType, pByte, &dwSize);
 		if (lRet != ERROR_SUCCESS)
-		{
 			return;
-		}
 
 		BYTE* pBegin = pByte + ((_CFavoritesOrderData*)pByte)->size + s_unknownOffset;
 		BYTE* pEnd = pByte + dwSize;

--- a/fav.h
+++ b/fav.h
@@ -143,15 +143,14 @@ public:
 		if (lRet != ERROR_SUCCESS || dwSize < s_unknownOffset)
 			return;
 
-		BYTE* pByte = (BYTE*)_malloca((dwSize + 10) * sizeof(BYTE));
+		std::unique_ptr<BYTE> upByte(new BYTE[dwSize + 10]());
+		BYTE* pByte = upByte.get();
 		if (!pByte)
 			return;
-		::memset(pByte, 0, dwSize + 10);
 
 		lRet = ::RegQueryValueEx(rkOrder, _T("Order"), NULL, &dwType, pByte, &dwSize);
 		if (lRet != ERROR_SUCCESS)
 		{
-			_freea(pByte);
 			return;
 		}
 
@@ -170,7 +169,6 @@ public:
 
 			pBegin += pData->size;
 		}
-		_freea(pByte);
 	}
 };
 class CFavoriteItem


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下のようなC6255の警告を解消。

```
重大度レベル	コード	説明	プロジェクト	ファイル	行	抑制状態
警告	C6255	_alloca は、スタック オーバーフロー例外を発生させて失敗を示します。_malloca を使用してください。	Sazabi	C:\gitdir\Chronos2\fav.h	146	
```

# How to verify the fixed issue:

## The steps to verify:

* ビルド/分析を実行
* メニューからお気に入りを表示

## Expected result:

* ビルド、分析の結果でC6255の警告が出ないこと
* お気に入り一覧が表示されること
* メモリリークしていないこと
  * デバッガーで確認
