### PR TITLE
Update to stable version of CEF 112

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=112.2.10+gd000e45+chromium-112.0.5615.121
+VERSION=112.3.0+gb09c4ca+chromium-112.0.5615.165
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_112.2.10+gd000e45+chromium-112.0.5615.121_windows32_minimal
+  set CEFVER=cef_binary_112.3.0+gb09c4ca+chromium-112.0.5615.165_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

It fixes:

* High CVE-2023-2133: Out of bounds memory access in Service Worker API. Reported by Rong Jian of VRI on
* High CVE-2023-2134: Out of bounds memory access in Service Worker API. Reported by Rong Jian of VRI on
* High CVE-2023-2135: Use after free in DevTools. Reported by Cassidy Kim(@cassidy6564) on
* High CVE-2023-2136: Integer overflow in Skia. Reported by Clément Lecigne of Google's Threat Analysis Group on
* Medium CVE-2023-2137: Heap buffer overflow in sqlite. Reported by Nan Wang(@eternalsakura13) and Guang Gong of 360 Vulnerability Research Institute on 2023-04-05

See
https://chromereleases.googleblog.com/2023/04/stable-channel-update-for-desktop_18.html

# How to verify the fixed issue:

Launch Chronos and check version information

## Expected result:

```
Chromium Embedded Framework Version 112.3.0+gb09c4ca+chromium-112.0.5615.165
Chromium(Blink) Version 112.0.5615.165
```