### PR TITLE
Fix the CopyDBLEXEToTempEx comment

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -2730,7 +2730,7 @@ static void LogErrNo(LPCWSTR prefix, int errNum)
 // * Windows 22H2
 //   * Windows 11 21H2以前では発生していない
 // * CopyFile()を使用する
-// * ThinApp上でDirectoryIsolationMode=Mergedのフォルダに書き出す
+// * ThinAppで仮想化されているファイルをコピーする
 void CSazabi::CopyDBLEXEToTempEx()
 {
 	//ネイティブ版は、DBLCは不要


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/68

# What this PR does / why we need it:

ThinApp上でCopyFileを実行した際にファイルが破損する条件が分かったので、それに合わせてコメントを修正。

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

## Expected result:

コメントの変更のみ。ビルドできればOK。

