### PR TITLE
Fix to automatically create the Chrome version in User-Agent

### DIFF
--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -32,9 +32,7 @@ Chronosの開発の手引き
       「Sazabi.rc」→「Version」→「VS_VERSION_INFO」と「VS_VERSION_INFO[英語]」のそれぞれについて
       「FILEVERSION」と「PRODUCTVERSION」の箇所を変更して保存する。
       （それ以外の箇所は自動的に追従するため、特に変更の必要はない。）
- 4. sbcommon.hのユーザーエージェント文字列を更新する。
-    * `sgSZB_UA_END` に含まれるバージョンを、CEFのバージョンに合わせる。
- 5. Visual Studio上でChronosをビルドする。
+ 4. Visual Studio上でChronosをビルドする。
 
 ## Chromiumのバージョンを確認する方法
 

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -4,6 +4,7 @@
 #include "fav.h"
 #include "locale.h"
 #include <sddl.h>
+#include "include/cef_version.h"
 
 #include "mmsystem.h"
 #pragma comment(lib, "winmm.lib")
@@ -53,11 +54,15 @@ private:
 static TCHAR gstrThisAppNameR[] = _T("Chronos");
 static TCHAR gstrThisAppNameSG[] = _T("Chronos SystemGuard");
 static TCHAR sgSZB_UA_START[] = _T("Mozilla/5.0 (");
+
+#define SB_CHROME_VERSION MAKE_STRING(CHROME_VERSION_MAJOR) "." MAKE_STRING(CHROME_VERSION_MINOR) "." MAKE_STRING(CHROME_VERSION_BUILD) "." MAKE_STRING(CHROME_VERSION_PATCH)
 //2021-01-07Googleにログインできない CEF経由ではNGになった。
 //調査結果、FirefoxにすればOK, Edge/87.0.0.0をつけてもOK
 //デフォルトのUAをEdgeに変更する対応にする。
 //2021-11-30 ↑の対策がNGになっていることに気がついた。UAにEdgeをつけてもNG
-static TCHAR sgSZB_UA_END[] = _T(") AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/98.0.4758.109 Safari/537.36 Chronos/SystemGuard");
+static TCHAR sgSZB_UA_END[] = _T(") AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/" SB_CHROME_VERSION " Safari/537.36 Chronos/SystemGuard");
+#undef SB_CHROME_VERSION
+
 typedef HRESULT(WINAPI* pfnDwmIsCompositionEnabled)(BOOL* pfEnabled);
 typedef HRESULT(WINAPI* pfnDwmGetWindowAttribute)(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute);
 typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/78

# What this PR does / why we need it:

User-Agentで使用されるChromeのバージョンを自動生成するように修正。

# How to verify the fixed issue:

## The steps to verify:

## Expected result:

DevToolでNetwork ->（Name欄のURL）-> Headers のUser-Agentを確認し、最新のバージョンになっていることを確認
現在の最新のバージョンは`112.0.5615.165`である。

![image](https://github.com/ThinBridge/Chronos/assets/15982708/7d684ea4-f22f-4754-90db-2feb84174cfe)

