### PR TITLE
[WIP] Modify some context menu text to "Link" from "Image" to match its actual functionality

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -1028,8 +1028,8 @@ BEGIN
     IDS_STRING_LOW_SYSTEM_RESOURCE_SUGGEST 
                             "警告:システムリソースが不足しています。\n他のウィンドウを閉じるか、アプリケーション(%s)を再起動して下さい。"
     IDS_STRING_CONFIRM_CLOSE_VOS_PROCESS "VOSで実行中のプロセスを強制終了してもよろしいですか？"
-    ID_CONTEXT_MENU_OPEN_LINK_TAB "新しいタブで開く"
-    ID_CONTEXT_MENU_OPEN_LINK_TAB_INACTIVE "新しいタブで開く(非アクティブ)"
+    ID_CONTEXT_MENU_OPEN_LINK_TAB "新しいタブでリンクを開く"
+    ID_CONTEXT_MENU_OPEN_LINK_TAB_INACTIVE "新しいタブでリンクを開く(非アクティブ)"
     ID_CONTEXT_MENU_OPEN_LINK_WINDOW "新しいウィンドウで開く"
     ID_CONTEXT_MENU_OPEN_LINK_WINDOW_INACTIVE "新しいウィンドウで開く(非アクティブ)"
     ID_CONTEXT_MENU_COPY_LINK "リンクのアドレスをコピー"
@@ -2353,8 +2353,8 @@ BEGIN
                             "SYSTEM Resource allocation failuer. Please close window or restart the application (%s)."
     IDS_STRING_CONFIRM_CLOSE_VOS_PROCESS 
                             "Do you want the process running on VOS to be terminated?"
-    ID_CONTEXT_MENU_OPEN_LINK_TAB "Open in New Tab"
-    ID_CONTEXT_MENU_OPEN_LINK_TAB_INACTIVE "Open in New Background Tab"
+    ID_CONTEXT_MENU_OPEN_LINK_TAB "Open Link in New Tab"
+    ID_CONTEXT_MENU_OPEN_LINK_TAB_INACTIVE "Open Link in New Background Tab"
     ID_CONTEXT_MENU_OPEN_LINK_WINDOW "Open in New Window"
     ID_CONTEXT_MENU_OPEN_LINK_WINDOW_INACTIVE "Open in New Background Window"
     ID_CONTEXT_MENU_COPY_LINK "Copy Link URL"


### PR DESCRIPTION
# Which issue(s) this PR fixes:

Chrono-SG Issue 22: The context menu on a text hyperlink shows "Open Image" instead of "Open Link." 

# What this PR does / why we need it:

By modifying text to match what it means and how it acts.

# How to verify the fixed issue:

Right-click on a text hyperlink.

## The steps to verify:

1. Right-click on a text hyperlink, which includes no images.
2. See the text of context menu

## Expected result:

The first two items of the context menu should be:
+ Open Link in New Tab
+ Open Link in New Background Tab

In Japanese context, they should be:
+ 新しいタブでリンクを開く
+ 新しいタブでリンクを開く(非アクティブ)
