### PR TITLE
Cast size_t to unsigned long long

### DIFF
--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -870,7 +870,7 @@ void CMainFrame::OnTimer(UINT_PTR nIDEvent)
 		size_t iMemL = theApp.m_AppSettings.GetMemoryUsageLimit();
 		CString logmsg;
 
-		if (iMemSize > iMemL * 1024 * 1024)
+		if (iMemSize > (unsigned long long)iMemL * 1024 * 1024)
 		{
 			//一旦ワーキングセットをクリアして開放してしまう。
 			theApp.EmptyWorkingSetAll();


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告の解決

```
警告	C26451	演算のオーバーフロー: 4 バイトの値に演算子 '*' を使用し、結果を 8 バイトの値にキャストしています。オーバーフローを避けるため、演算子 '*' を呼び出す前に値を幅の広い型にキャストしてください (io.2)。	Sazabi	C:\gitdir\Chronos\MainFrm.cpp	873	
```


# How to verify the fixed issue:

## The steps to verify:

## Expected result:

* ビルド/分析を実行し、上記の警告が出ないこと。