### PR TITLE
Fix ChronosFileOpenDialog and ChronosFileSaveDialog

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -79,14 +79,9 @@ public:
 			strPath = strRootPath;
 
 			FILEOPENDIALOGOPTIONS option = 0;
-			option &= ~OFN_ENABLEHOOK;
-			option &= ~OFN_ENABLETEMPLATE;
-			option |= OFN_LONGNAMES;
-			option |= OFN_NONETWORKBUTTON;
-			option |= OFN_DONTADDTORECENT;
-			option |= OFN_EX_NOPLACESBAR;
-			option |= OFN_OVERWRITEPROMPT;
-
+			option |= FOS_HIDEMRUPLACES;
+			option |= FOS_OVERWRITEPROMPT;
+			option |= FOS_HIDEPINNEDPLACES;
 			hresult = this->SetOptions(option);
 			if (FAILED(hresult))
 			{
@@ -430,14 +425,9 @@ public:
 		}
 
 		FILEOPENDIALOGOPTIONS option = 0;
-
-		option &= ~OFN_ENABLEHOOK;
-		option &= ~OFN_ENABLETEMPLATE;
-		option |= OFN_LONGNAMES;
-		option |= OFN_NONETWORKBUTTON;
-		option |= OFN_DONTADDTORECENT;
-		option |= OFN_EX_NOPLACESBAR;
-		option |= OFN_OVERWRITEPROMPT;
+		option |= FOS_HIDEMRUPLACES;
+		option |= FOS_OVERWRITEPROMPT;
+		option |= FOS_HIDEPINNEDPLACES;
 
 		return this->SetOptions(option);
 	}

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -623,8 +623,7 @@ public:
 			return m_originalDialog->Show(hwndOwner);
 		}
 
-		HRESULT hresult = S_OK;
-		hresult = SetUp();
+		HRESULT hresult = SetUp();
 		if (FAILED(hresult))
 			return hresult;
 

--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -278,8 +278,8 @@ public:
 	/* [local] */ HRESULT STDMETHODCALLTYPE Show(
 	    /* [annotation][unique][in] */ _In_opt_ HWND hwndOwner)
 	{
-		//ŒÄ‚Ño‚µŒ³‚ðŠm”FBe‚ð’H‚Á‚Ä‚¢‚«ACSGViewiBroViewj‚ª“oê‚µ‚È‚¢‚È‚çAÝ’è‰æ–Ê‚©‚ç‚ÌŒÄ‚Ño‚µB
-		//Ý’è‰æ–Ê‚©‚ç‚ÌŒÄ‚Ño‚µ‚©‚ÂSGƒ‚[ƒh‚Å‚È‚¢‚Æ‚«‚ÍA‚»‚Ì‚Ü‚Ü–³ðŒ‚ÅŠJ‚¢‚Ä—Ç‚¢B
+		//å‘¼ã³å‡ºã—å…ƒã‚’ç¢ºèªã€‚è¦ªã‚’è¾¿ã£ã¦ã„ãã€CSGViewï¼ˆBroViewï¼‰ãŒç™»å ´ã—ãªã„ãªã‚‰ã€è¨­å®šç”»é¢ã‹ã‚‰ã®å‘¼ã³å‡ºã—ã€‚
+		//è¨­å®šç”»é¢ã‹ã‚‰ã®å‘¼ã³å‡ºã—ã‹ã¤SGãƒ¢ãƒ¼ãƒ‰ã§ãªã„ã¨ãã¯ã€ãã®ã¾ã¾ç„¡æ¡ä»¶ã§é–‹ã„ã¦è‰¯ã„ã€‚
 		HWND hWindowParent = hwndOwner;
 		while (hWindowParent)
 		{
@@ -298,7 +298,7 @@ public:
 
 		if (theApp.m_AppSettings.IsEnableUploadRestriction())
 		{
-			CString strMsg(L"ƒtƒ@ƒCƒ‹ ƒAƒbƒvƒ[ƒh‚ÍAƒVƒXƒeƒ€ŠÇ—ŽÒ‚É‚æ‚è§ŒÀ‚³‚ê‚Ä‚¢‚Ü‚·B");
+			CString strMsg(L"ãƒ•ã‚¡ã‚¤ãƒ« ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ã¯ã€ã‚·ã‚¹ãƒ†ãƒ ç®¡ç†è€…ã«ã‚ˆã‚Šåˆ¶é™ã•ã‚Œã¦ã„ã¾ã™ã€‚");
 			if (hWindowParent)
 			{
 				theApp.SB_MessageBox(hWindowParent, strMsg, NULL, MB_OK | MB_ICONWARNING, TRUE);
@@ -310,8 +310,7 @@ public:
 			return E_ACCESSDENIED;
 		}
 
-		HRESULT hresult = S_OK;
-		hresult = SetUp();
+		HRESULT hresult = SetUp();
 		if (FAILED(hresult))
 			return hresult;
 
@@ -354,7 +353,7 @@ public:
 				{
 					CString strCaption(theApp.m_strThisAppName);
 					CString strMsg;
-					strMsg.Format(L"ƒAƒbƒvƒ[ƒhƒtƒHƒ‹ƒ_[[%s]ˆÈŠO‚©‚ç‚ÍƒAƒbƒvƒ[ƒh‚Å‚«‚Ü‚¹‚ñB\n\nŽw’è‚µ‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B\n\n‘I‘ð‚³‚ê‚½êŠ[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+					strMsg.Format(L"ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ãƒ•ã‚©ãƒ«ãƒ€ãƒ¼[%s]ä»¥å¤–ã‹ã‚‰ã¯ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ã§ãã¾ã›ã‚“ã€‚\n\næŒ‡å®šã—ãªãŠã—ã¦ãã ã•ã„ã€‚\n\né¸æŠžã•ã‚ŒãŸå ´æ‰€[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
 					::MessageBoxW(hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}
@@ -672,7 +671,7 @@ public:
 			if (strSelPath.Find(strRoot) != 0)
 			{
 				CString strMsg;
-				strMsg.Format(L"%sƒhƒ‰ƒCƒuˆÈŠO‚ÍŽw’è‚Å‚«‚Ü‚¹‚ñB\n\n•Û‘¶‚·‚éêŠ‚©‚ç%s‚ðŽw’è‚µ‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B\n\n‘I‘ð‚³‚ê‚½êŠ[%s]", (LPCWSTR)strRoot, (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+				strMsg.Format(L"%sãƒ‰ãƒ©ã‚¤ãƒ–ä»¥å¤–ã¯æŒ‡å®šã§ãã¾ã›ã‚“ã€‚\n\nä¿å­˜ã™ã‚‹å ´æ‰€ã‹ã‚‰%sã‚’æŒ‡å®šã—ãªãŠã—ã¦ãã ã•ã„ã€‚\n\né¸æŠžã•ã‚ŒãŸå ´æ‰€[%s]", (LPCWSTR)strRoot, (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
 				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 				continue;
 			}
@@ -681,7 +680,7 @@ public:
 			if (strSelPath.Find(strTSG_Upload) == 0)
 			{
 				CString strMsg;
-				strMsg.Format(L"ƒAƒbƒvƒ[ƒhƒtƒHƒ‹ƒ_[[%s]‚É‚Í•Û‘¶‚Å‚«‚Ü‚¹‚ñB\n\nŽw’è‚µ‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B\n\n‘I‘ð‚³‚ê‚½êŠ[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)strSelPath);
+				strMsg.Format(L"ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ãƒ•ã‚©ãƒ«ãƒ€ãƒ¼[%s]ã«ã¯ä¿å­˜ã§ãã¾ã›ã‚“ã€‚\n\næŒ‡å®šã—ãªãŠã—ã¦ãã ã•ã„ã€‚\n\né¸æŠžã•ã‚ŒãŸå ´æ‰€[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)strSelPath);
 				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 				continue;
 			}
@@ -797,7 +796,7 @@ static BOOL WINAPI Hook_GetSaveFileNameW(
 	BOOL bRet = FALSE;
 	try
 	{
-		//Download‹ÖŽ~
+		//Downloadç¦æ­¢
 		if (theApp.m_AppSettings.IsEnableDownloadRestriction())
 		{
 			return FALSE;
@@ -813,22 +812,22 @@ static BOOL WINAPI Hook_GetSaveFileNameW(
 		strPath = strPath.TrimRight('\\');
 		strPath += _T("\\");
 
-		//ƒtƒbƒNŠÖ”‚ð–³Œø
+		//ãƒ•ãƒƒã‚¯é–¢æ•°ã‚’ç„¡åŠ¹
 		lpofn->Flags &= ~OFN_ENABLEHOOK;
-		//ƒ_ƒCƒAƒƒOƒeƒ“ƒvƒŒ[ƒg–³Œø
+		//ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆç„¡åŠ¹
 		lpofn->Flags &= ~OFN_ENABLETEMPLATE;
 
-		//Longƒtƒ@ƒCƒ‹–¼‚ð‹­§
+		//Longãƒ•ã‚¡ã‚¤ãƒ«åã‚’å¼·åˆ¶
 		lpofn->Flags |= OFN_LONGNAMES;
-		//ƒlƒbƒgƒ[ƒNƒ{ƒ^ƒ“‚ð‰B‚·
+		//ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ãƒœã‚¿ãƒ³ã‚’éš ã™
 		lpofn->Flags |= OFN_NONETWORKBUTTON;
 
-		//Å‹ßŽg‚Á‚½ƒtƒ@ƒCƒ‹‚ð’Ç‰Á‚µ‚È‚¢
+		//æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚¡ã‚¤ãƒ«ã‚’è¿½åŠ ã—ãªã„
 		lpofn->Flags |= OFN_DONTADDTORECENT;
-		//ƒvƒŒ[ƒXƒo[‚ð–³Œø
+		//ãƒ—ãƒ¬ãƒ¼ã‚¹ãƒãƒ¼ã‚’ç„¡åŠ¹
 		lpofn->FlagsEx |= OFN_EX_NOPLACESBAR;
 
-		//ƒtƒ@ƒCƒ‹‚ðã‘‚«‚·‚é‚©‚Ç‚¤‚©Šm”F‚·‚éƒvƒƒ“ƒvƒg‚ð•\Ž¦
+		//ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¸Šæ›¸ãã™ã‚‹ã‹ã©ã†ã‹ç¢ºèªã™ã‚‹ãƒ—ãƒ­ãƒ³ãƒ—ãƒˆã‚’è¡¨ç¤º
 		lpofn->Flags |= OFN_OVERWRITEPROMPT;
 
 		CStringW strCaption(theApp.m_strThisAppName);
@@ -848,7 +847,7 @@ static BOOL WINAPI Hook_GetSaveFileNameW(
 			strRoot.MakeUpper();
 			if (strSelPath.Find(strRoot) != 0)
 			{
-				strMsg.Format(L"%sƒhƒ‰ƒCƒuˆÈŠO‚ÍŽw’è‚Å‚«‚Ü‚¹‚ñB\n\n•Û‘¶‚·‚éêŠ‚©‚ç%s‚ðŽw’è‚µ‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B\n\n‘I‘ð‚³‚ê‚½êŠ[%s]", (LPCWSTR)strRoot, (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+				strMsg.Format(L"%sãƒ‰ãƒ©ã‚¤ãƒ–ä»¥å¤–ã¯æŒ‡å®šã§ãã¾ã›ã‚“ã€‚\n\nä¿å­˜ã™ã‚‹å ´æ‰€ã‹ã‚‰%sã‚’æŒ‡å®šã—ãªãŠã—ã¦ãã ã•ã„ã€‚\n\né¸æŠžã•ã‚ŒãŸå ´æ‰€[%s]", (LPCWSTR)strRoot, (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
 				::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 				continue;
 			}
@@ -856,7 +855,7 @@ static BOOL WINAPI Hook_GetSaveFileNameW(
 			CStringW strTSG_Upload = strRoot + L"UPLOAD\\";
 			if (strSelPath.Find(strTSG_Upload) == 0)
 			{
-				strMsg.Format(L"ƒAƒbƒvƒ[ƒhƒtƒHƒ‹ƒ_[[%s]‚É‚Í•Û‘¶‚Å‚«‚Ü‚¹‚ñB\n\nŽw’è‚µ‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B\n\n‘I‘ð‚³‚ê‚½êŠ[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)strSelPath);
+				strMsg.Format(L"ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ãƒ•ã‚©ãƒ«ãƒ€ãƒ¼[%s]ã«ã¯ä¿å­˜ã§ãã¾ã›ã‚“ã€‚\n\næŒ‡å®šã—ãªãŠã—ã¦ãã ã•ã„ã€‚\n\né¸æŠžã•ã‚ŒãŸå ´æ‰€[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)strSelPath);
 				::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 				continue;
 			}
@@ -876,12 +875,12 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 	BOOL bRet = FALSE;
 	try
 	{
-		//ŒÄ‚Ño‚µ‚à‚Æ‚ðŠm”FAe‚Ìe‚ªNULL‚¾‚Á‚½‚çChronos‚ÌÝ’è‰æ–Ê‚©‚ç
+		//å‘¼ã³å‡ºã—ã‚‚ã¨ã‚’ç¢ºèªã€è¦ªã®è¦ªãŒNULLã ã£ãŸã‚‰Chronosã®è¨­å®šç”»é¢ã‹ã‚‰
 		HWND hWindowOwner = GetParent(lpofn->hwndOwner);
 		HWND hWindowParent = {0};
 		if (hWindowOwner)
 			hWindowParent = GetParent(hWindowOwner);
-		//hWindowParent‚ªNULL‚Ìê‡‚ÍA‚»‚Ì‚Ü‚Ü
+		//hWindowParentãŒNULLã®å ´åˆã¯ã€ãã®ã¾ã¾
 		if (!hWindowParent)
 		{
 			bRet = pORG_GetOpenFileNameW(lpofn);
@@ -891,10 +890,10 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 		CStringW strCaption(theApp.m_strThisAppName);
 		CStringW strMsg;
 
-		//Upload‹ÖŽ~
+		//Uploadç¦æ­¢
 		if (theApp.m_AppSettings.IsEnableUploadRestriction())
 		{
-			strMsg = (L"ƒtƒ@ƒCƒ‹ ƒAƒbƒvƒ[ƒh‚ÍAƒVƒXƒeƒ€ŠÇ—ŽÒ‚É‚æ‚è§ŒÀ‚³‚ê‚Ä‚¢‚Ü‚·B");
+			strMsg = (L"ãƒ•ã‚¡ã‚¤ãƒ« ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ã¯ã€ã‚·ã‚¹ãƒ†ãƒ ç®¡ç†è€…ã«ã‚ˆã‚Šåˆ¶é™ã•ã‚Œã¦ã„ã¾ã™ã€‚");
 			if (hWindowParent)
 				theApp.SB_MessageBox(hWindowParent, strMsg, NULL, MB_OK | MB_ICONWARNING, TRUE);
 			else
@@ -912,7 +911,7 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 		CString strRootPath;
 		if (theApp.IsSGMode())
 		{
-			//UploadTab‚ðŽg‚¤ê‡‚ÍAB:\\Upload‚É‚·‚é
+			//UploadTabã‚’ä½¿ã†å ´åˆã¯ã€B:\\Uploadã«ã™ã‚‹
 			if (theApp.m_AppSettings.IsShowUploadTab())
 			{
 				strRootPath = theApp.m_AppSettings.GetRootPath();
@@ -922,7 +921,7 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 				if (!theApp.IsFolderExists(strRootPath))
 					strRootPath = _T("B:\\");
 			}
-			//UploadTab‚ðŽg‚í‚È‚¢ê‡‚ÍAO:\\‚É‚·‚é
+			//UploadTabã‚’ä½¿ã‚ãªã„å ´åˆã¯ã€O:\\ã«ã™ã‚‹
 			else
 			{
 				strRootPath = theApp.m_AppSettings.GetUploadBasePath();
@@ -931,22 +930,22 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 			}
 			strPath = strRootPath;
 
-			//ƒtƒbƒNŠÖ”‚ð–³Œø
+			//ãƒ•ãƒƒã‚¯é–¢æ•°ã‚’ç„¡åŠ¹
 			lpofn->Flags &= ~OFN_ENABLEHOOK;
-			//ƒ_ƒCƒAƒƒOƒeƒ“ƒvƒŒ[ƒg–³Œø
+			//ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒ†ãƒ³ãƒ—ãƒ¬ãƒ¼ãƒˆç„¡åŠ¹
 			lpofn->Flags &= ~OFN_ENABLETEMPLATE;
 
-			//Longƒtƒ@ƒCƒ‹–¼‚ð‹­§
+			//Longãƒ•ã‚¡ã‚¤ãƒ«åã‚’å¼·åˆ¶
 			lpofn->Flags |= OFN_LONGNAMES;
-			//ƒlƒbƒgƒ[ƒNƒ{ƒ^ƒ“‚ð‰B‚·
+			//ãƒãƒƒãƒˆãƒ¯ãƒ¼ã‚¯ãƒœã‚¿ãƒ³ã‚’éš ã™
 			lpofn->Flags |= OFN_NONETWORKBUTTON;
 
-			//Å‹ßŽg‚Á‚½ƒtƒ@ƒCƒ‹‚ð’Ç‰Á‚µ‚È‚¢
+			//æœ€è¿‘ä½¿ã£ãŸãƒ•ã‚¡ã‚¤ãƒ«ã‚’è¿½åŠ ã—ãªã„
 			lpofn->Flags |= OFN_DONTADDTORECENT;
-			//ƒvƒŒ[ƒXƒo[‚ð–³Œø
+			//ãƒ—ãƒ¬ãƒ¼ã‚¹ãƒãƒ¼ã‚’ç„¡åŠ¹
 			lpofn->FlagsEx |= OFN_EX_NOPLACESBAR;
 
-			//ƒtƒ@ƒCƒ‹‚ðã‘‚«‚·‚é‚©‚Ç‚¤‚©Šm”F‚·‚éƒvƒƒ“ƒvƒg‚ð•\Ž¦
+			//ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ä¸Šæ›¸ãã™ã‚‹ã‹ã©ã†ã‹ç¢ºèªã™ã‚‹ãƒ—ãƒ­ãƒ³ãƒ—ãƒˆã‚’è¡¨ç¤º
 			lpofn->Flags |= OFN_OVERWRITEPROMPT;
 		}
 		else
@@ -982,7 +981,7 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 				strRoot.MakeUpper();
 				if (strSelPath.Find(strRoot) != 0)
 				{
-					strMsg.Format(L"ƒAƒbƒvƒ[ƒhƒtƒHƒ‹ƒ_[[%s]ˆÈŠO‚©‚ç‚ÍƒAƒbƒvƒ[ƒh‚Å‚«‚Ü‚¹‚ñB\n\nŽw’è‚µ‚È‚¨‚µ‚Ä‚­‚¾‚³‚¢B\n\n‘I‘ð‚³‚ê‚½êŠ[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+					strMsg.Format(L"ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ãƒ•ã‚©ãƒ«ãƒ€ãƒ¼[%s]ä»¥å¤–ã‹ã‚‰ã¯ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ã§ãã¾ã›ã‚“ã€‚\n\næŒ‡å®šã—ãªãŠã—ã¦ãã ã•ã„ã€‚\n\né¸æŠžã•ã‚ŒãŸå ´æ‰€[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
 					::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}
@@ -1014,7 +1013,7 @@ static PIDLIST_ABSOLUTE WINAPI Hook_SHBrowseForFolderW(
 {
 	CStringW strCaption(theApp.m_strThisAppName);
 	CStringW strMsg;
-	strMsg.Format(L"ƒtƒHƒ‹ƒ_[‚ÌŽQÆ‹@”\‚Í—˜—p‚Å‚«‚Ü‚¹‚ñB");
+	strMsg.Format(L"ãƒ•ã‚©ãƒ«ãƒ€ãƒ¼ã®å‚ç…§æ©Ÿèƒ½ã¯åˆ©ç”¨ã§ãã¾ã›ã‚“ã€‚");
 	::MessageBoxW(lpbi->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 
 	return NULL;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/79

# What this PR does / why we need it:

* 不要なエラーダイアログが出力されないように修正。
  * 設定のカスタムスクリプト->新規作成-> 「...」でファイルを開くダイアログを開く場合のみ発生する。
* ThinAppで動作しているファイルを開くダイアログで、左ペインに最近使ったファイルなどのリストが出ないように修正

# How to verify the fixed issue:

## The steps to verify:

ネイティブ版とThinApp版でそれぞれ以下の確認を行う。

1. 設定の カスタムスクリプト->新規作成-> 「...」でファイルを開くダイアログを開く
2. 設定の リダイレクト設定 -> 指定ブラウザー1 -> 参照からファイルを開くダイアログを開く
3. どこでも良いので、WEBページ上で（設定画面以外で）ファイルを開くダイアログを開く
    * 設定のカスタムスクリプト->新規作成-> 「...」で参照したときのみ出力される
4. どこでも良いので、ファイルの保存を行う

## Expected result:

**ネイティブ版Chronos**

1.1. エラーダイアログが出ないこと
1.2. ファイルを開くダイアログの左ペインが表示されていること
1.3. ローカルのファイルが参照できていること

2.1. エラーダイアログが出ないこと
2.2. ファイルを開くダイアログの左ペインが表示されていること
2.3. ローカルのファイルが参照できていること

3.1. エラーダイアログが出ないこと
3.2. ファイルを開くダイアログの左ペインが表示されていること
3.3. ローカルのファイルが参照できていること

4.1. エラーダイアログが出ないこと
4.2. ファイルを保存ダイアログの左ペインが表示されていること
4.3. ローカルのフォルダが指定できていること

**ThinApp版Chronos**

1.1. エラーダイアログが出ないこと
1.2. ファイルを開くダイアログの左ペインが表示されていないこと ※1
1.3. 仮想環境のファイルのみが参照できていること

※1 以下の画像のような状態になっていること

![image](https://github.com/ThinBridge/Chronos/assets/15982708/7ec69386-03b3-43f2-bafe-81df4cc2dc6a)


2.1. エラーダイアログが出ないこと
2.2. ファイルを開くダイアログの左ペインが表示されていないこと
2.3. 仮想環境のファイルのみが参照できていること

3.1. エラーダイアログが出ないこと
3.2. ファイルを開くダイアログの左ペインが表示されていないこと
3.3. 仮想環境のファイルのみが参照できていること

4.1. エラーダイアログが出ないこと
4.2. ファイルを保存ダイアログの左ペインが表示されていないこと
4.3. 仮想環境のフォルダのみが参照できていること