### PR TITLE
Specify appropriate size

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1486,7 +1486,7 @@ void CSazabi::SetThisAppVersionString()
 {
 	TCHAR path[MAX_PATH] = {0};
 	DWORD handle = 0;
-	::GetModuleFileName(AfxGetInstanceHandle(), path, sizeof(path));
+	::GetModuleFileName(AfxGetInstanceHandle(), path, MAX_PATH);
 	DWORD size = ::GetFileVersionInfoSize(path, &handle);
 	CByteArray buf;
 	buf.SetSize(size);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42 

# What this PR does / why we need it:

以下の警告に対処。

```
重大度レベル	コード	説明	プロジェクト	ファイル	行	抑制状態
警告	C6386	'path' への書き込み中にバッファー オーバーランが発生しました: 書き込み可能なサイズは '520' バイトですが、'1040' バイトを書き込む可能性があります。	Sazabi	C:\gitdir\Chronos2\Sazabi.cpp	1489	
```


# How to verify the fixed issue:

## The steps to verify:

* ビルド / 分析を実行する
* Chronosを起動する

## Expected result:

* 警告が出ないこと
* SetThisAppVersionStringを通り、エラーにならないことを確認
  * 境界値の確認まではしていない。