### PR TITLE
Update to latest Windows SDK

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,10 +9,12 @@ jobs:
     strategy:
       matrix:
         version: [current, stable, beta]
-    runs-on: [ windows-2019 ]
+    runs-on: [ windows-2022 ]
     steps:
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1
+      - uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: '[17, 18)'
       - if: matrix.version == 'stable'
         name: Use stable version of CEF
         run: |

--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -4,7 +4,7 @@ Chronosの開発の手引き
  * 開発には Visual Studio 2019が必要です。
    * `Desktop Development with C++ > C++ CMake tools for Windows` を選択
    * `Desktop Development with C++ > C++ MFC for latest ...` を選択
- * Windows SDK 10.0.18362.0の事前インストールが必要です。
+ * Windows SDK 10.0.22000.0の事前インストールが必要です。
 
 ## ビルド手順
 

--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -1,22 +1,23 @@
 Chronosの開発の手引き
 =====================
 
- * 開発には Visual Studio 2019が必要です。
+ * 開発には Visual Studio 2022が必要です。
    * `Desktop Development with C++ > C++ CMake tools for Windows` を選択
    * `Desktop Development with C++ > C++ MFC for latest ...` を選択
  * Windows SDK 10.0.22000.0の事前インストールが必要です。
+   * Visual Studio Installerからインストール可能です。
 
 ## ビルド手順
 
  1. このレポジトリをローカルにクローンする。
- 2. スタートメニューから開発者コマンドプロンプト（Developer Command Prompt for VS 2019）を開き`setup-cef.bat`を実行する。
+ 2. スタートメニューから開発者コマンドプロンプト（Developer Command Prompt for VS 2022）を開き`setup-cef.bat`を実行する。
     * この段階で以下のディレクトリが作成される。
       - `D32`: デバッグ版の実行ファイル一式（CEFから抽出＋Chronos固有のビルド済みバイナリが置かれる）
       - `R32`: リリース版の実行ファイル一式（CEFから抽出＋Chronos固有のビルド済みバイナリが置かれる）
       - `lib`: デバッグ版のコンパイルに必要なライブラリ（CEFから抽出）
       - `rlib`: リリース版のコンパイルに必要なライブラリ（CEFから抽出）
       - `include`: CEFのヘッダファイル（CEFから抽出）
- 3. Visual Studio 2019でプロジェクト（Sazabi.sln）を開く。
+ 3. Visual Studio 2022でプロジェクト（Sazabi.sln）を開く。
  4. 構成を「R64_CSG」（リリース版）または「D64_CSG」（デバッグ版）から選択する。
  5. メニューから「Local Windows Debugger」を実行する。
 
@@ -24,11 +25,11 @@ Chronosの開発の手引き
 
  1. `setup-cef.bat`に記載されている`CEFVER`を更新する。
     * https://cef-builds.spotifycdn.com/index.html#windows32 に掲載されている「Windows 32」且つ「minimal」のものを使用する。
- 2. スタートメニューから開発者コマンドプロンプト（Developer Command Prompt for VS 2019）を開き`setup-cef.bat`を再実行する。
+ 2. スタートメニューから開発者コマンドプロンプト（Developer Command Prompt for VS 2022）を開き`setup-cef.bat`を再実行する。
  3. Chronosのバージョンを上げる。
     * CEF（Chromium）のメジャーバージョンをChronosのバージョンの3桁目に反映する。
       たとえば、Chromium 96ベースのCEFであれば、Chronosのバージョンは x.x.96.x となる。
-    * Visual Studio 2019でプロジェクト（Sazabi.sln）を開き、リソースビューの「Sazabi」から
+    * Visual Studio 2022でプロジェクト（Sazabi.sln）を開き、リソースビューの「Sazabi」から
       「Sazabi.rc」→「Version」→「VS_VERSION_INFO」と「VS_VERSION_INFO[英語]」のそれぞれについて
       「FILEVERSION」と「PRODUCTVERSION」の箇所を変更して保存する。
       （それ以外の箇所は自動的に追従するため、特に変更の必要はない。）

--- a/Sazabi.sln
+++ b/Sazabi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31605.320
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Sazabi", "Sazabi.vcxproj", "{83410426-0B15-352C-4BC5-CCD2A7EF1930}"
 EndProject

--- a/Sazabi.vcxproj
+++ b/Sazabi.vcxproj
@@ -15,7 +15,7 @@
     <SccLocalPath />
     <Keyword>MFCProj</Keyword>
     <ProjectGuid>{83410426-0B15-352C-4BC5-CCD2A7EF1930}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='D64_CSG|Win32'" Label="Configuration">

--- a/Sazabi.vcxproj
+++ b/Sazabi.vcxproj
@@ -22,7 +22,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='R64_CSG|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -30,7 +30,7 @@
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <UseOfAtl>false</UseOfAtl>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/doc/CEFPORTING.md
+++ b/doc/CEFPORTING.md
@@ -7,7 +7,7 @@ Chronosで採用しているCEFを継続的に更新していくために必要�
 ## 移植の基本的な流れ
 
 1. [HOWTOBUILD](../HOWTOBUILD.md)を参考に、setup-cef.batを更新し、採用すべきビルド済みバイナリを変更する。
-2. Visual Studio 2019を起動しソリューションをビルドするか、Developer Command Prompt for VS 2019を起動し、msbuildでビルドする。参考:[build.yaml](../.github/workflows/build.yaml)
+2. Visual Studio 2022を起動しソリューションをビルドするか、Developer Command Prompt for VS 2022を起動し、msbuildでビルドする。参考:[build.yaml](../.github/workflows/build.yaml)
 
 ```
 msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

使用するWindows SDKをVisual Studio InstallerのVisual Studio 2019向けの中から選べる最新のものである10.0.22000.0に更新。



これにより以下の警告が解消する。

```
重大度レベル	コード	説明	プロジェクト	ファイル	行	抑制状態
警告	81010002	Unrecognized Element "heapType" in namespace "http://schemas.microsoft.com/SMI/2020/WindowsSettings".	Sazabi	C:\gitdir\Chronos\res\sazabi.manifest	1	
```

警告が出ている`heapType`は`http://schemas.microsoft.com/SMI/2020/WindowsSettings`で定義されているので2020年頃追加されたものと思われる。
一方で https://en.wikipedia.org/wiki/Microsoft_Windows_SDK を見ると現在使っているWindows SDK 10.0.18362.0のリリースが2019-05-21なので、まだ`heapType`がなく警告が出ている。

なお、現状リリースされている最新のSDKは 10.0.22621.0 なのだが、（Visual Studio Installer経由ではなく自分でインストールして）そのSDKを使うとビルドできなくなったため、10.0.22000.0 を使っている。

10.0.22000.0 でサポートしているOSバージョンは見つけられなかったのだが、より新しいバージョンである10.0.22621.0向けの記事でも、Windows10の初期リリースやWindow 2019が対象バージョンに入っているので、ChronosがサポートしているOSはこのSDKでもサポートされている。

https://developer.microsoft.com/ja-jp/windows/downloads/windows-sdk/

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

* Chronosをビルド/分析する
* ネイティブのChronosを動作させる
* ThinApp化したChronosを動作させる

## Expected result:

* ビルドに成功し、81010002の警告が出ないこと
* ネイティブのChronosが問題なく動作すること
  * このPRとしては、起動しさえすれば良い
  * 影響は全体に及ぶので、詳細な確認は全機能を確認するようなテストフェーズで行うのが良さそうである
* ThinApp化したChronosが問題なく動作すること
  * このPRとしては、起動しさえすれば良い
  * 影響は全体に及ぶので、詳細な確認は全機能を確認するようなテストフェーズで行うのが良さそうである