### PR TITLE
Update CEF version to 112.2.9+g3303e87+chromium-112.0.5615.87

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=112.2.7+gef29713+chromium-112.0.5615.49
+VERSION=112.2.9+g3303e87+chromium-112.0.5615.87
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_112.2.7+gef29713+chromium-112.0.5615.49_windows32_minimal
+  set CEFVER=cef_binary_112.2.9+g3303e87+chromium-112.0.5615.87_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Because the current stable CEF version is 112.2.9+g3303e87+chromium-112.0.5615.87

https://cef-builds.spotifycdn.com/index.html

# How to verify the fixed issue:

## The steps to verify:
## Expected result:

* Succeed to build
