### PR TITLE
Suppress warning C6388

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1491,7 +1491,7 @@ void CSazabi::SetThisAppVersionString()
 	DWORD size = ::GetFileVersionInfoSize(path, &handle);
 	CByteArray buf;
 	buf.SetSize(size);
-	::GetFileVersionInfo(path, handle, (DWORD)buf.GetSize(), buf.GetData());
+	::GetFileVersionInfo(path, 0, (DWORD)buf.GetSize(), buf.GetData());
 	LPVOID item = {0};
 	UINT itemsize = 0;
 	::VerQueryValue(buf.GetData(), _T("\\VarFileInfo\\Translation"), &item, &itemsize);
@@ -3823,7 +3823,7 @@ CString CSazabi::GetVOSInfo()
 		if (pBlock == NULL)
 			break;
 		memset(pBlock, 0x00, dwVerInfoSize * sizeof(UCHAR));
-		GetFileVersionInfo(szTargetPath, dwZero, dwVerInfoSize, pBlock);
+		GetFileVersionInfo(szTargetPath, 0, dwVerInfoSize, pBlock);
 
 		VerQueryValue(pBlock, _T("\\VarFileInfo\\Translation"),
 			      (LPVOID*)&lpTranslate, &TranslateLen);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告を解消。

```
警告	C6388	'handle' は '0' でない可能性があります: この動作は、関数 'GetFileVersionInfoW' の指定に従っていません。	Sazabi	C:\gitdir\Chronos\Sazabi.cpp	1494	
警告	C6388	'dwZero' は '0' でない可能性があります: この動作は、関数 'GetFileVersionInfoW' の指定に従っていません。	Sazabi	C:\gitdir\Chronos\Sazabi.cpp	3826	
```

https://learn.microsoft.com/en-us/windows/win32/api/winver/nf-winver-getfileversioninfow

`GetFileVersionInfoW`の第二引数は無視されるので、0を指定するように変更。
Chronosの他の個所でも（NULLではなく）0を指定しているので、それに合わせている。

ちなみに、C6388の警告が出ているのは、以下のように実装上は第二引数が`_Reserved_`になっていて、`_Reserved_`は0/NULLを指定する必要があるため。（`_Reserved_`なら0/NULLを指定しないといけないという情報の一次情報が見つけられない...）


```
/* Read version info into buffer */
BOOL
APIENTRY
GetFileVersionInfoW(
        _In_                LPCWSTR lptstrFilename, /* Filename of version stamped file */
        _Reserved_          DWORD dwHandle,          /* Information from GetFileVersionSize */
        _In_                DWORD dwLen,             /* Length of buffer for info */
        _Out_writes_bytes_(dwLen) LPVOID lpData            /* Buffer to place the data structure */
        );
```



# How to verify the fixed issue:

## The steps to verify:
## Expected result:

* ビルド/分析を実施して、C6388の警告が出ないこと
* ヘルプ画面からバージョンを確認し、Chronoのバージョン、ThinAppのバージョンが正しく取得できていること
  * ThinApp化して確認すること