### PR TITLE
Suppress warning C6258

### DIFF
--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -313,7 +313,8 @@ void CLogDispatcher::ChkThread()
 									// スレッド強制停止
 									// (絶対に停止するなら WaitForSingleObjectで INFINITE も可）
 #pragma warning(push, 0)
-//普通に停止できなかった場合に強制停止するために使っているので、正しい使い方
+//警告 C6258 TerminateThread を使用すると、正しくスレッドをクリーンアップすることができません。
+// -> 普通に停止できなかった場合に強制停止するために使っている。正しい使い方なので警告を無視。
 #pragma warning(disable : 6258)
 									::TerminateThread(pThread->m_hThread, 0xffffffff);
 #pragma warning(pop)

--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -312,7 +312,11 @@ void CLogDispatcher::ChkThread()
 								{
 									// ƒXƒŒƒbƒh‹­§’âŽ~
 									// (â‘Î‚É’âŽ~‚·‚é‚È‚ç WaitForSingleObject‚Å INFINITE ‚à‰Âj
+#pragma warning(push, 0)
+//•’Ê‚É’âŽ~‚Å‚«‚È‚©‚Á‚½ê‡‚É‹­§’âŽ~‚·‚é‚½‚ß‚ÉŽg‚Á‚Ä‚¢‚é‚Ì‚ÅA³‚µ‚¢Žg‚¢•û
+#pragma warning(disable : 6258)
 									::TerminateThread(pThread->m_hThread, 0xffffffff);
+#pragma warning(pop)
 									::CloseHandle(pThread->m_hThread);
 									DebugWndLogData dwLogData;
 									dwLogData.mHWND.Format(_T("SEND_LOG_WND:0x%08x"), 0);

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -2986,7 +2986,8 @@ public:
 						// スレッド強制停止
 						// (絶対に停止するなら WaitForSingleObjectで INFINITE も可）
 #pragma warning(push, 0)
-//普通に停止できなかった場合に強制停止するために使っているので、正しい使い方
+//警告 C6258 TerminateThread を使用すると、正しくスレッドをクリーンアップすることができません。
+// -> 普通に停止できなかった場合に強制停止するために使っている。正しい使い方なので警告を無視。
 #pragma warning(disable : 6258)
 						::TerminateThread(pThread->m_hThread, 0xffffffff);
 #pragma warning(pop)

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -2985,7 +2985,11 @@ public:
 					{
 						// ƒXƒŒƒbƒh‹­§’âŽ~
 						// (â‘Î‚É’âŽ~‚·‚é‚È‚ç WaitForSingleObject‚Å INFINITE ‚à‰Âj
+#pragma warning(push, 0)
+//•’Ê‚É’âŽ~‚Å‚«‚È‚©‚Á‚½ê‡‚É‹­§’âŽ~‚·‚é‚½‚ß‚ÉŽg‚Á‚Ä‚¢‚é‚Ì‚ÅA³‚µ‚¢Žg‚¢•û
+#pragma warning(disable : 6258)
 						::TerminateThread(pThread->m_hThread, 0xffffffff);
+#pragma warning(pop)
 					}
 				}
 				ASSERT(FALSE);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告を抑止。
普通に終了できなかった場合に強制終了するために使っている。
これは正しい使い方なのでpragmaで警告抑止。

```
警告	C6258	TerminateThread を使用すると、正しくスレッドをクリーンアップすることができません。	Sazabi	C:\gitdir\Chronos\sbcommon.cpp	315	
```

https://learn.microsoft.com/en-us/cpp/code-quality/c6258?view=msvc-170

# How to verify the fixed issue:

## The steps to verify:
## Expected result:

ビルド/分析を実行し、C6258が出ないこと
