### PR TITLE
Suppress warning C26454

### DIFF
--- a/DlgDebugWnd.cpp
+++ b/DlgDebugWnd.cpp
@@ -70,6 +70,8 @@ void CDlgDebugWnd::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_LIST1, m_List);
 }
 
+#pragma warning(push, 0)
+#pragma warning(disable : 26454)
 BEGIN_MESSAGE_MAP(CDlgDebugWnd, CDialogEx)
 	ON_BN_CLICKED(IDOK, &CDlgDebugWnd::OnBnClickedOk)
 	ON_BN_CLICKED(IDCANCEL, &CDlgDebugWnd::OnBnClickedCancel)
@@ -81,6 +83,7 @@ BEGIN_MESSAGE_MAP(CDlgDebugWnd, CDialogEx)
 	ON_NOTIFY(LVN_GETDISPINFO, IDC_LIST1, &CDlgDebugWnd::OnGetdispinfoList1)
 	ON_BN_CLICKED(IDC_CHECK1, &CDlgDebugWnd::OnBnClickedCheck1)
 END_MESSAGE_MAP()
+#pragma warning(pop)
 
 BOOL CDlgDebugWnd::OnInitDialog()
 {

--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -182,6 +182,8 @@ void CSettingsDialog::DoDataExchange(CDataExchange* pDX)
 	//}}AFX_DATA_MAP
 }
 
+#pragma warning(push, 0)
+#pragma warning(disable : 26454)
 BEGIN_MESSAGE_MAP(CSettingsDialog, CDialog)
 	//{{AFX_MSG_MAP(CSettingsDialog)
 	ON_NOTIFY(TVN_GETDISPINFO, IDC_TREE_CTRL, OnGetDispInfoTreeCtrl)
@@ -189,6 +191,7 @@ BEGIN_MESSAGE_MAP(CSettingsDialog, CDialog)
 	ON_WM_SIZE()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
+#pragma warning(pop)
 
 /////////////////////////////////////////////////////////////////////////////
 // CSettingsDialog message handlers
@@ -1772,6 +1775,9 @@ void CDlgSetDomainFilter::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_LIST1, m_List);
 	//}}AFX_DATA_MAP
 }
+
+#pragma warning(push, 0)
+#pragma warning(disable : 26454)
 BEGIN_MESSAGE_MAP(CDlgSetDomainFilter, CPropertyPage)
 	//{{AFX_MSG_MAP(CDlgSetDomainFilter)
 	ON_BN_CLICKED(IDC_BUTTON_INS, OnButtonPopIns)
@@ -1786,6 +1792,7 @@ BEGIN_MESSAGE_MAP(CDlgSetDomainFilter, CPropertyPage)
 	//}}AFX_MSG_MAP
 	ON_MESSAGE(ID_SETTING_OK, Set_OK)
 END_MESSAGE_MAP()
+#pragma warning(pop)
 
 /////////////////////////////////////////////////////////////////////////////
 // CDlgSetDomainFilter メッセージ ハンドラ
@@ -2405,6 +2412,9 @@ void CDlgSetCustomScript::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_LIST1, m_List);
 	//}}AFX_DATA_MAP
 }
+
+#pragma warning(push, 0)
+#pragma warning(disable : 26454)
 BEGIN_MESSAGE_MAP(CDlgSetCustomScript, CPropertyPage)
 	//{{AFX_MSG_MAP(CDlgSetCustomScript)
 	ON_BN_CLICKED(IDC_BUTTON_INS, OnButtonPopIns)
@@ -2421,6 +2431,7 @@ BEGIN_MESSAGE_MAP(CDlgSetCustomScript, CPropertyPage)
 	ON_BN_CLICKED(IDC_BUTTON1, &CDlgSetCustomScript::OnBnClickedButton1)
 	ON_BN_CLICKED(IDC_SHOW_DEV_TOOLS, &CDlgSetCustomScript::OnBnClickedShowDevTools)
 END_MESSAGE_MAP()
+#pragma warning(pop)
 
 /////////////////////////////////////////////////////////////////////////////
 // CDlgSetCustomScript メッセージ ハンドラ

--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -183,6 +183,7 @@ void CSettingsDialog::DoDataExchange(CDataExchange* pDX)
 }
 
 #pragma warning(push, 0)
+//警告 C26454 演算のオーバーフロー : '-' の操作では、コンパイル時に負の符号なしの結果が生成されます(io .5)。
 #pragma warning(disable : 26454)
 BEGIN_MESSAGE_MAP(CSettingsDialog, CDialog)
 	//{{AFX_MSG_MAP(CSettingsDialog)
@@ -1777,6 +1778,7 @@ void CDlgSetDomainFilter::DoDataExchange(CDataExchange* pDX)
 }
 
 #pragma warning(push, 0)
+//警告 C26454 演算のオーバーフロー : '-' の操作では、コンパイル時に負の符号なしの結果が生成されます(io .5)。
 #pragma warning(disable : 26454)
 BEGIN_MESSAGE_MAP(CDlgSetDomainFilter, CPropertyPage)
 	//{{AFX_MSG_MAP(CDlgSetDomainFilter)
@@ -2414,6 +2416,7 @@ void CDlgSetCustomScript::DoDataExchange(CDataExchange* pDX)
 }
 
 #pragma warning(push, 0)
+//警告 C26454 演算のオーバーフロー : '-' の操作では、コンパイル時に負の符号なしの結果が生成されます(io .5)。
 #pragma warning(disable : 26454)
 BEGIN_MESSAGE_MAP(CDlgSetCustomScript, CPropertyPage)
 	//{{AFX_MSG_MAP(CDlgSetCustomScript)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告を抑止。
警告が出ていた場所は `ON_NOTIFY(TVN_SELCHANGED, IDC_TREE_CTRL, OnTreeSelChanged)` などのwinfrm.cppなどのライブラリ側で定義されてい値/マクロを使っている部分で、Chronos側から対処ができなかったため、pragmaで抑止。

```
警告	C26454	演算のオーバーフロー: '-' の操作では、コンパイル時に負の符号なしの結果が生成されます (io.5)。	Sazabi	C:\gitdir\Chronos\DlgDebugWnd.cpp	81	
```

# How to verify the fixed issue:

## The steps to verify:
## Expected result:

* ビルド/分析を実施し、C26454の警告がでないこと
