### PR TITLE
Use IsWindows* and GetSystemMetrics instead of GetVersionEx

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3899,32 +3899,15 @@ CString CSazabi::GetVOSInfo()
 
 CString CSazabi::GetOSInfo(void)
 {
-	OSVERSIONINFOEX ovi = {0};
-	ovi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-	GetVersionEx((OSVERSIONINFO*)&ovi);
-	DWORD dwBuildNumber = ovi.dwBuildNumber;
-	CString strOS = _T("Windows");
+	CString strBuff = _T("Windows");
 
-	CString strBuff;
+	strBuff += IsWindowsServer() ? _T(" Server") : _T(" Client");
 
-	if (ovi.wProductType == VER_NT_WORKSTATION)
-		strOS += _T(" Client");
-	else if (ovi.wProductType == VER_NT_DOMAIN_CONTROLLER || ovi.wProductType == VER_NT_SERVER)
-		strOS += _T(" Server");
+	strBuff += SBUtil::Is64BitWindows() ? _T(" x64") : _T(" x86");
 
-	if (SBUtil::Is64BitWindows())
+	if (GetSystemMetrics(SM_REMOTESESSION))
 	{
-		strBuff.Format(_T("%s x64"), (LPCTSTR)strOS);
-	}
-	else
-	{
-		strBuff.Format(_T("%s x86"), (LPCTSTR)strOS);
-	}
-
-	if ((ovi.wSuiteMask & VER_SUITE_TERMINAL) == VER_SUITE_TERMINAL)
-	{
-		if (!((ovi.wSuiteMask & VER_SUITE_SINGLEUSERTS) == VER_SUITE_SINGLEUSERTS))
-			strBuff += _T(" (RDS Session)");
+		strBuff += _T(" (RDS Session)");
 	}
 
 	return strBuff;

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -4,6 +4,7 @@
 #include "fav.h"
 #include "locale.h"
 #include <sddl.h>
+#include <VersionHelpers.h>
 #include "include/cef_version.h"
 
 #include "mmsystem.h"
@@ -500,20 +501,7 @@ namespace SBUtil
 
 	static inline BOOL IsWindowsServerRDS()
 	{
-		OSVERSIONINFOEX ovi = {0};
-		ovi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-		GetVersionEx((OSVERSIONINFO*)&ovi);
-		if (ovi.wProductType == VER_NT_WORKSTATION)
-			return FALSE;
-		else if (ovi.wProductType == VER_NT_DOMAIN_CONTROLLER || ovi.wProductType == VER_NT_SERVER)
-		{
-			if ((ovi.wSuiteMask & VER_SUITE_TERMINAL) == VER_SUITE_TERMINAL)
-			{
-				if (!((ovi.wSuiteMask & VER_SUITE_SINGLEUSERTS) == VER_SUITE_SINGLEUSERTS))
-					return TRUE;
-			}
-		}
-		return FALSE;
+		return IsWindowsServer() && GetSystemMetrics(SM_REMOTESESSION);
 	}
 
 	static inline void SafeGetWindowText(HWND hWnd, CString& str)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告を解消。

```
警告	C28159	'IsWindows*' を 'GetVersionExW' の代わりに使用してください。理由: Deprecated. Use VerifyVersionInfo* or IsWindows* macros from VersionHelpers.	Sazabi	C:\gitdir\Chronos\sbcommon.h	494
警告	C28159	'IsWindows*' を 'GetVersionExW' の代わりに使用してください。理由: Deprecated. Use VerifyVersionInfo* or IsWindows* macros from VersionHelpers.	Sazabi	C:\gitdir\Chronos\Sazabi.cpp	3904
```

Windows Serverかどうか、RDS（リモートデスクトップ）かどうかの判定ロジックを変更。
これに伴い、筆者環境ではRDSなのにRDSと判定されていなかったのが、正しくRDSと判定されるようになった。

# How to verify the fixed issue:

## The steps to verify:

* ビルド/分析を実行
* Windows10にリモートデスクトップでログインし、Chronosを起動する
* Windows10にローカルログイン（リモートデスクトップではない、の意）でログインし、Chronosを起動する
* Windows Server 2019にリモートデスクトップでログインし、Chronosを起動する
* Windows Server 2019にローカルログイン（リモートデスクトップではない、の意）でログインし、Chronosを起動する

## Expected result:

* ビルド/分析を実行
  * C28159の警告がでないこと
* Windows10にリモートデスクトップでログインし、Chronosを起動する
  * ヘルプのバージョン情報で、OSバージョンが`Windows Client x64 (RDS Session)`と表示されていること
* Windows10にローカルログイン（リモートデスクトップではない、の意）でログインし、Chronosを起動する
  * ヘルプのバージョン情報で、OSバージョンが`Windows Client x64`と表示されていること
* Windows Server 2019にリモートデスクトップでログインし、Chronosを起動する
  * ヘルプのバージョン情報で、OSバージョンが`Windows Server x64 (RDS Session)`と表示されていること
* ~~Windows Server 2019にローカルログイン（リモートデスクトップではない、の意）でログインし、Chronosを起動する~~
  * ~~ヘルプのバージョン情報で、OSバージョンが`Windows Server x64`と表示されていること~~
  * =>環境をAWS上で準備したのだが、上手くローカルログインできなかったので、このケースを試せなかった。RDSでの接続は確認した。Windows10の方でRDS接続かどうかで`(RDS Session)`が出るかどうか確認できているので、単体レベルではこの手順をスキップしても問題なさそうなので、今回はスキップとしたい。

上記の確認では `IsWindowsServerRDS()` が正しく動いているか直接は確認できていない。
`CSazabi::GetOSInfo(void)`の変更内容のみが確認できる。
そもそも、`IsWindowsServerRDS()`が外部仕様に影響するような部分で使われていなさそうなので、実際に動作や表示などからは確認できない。

ただし、`IsWindowsServerRDS`で使っている`IsWindowsServer()`と`GetSystemMetrics(SM_REMOTESESSION)`の動作確認は、上記のテストで確認できている。
また、デバッガーでWindows10環境で `IsWindowsServerRDS()`が正しく動いていることは確認済み。
以上から、このテスト手順だけで十分としたい。