### PR TITLE
Suppress warning C6001

### DIFF
--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -272,7 +272,12 @@ void CLogDispatcher::ChkThread()
 							{
 								try
 								{
+#pragma warning(push, 0)
+//警告 C6001 初期化されていないメモリ '**pThread.m_hThread' を使用しています。
+// -> 通常初期化されているはず。もし本当に初期化されていないとしても、catch句に拾われるので問題ない。
+#pragma warning(disable : 6001)
 									dRet = ::WaitForSingleObject(pThread->m_hThread, 30 * 1000);
+#pragma warning(pop)
 								}
 								catch (...)
 								{

--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -216,7 +216,7 @@ void CLogDispatcher::ChkThread()
 		{
 			try
 			{
-				m_MapLogThreadMgr.GetNextAssoc(pos, strKey, (void *&)pThread);
+				m_MapLogThreadMgr.GetNextAssoc(pos, strKey, (void*&)pThread);
 				if (pThread == NULL)
 				{
 					strARemoveList.Add(strKey);

--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -206,7 +206,7 @@ void CLogDispatcher::ChkThread()
 		if (m_bStop)
 			return;
 
-		void* iVal = 0;
+		CWinThread* pThread = NULL;
 		CString strKey;
 
 		//終了した物を消す。
@@ -216,8 +216,8 @@ void CLogDispatcher::ChkThread()
 		{
 			try
 			{
-				m_MapLogThreadMgr.GetNextAssoc(pos, strKey, iVal);
-				if (iVal == NULL)
+				m_MapLogThreadMgr.GetNextAssoc(pos, strKey, (void *&)pThread);
+				if (pThread == NULL)
 				{
 					strARemoveList.Add(strKey);
 				}
@@ -236,7 +236,7 @@ void CLogDispatcher::ChkThread()
 				strKey = strARemoveList.GetAt(i);
 				if (!strKey.IsEmpty())
 				{
-					if (m_MapLogThreadMgr.Lookup(strKey, iVal))
+					if (m_MapLogThreadMgr.Lookup(strKey, (void*&)pThread))
 					{
 						m_MapLogThreadMgr.RemoveKey(strKey);
 					}
@@ -252,16 +252,14 @@ void CLogDispatcher::ChkThread()
 		{
 			try
 			{
-				m_MapLogThreadMgr.GetNextAssoc(pos, strKey, iVal);
+				m_MapLogThreadMgr.GetNextAssoc(pos, strKey, (void*&)pThread);
 				if (m_bStop)
 					return;
 
-				if (iVal)
+				if (pThread)
 				{
-					CWinThread* pThread = NULL;
-					if (m_MapLogThreadMgr.Lookup(strKey, iVal))
+					if (m_MapLogThreadMgr.Lookup(strKey, (void*&)pThread))
 					{
-						pThread = (CWinThread*)iVal;
 						if (pThread)
 						{
 							DWORD dRet = 0;
@@ -272,12 +270,7 @@ void CLogDispatcher::ChkThread()
 							{
 								try
 								{
-#pragma warning(push, 0)
-//警告 C6001 初期化されていないメモリ '**pThread.m_hThread' を使用しています。
-// -> 通常初期化されているはず。もし本当に初期化されていないとしても、catch句に拾われるので問題ない。
-#pragma warning(disable : 6001)
 									dRet = ::WaitForSingleObject(pThread->m_hThread, 30 * 1000);
-#pragma warning(pop)
 								}
 								catch (...)
 								{

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -2973,15 +2973,13 @@ public:
 		{
 			if (pThread == NULL) return;
 			if (lpIndex == NULL) return;
-			void* iVal = (void*)pThread;
-			if (m_MapLogThreadMgr.Lookup(lpIndex, iVal))
+			CWinThread* pThreadLocal = NULL;
+			if (m_MapLogThreadMgr.Lookup(lpIndex, (void*&)pThreadLocal))
 			{
-				if (iVal)
+				if (pThreadLocal)
 				{
-					CWinThread* pThread = NULL;
-					pThread = (CWinThread*)iVal;
 					// スレッド終了待ち
-					if (::WaitForSingleObject(pThread->m_hThread, 5000) == WAIT_TIMEOUT)
+					if (::WaitForSingleObject(pThreadLocal->m_hThread, 5000) == WAIT_TIMEOUT)
 					{
 						// スレッド強制停止
 						// (絶対に停止するなら WaitForSingleObjectで INFINITE も可）
@@ -2998,7 +2996,7 @@ public:
 			}
 			else
 			{
-				m_MapLogThreadMgr.SetAt(lpIndex, iVal);
+				m_MapLogThreadMgr.SetAt(lpIndex, pThread);
 			}
 		}
 		catch (...)

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -2987,7 +2987,7 @@ public:
 //警告 C6258 TerminateThread を使用すると、正しくスレッドをクリーンアップすることができません。
 // -> 普通に停止できなかった場合に強制停止するために使っている。正しい使い方なので警告を無視。
 #pragma warning(disable : 6258)
-						::TerminateThread(pThread->m_hThread, 0xffffffff);
+						::TerminateThread(pThreadLocal->m_hThread, 0xffffffff);
 #pragma warning(pop)
 					}
 				}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42 

# What this PR does / why we need it:

以下の警告を抑止。
通常初期化されているはずであること、仮に本当に初期化されていないとしても、後続のcatch句に拾われる想定であることから、単にpragmaで抑止。

```
警告	C6001	初期化されていないメモリ '**pThread.m_hThread' を使用しています。	Sazabi	C:\gitdir\Chronos\sbcommon.cpp	275	
```

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:
## Expected result:

* ビルド/分析を実施し、C6001の警告がでないこと。
* 監査ログ設定を行い（対象URLには適当にlocalhostなどを指定する）、ログ出力をし、クラッシュなどが発生しないこと