### PR TITLE
Bump version number to 13.0.112.0

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -576,8 +576,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 12,111,112,0
- PRODUCTVERSION 12,111,112,0
+ FILEVERSION 13,0,112,0
+ PRODUCTVERSION 13,0,112,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -593,12 +593,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "12.111.112.0"
+            VALUE "FileVersion", "13.0.112.0"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "12.111.112.0"
+            VALUE "ProductVersion", "13.0.112.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -1893,8 +1893,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 12,111,112,0
- PRODUCTVERSION 12,111,112,0
+ FILEVERSION 13,0,112,0
+ PRODUCTVERSION 13,0,112,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -1910,12 +1910,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "12.111.98.3"
+            VALUE "FileVersion", "13.0.112.0"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "12.111.98.3"
+            VALUE "ProductVersion", "13.0.112.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
> Describe issue number. If issue doesn't exist, fill N/A.

# What this PR does / why we need it:

It's the first major release after maintainer is changed, so we bump up the major version to clarify it.

# Which issue(s) this PR fixes:

N/A

# How to verify the fixed issue:

Check the version number

## The steps to verify:

1. Check the version of ChronosN.exe on Japanese environment
1. Check the version of ChronosN.exe on English environment

## Expected result:

`13.0.112.0`
