### PR TITLE
Suppress warning C28181.

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -2978,6 +2978,8 @@ void CBrowserFrame::OnTabListShow()
 			bmi.bmiHeader.biPlanes = 1;
 			bmi.bmiHeader.biBitCount = 32;
 			hbmp = CreateDIBSection(NULL, (BITMAPINFO*)&bmi, DIB_RGB_COLORS, &lpBits, NULL, 0);
+			if (!hbmp)
+				continue;
 			hdcMem = CreateCompatibleDC(NULL);
 			hbmpPrev = (HBITMAP)SelectObject(hdcMem, hbmp);
 			DrawIconEx(hdcMem, 0, 0, hicon, uWidth, uHeight, 0, NULL, DI_NORMAL);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告の解消。

```
警告	C28183	'hbmp' は '0' である可能性があり、'CreateDIBSection()`2980' で見つかった値のコピーです: この動作は、関数 'SelectObject' の指定に従っていません。	Sazabi	C:\gitdir\Chronos\BroFrame.cpp	2982	
```

forループの中にいるので、`hbmp`が`NULL`なら`continue`するように変更。
これによるメモリ解放漏れなどは発生しないはず。

# How to verify the fixed issue:

## The steps to verify:
## Expected result:

* ビルド/解析をして、C28183がでないこと
* タブ一覧表示ボタンを押して、正しくタブ一覧が表示されること