### PR TITLE
Fix a typo in TRACE Log Monitor Window with English language pack

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -1717,7 +1717,7 @@ CAPTION "TRACE Log Monitor Window"
 FONT 10, "MS Gothic", 400, 0, 0x80
 BEGIN
     PUSHBUTTON      "Copy to the clipboard",IDC_BUTTON1,5,5,93,14
-    PUSHBUTTON      "Cler",IDOK,103,5,50,14
+    PUSHBUTTON      "Clear",IDOK,103,5,50,14
     PUSHBUTTON      "Close",IDCANCEL,155,5,50,14
     CONTROL         "Auto scroll",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,230,7,60,10
     LTEXT           "No item",IDC_STATIC_LINE,299,5,57,12,0,WS_EX_RIGHT | WS_EX_STATICEDGE


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A


# What this PR does / why we need it:

If Windows Display setting is set to English, there is a typo in TRACE log monitor window with "Clear" button.

![image](https://github.com/ThinBridge/Chronos/assets/225841/a9dbeae9-bb1a-4e2a-9964-d69e8b9be05b)

# How to verify the fixed issue:


1. Change windows display setting (region&time) to  English
2. Launch Chronos
3. Launch TRACE log monitor window


## Expected result:

label for clear button must be "Clear", not "Cler"

![trace-log-monitor-window-en-us](https://github.com/ThinBridge/Chronos/assets/225841/20e292f5-9041-454a-b736-40fc3242753a)
