### PR TITLE
Suppress warning of nullable variables

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -2776,7 +2776,7 @@ void CBrowserFrame::OnCloseDelay()
 			{
 				hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, theApp.m_strEventLogName);
 				if (!hEvent)
-					throw std::runtime_error("Failed to execute OpenEvent");
+					throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 				DWORD waitRes = WaitForSingleObject(hEvent, 100);
 				if (waitRes == WAIT_TIMEOUT)

--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -2775,6 +2775,9 @@ void CBrowserFrame::OnCloseDelay()
 			if (!m_wndView.IsPopupWindow())
 			{
 				hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, theApp.m_strEventLogName);
+				if (!hEvent)
+					throw std::runtime_error("Failed to execute OpenEvent");
+
 				DWORD waitRes = WaitForSingleObject(hEvent, 100);
 				if (waitRes == WAIT_TIMEOUT)
 				{

--- a/CTabWnd.cpp
+++ b/CTabWnd.cpp
@@ -199,8 +199,11 @@ LRESULT CTabWnd::OnTabLButtonUp(WPARAM wParam, LPARAM lParam)
 				tcitem.mask = TCIF_PARAM;
 				tcitem.lParam = 0;
 				TabCtrl_GetItem(m_hwndTab, nDstTab, &tcitem);
-				ShowTabWindow((HWND)tcitem.lParam);
-				SendMessage((HWND)tcitem.lParam, WM_SETREDRAW, true, 0);
+				if (tcitem.lParam)
+				{
+					ShowTabWindow((HWND)tcitem.lParam);
+					SendMessage((HWND)tcitem.lParam, WM_SETREDRAW, true, 0);
+				}
 				BreakDrag();
 				return 1;
 			}
@@ -385,12 +388,15 @@ LRESULT CTabWnd::OnTabRButtonUp(WPARAM wParam, LPARAM lParam)
 		menu.LoadMenu(IDR_MENU_TAB);
 		CMenu* menuSub = NULL;
 		menuSub = menu.GetSubMenu(0);
-		int lResult = TrackPopupMenuEx(menu.GetSubMenu(0)->m_hMenu, TPM_LEFTALIGN | TPM_TOPALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON,
-					       rcOver.left, rcOver.bottom - 4,
-					       (HWND)tcitem.lParam, NULL);
-		if (lResult > 0)
+		if (tcitem.lParam)
 		{
-			SendMessage((HWND)tcitem.lParam, WM_COMMAND, MAKEWPARAM(LOWORD(lResult), 0x0), 0);
+			int lResult = TrackPopupMenuEx(menu.GetSubMenu(0)->m_hMenu, TPM_LEFTALIGN | TPM_TOPALIGN | TPM_RETURNCMD | TPM_RIGHTBUTTON,
+						       rcOver.left, rcOver.bottom - 4,
+						       (HWND)tcitem.lParam, NULL);
+			if (lResult > 0)
+			{
+				SendMessage((HWND)tcitem.lParam, WM_COMMAND, MAKEWPARAM(LOWORD(lResult), 0x0), 0);
+			}
 		}
 		return 1;
 	}

--- a/DlgDebugWnd.cpp
+++ b/DlgDebugWnd.cpp
@@ -33,6 +33,9 @@ void CDlgDebugWnd::ClearData()
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogDebugWnd);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
 		{
@@ -411,6 +414,9 @@ void CDlgDebugWnd::SetLogMsg(LPCTSTR pDATE_TIME,
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogDebugWnd);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
 		{

--- a/DlgDebugWnd.cpp
+++ b/DlgDebugWnd.cpp
@@ -34,7 +34,7 @@ void CDlgDebugWnd::ClearData()
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogDebugWnd);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
@@ -415,7 +415,7 @@ void CDlgDebugWnd::SetLogMsg(LPCTSTR pDATE_TIME,
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogDebugWnd);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)

--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -2695,6 +2695,9 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, theApp.m_strEventRecoveryName);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
 		{

--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -2696,7 +2696,7 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, theApp.m_strEventRecoveryName);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3180,7 +3180,7 @@ BOOL CSazabi::IsCacheRedirectFilterNone(LPCTSTR pURL)
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogScriptName);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 50);
 		if (waitRes == WAIT_TIMEOUT)
@@ -3215,7 +3215,7 @@ void CSazabi::AddCacheRedirectFilterNone(LPCTSTR pURL)
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogScriptName);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
@@ -3259,7 +3259,7 @@ BOOL CSazabi::IsCacheURLFilterAllow(LPCTSTR pURL)
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterAllow);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 50);
 		if (waitRes == WAIT_TIMEOUT)
@@ -3294,7 +3294,7 @@ BOOL CSazabi::IsCacheURLFilterDeny(LPCTSTR pURL)
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterDeny);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 50);
 		if (waitRes == WAIT_TIMEOUT)
@@ -3330,7 +3330,7 @@ void CSazabi::AddCacheURLFilterAllow(LPCTSTR pURL)
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterAllow);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
@@ -3373,7 +3373,7 @@ void CSazabi::AddCacheURLFilterDeny(LPCTSTR pURL)
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterDeny);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3175,6 +3175,9 @@ BOOL CSazabi::IsCacheRedirectFilterNone(LPCTSTR pURL)
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogScriptName);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+		
 		DWORD waitRes = WaitForSingleObject(hEvent, 50);
 		if (waitRes == WAIT_TIMEOUT)
 		{
@@ -3207,6 +3210,9 @@ void CSazabi::AddCacheRedirectFilterNone(LPCTSTR pURL)
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogScriptName);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
 		{
@@ -3248,6 +3254,9 @@ BOOL CSazabi::IsCacheURLFilterAllow(LPCTSTR pURL)
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterAllow);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 50);
 		if (waitRes == WAIT_TIMEOUT)
 		{
@@ -3280,6 +3289,9 @@ BOOL CSazabi::IsCacheURLFilterDeny(LPCTSTR pURL)
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterDeny);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 50);
 		if (waitRes == WAIT_TIMEOUT)
 		{
@@ -3313,6 +3325,9 @@ void CSazabi::AddCacheURLFilterAllow(LPCTSTR pURL)
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterAllow);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
 		{
@@ -3353,6 +3368,9 @@ void CSazabi::AddCacheURLFilterDeny(LPCTSTR pURL)
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventURLFilterDeny);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 100);
 		if (waitRes == WAIT_TIMEOUT)
 		{

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -2202,6 +2202,8 @@ BOOL CSazabi::SafeTerminateProcess(HANDLE hProcess, INT_PTR uExitCode)
 	HANDLE hProcessDup = INVALID_HANDLE_VALUE;
 	HANDLE hRT = NULL;
 	HINSTANCE hKernel = GetModuleHandle(_T("Kernel32"));
+	if (!hKernel)
+		return FALSE;
 	BOOL bSuccess = FALSE;
 	BOOL bDup = DuplicateHandle(GetCurrentProcess(), hProcess, GetCurrentProcess(), &hProcessDup, PROCESS_ALL_ACCESS, FALSE, 0);
 	if (GetExitCodeProcess((bDup) ? hProcessDup : hProcess, &dwCode) && (dwCode == STILL_ACTIVE))
@@ -2979,6 +2981,8 @@ unsigned long long CSazabi::GetMemoryUsageSizeFromPID(DWORD dwPID)
 			VM_COUNTERS_EX2 vm = {0};
 			// Locating functions
 			HINSTANCE hNtDll = GetModuleHandleW(L"ntdll.dll");
+			if (!hNtDll)
+				throw std::runtime_error("Failed to execute GetModuleHandleW");
 			NtQueryInformationProcessPtr NtQueryInformationProcess = (NtQueryInformationProcessPtr)GetProcAddress(hNtDll, "NtQueryInformationProcess");
 			RtlNtStatusToDosErrorPtr RtlNtStatusToDosError = (RtlNtStatusToDosErrorPtr)GetProcAddress(hNtDll, "RtlNtStatusToDosError");
 			if (!NtQueryInformationProcess || !RtlNtStatusToDosError)

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3181,7 +3181,7 @@ BOOL CSazabi::IsCacheRedirectFilterNone(LPCTSTR pURL)
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventLogScriptName);
 		if (!hEvent)
 			throw std::runtime_error("Failed to execute OpenEvent");
-		
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 50);
 		if (waitRes == WAIT_TIMEOUT)
 		{

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1785,6 +1785,10 @@ bool ClientHandler::OnSelectClientCertificate(
 			return false;
 		}
 
+#pragma warning(push, 0)
+// CryptUIDlgSelectCertificateFromStoreの第7引数は実際にはNULL許容だが、_In_で定義されているので
+//C6387: 「_Param_(7)は'0'である可能性があります」の警告が出る。仕方がないのでこの警告は無視する。
+#pragma warning(disable : 6387)
 		PCCERT_CONTEXT pCertContext;
 		pCertContext = CryptUIDlgSelectCertificateFromStore(hCertStore,
 								    hWindow,
@@ -1793,6 +1797,8 @@ bool ClientHandler::OnSelectClientCertificate(
 								    0,	  // show default columns
 								    0,	  // reserved dwFlags
 								    NULL);
+#pragma warning(pop)
+
 		if (!pCertContext)
 		{
 			// Failed to select certificate or canceled or closed dialog.

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1785,7 +1785,7 @@ bool ClientHandler::OnSelectClientCertificate(
 			return false;
 		}
 
-#pragma warning(push, 0)
+#pragma warning(push)
 // CryptUIDlgSelectCertificateFromStoreの第7引数は実際にはNULL許容だが、_In_で定義されているので
 //C6387: 「_Param_(7)は'0'である可能性があります」の警告が出る。仕方がないのでこの警告は無視する。
 #pragma warning(disable : 6387)

--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -470,6 +470,9 @@ void CLogDispatcher::SendLog(int iLogType, LPCTSTR lpFileName, LPCTSTR lpTargetU
 	try
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventSendMsgName);
+		if (!hEvent)
+			throw std::runtime_error("Failed to execute OpenEvent");
+
 		DWORD waitRes = WaitForSingleObject(hEvent, 200);
 		if (waitRes == WAIT_TIMEOUT)
 		{

--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -471,7 +471,7 @@ void CLogDispatcher::SendLog(int iLogType, LPCTSTR lpFileName, LPCTSTR lpTargetU
 	{
 		hEvent = OpenEvent(EVENT_ALL_ACCESS, FALSE, m_strEventSendMsgName);
 		if (!hEvent)
-			throw std::runtime_error("Failed to execute OpenEvent");
+			throw std::runtime_error("Failed to execute OpenEvent at " __FUNCTION__ " : " MAKE_STRING(__LINE__));
 
 		DWORD waitRes = WaitForSingleObject(hEvent, 200);
 		if (waitRes == WAIT_TIMEOUT)

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -3477,7 +3477,7 @@ public:
 				pSource = VBSource;
 
 				//スクリプトコードのロードと解析。
-#pragma warning(push, 0)
+#pragma warning(push)
 //ParseScriptTextの各引数とGetScriptDispatchの第一引数はNULL許容なので、「NULLの可能性がある」警告は無視する。
 #pragma warning(disable : 6387)
 				if (FAILED(hRes = pASP->ParseScriptText(pSource,
@@ -3638,7 +3638,7 @@ public:
 				LPCWSTR pSource = NULL;
 				pSource = VBSource;
 
-#pragma warning(push, 0)
+#pragma warning(push)
 //ParseScriptTextの各引数とGetScriptDispatchの第一引数はNULL許容なので、「NULLの可能性がある」警告は無視する。
 #pragma warning(disable : 6387)
 				//スクリプトコードのロードと解析。

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -488,12 +488,12 @@ namespace SBUtil
 		// so must sniff
 		BOOL f64 = FALSE;
 		LPFN_ISWOW64PROCESS fnIsWow64Process = {0};
-
-		fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(GetModuleHandle(_T("kernel32.dll")), "IsWow64Process");
+		HMODULE hModule = GetModuleHandle(_T("kernel32.dll"));
+		if (!hModule)
+			return FALSE;
+		fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(hModule, "IsWow64Process");
 		if (NULL != fnIsWow64Process)
-		{
 			return fnIsWow64Process(GetCurrentProcess(), &f64) && f64;
-		}
 		return FALSE;
 #else
 		return FALSE; // Win64 does not support Win16
@@ -761,6 +761,8 @@ namespace SBUtil
 	static SIZE_T GetRemoteCommandLineW(HANDLE hProcess, LPWSTR pszBuffer, UINT bufferLength)
 	{
 		HINSTANCE hNtDll = GetModuleHandleW(L"ntdll.dll");
+		if (!hNtDll)
+			return 0;
 		NtQueryInformationProcessPtr NtQueryInformationProcess = (NtQueryInformationProcessPtr)GetProcAddress(hNtDll, "NtQueryInformationProcess");
 		RtlNtStatusToDosErrorPtr RtlNtStatusToDosError = (RtlNtStatusToDosErrorPtr)GetProcAddress(hNtDll, "RtlNtStatusToDosError");
 
@@ -3475,6 +3477,9 @@ public:
 				pSource = VBSource;
 
 				//スクリプトコードのロードと解析。
+#pragma warning(push, 0)
+//ParseScriptTextの各引数とGetScriptDispatchの第一引数はNULL許容なので、「NULLの可能性がある」警告は無視する。
+#pragma warning(disable : 6387)
 				if (FAILED(hRes = pASP->ParseScriptText(pSource,
 									NULL,
 									NULL,
@@ -3494,7 +3499,7 @@ public:
 				CComPtr<IDispatch> pScriptDisp;
 				if (FAILED(hRes = pAS->GetScriptDispatch(NULL, &pScriptDisp)))
 					goto cleanup;
-
+#pragma warning(pop)
 				// スクリプト上に定義されているtestfuncの呼び出し
 				LPOLESTR szMember[] = {L"OnRedirect", NULL};
 				DISPID dispids[1] = {0};
@@ -3633,6 +3638,9 @@ public:
 				LPCWSTR pSource = NULL;
 				pSource = VBSource;
 
+#pragma warning(push, 0)
+//ParseScriptTextの各引数とGetScriptDispatchの第一引数はNULL許容なので、「NULLの可能性がある」警告は無視する。
+#pragma warning(disable : 6387)
 				//スクリプトコードのロードと解析。
 				if (FAILED(hRes = pASP->ParseScriptText(pSource,
 									NULL,
@@ -3653,7 +3661,7 @@ public:
 				CComPtr<IDispatch> pScriptDisp;
 				if (FAILED(hRes = pAS->GetScriptDispatch(NULL, &pScriptDisp)))
 					goto cleanup;
-
+#pragma warning(pop)
 				// スクリプト上に定義されているtestfuncの呼び出し
 				LPOLESTR szMember[] = {L"URLFilter", NULL};
 				DISPID dispids[1] = {0};


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下のようなC6387の警告を解消/抑止

```
警告	C6387	'hEvent' は '0' である可能性があります: この動作は、関数 'WaitForSingleObject' の指定に従っていません。	Sazabi	C:\gitdir\Chronos\DlgDebugWnd.cpp	36	
警告	C6387	'hEvent' は '0' である可能性があります: この動作は、関数 'SetEvent' の指定に従っていません。これが行われる可能性のある以前の行 36 を参照してください	Sazabi	C:\gitdir\Chronos\DlgDebugWnd.cpp	57	
```

# How to verify the fixed issue:

## The steps to verify:
## Expected result:

* ビルド/分析を実施し、C6387がでないこと
* Chronosを動作させ、タブの追加や設定ウィンドウの表示など、通常の動作が問題なく動作すること
  * 主にハンドル関係の処理に対して修正を入れているのでこのような確認をした
  * 細かく全ての修正箇所は見れていない。どこかで全体を一周テストする前に入れてしまって、正式にはその時に全てのケースが問題がないかどうかで確認するのが良さそうである。

