### PR TITLE
Enable to work the `/MIN` option when rebooting Chronos

### DIFF
--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -661,8 +661,10 @@ BOOL CMainFrame::ParseCommandLineAndNewWnd(CString strCommandLine)
 		m_bAtomOpen = FALSE;
 	}
 
+	BOOL minMode = FALSE;
 	if (OptionParam.CompareNoCase(_T("/MIN")) == 0)
 	{
+		minMode = TRUE;
 		pFrame->ShowWindow(SW_MINIMIZE);
 	}
 	else if (OptionParam.CompareNoCase(_T("/MAX")) == 0)
@@ -684,7 +686,7 @@ BOOL CMainFrame::ParseCommandLineAndNewWnd(CString strCommandLine)
 		;
 	}
 	//Newアクティブ(前面)に表示する。
-	if (theApp.m_bNewInstanceParam)
+	if (theApp.m_bNewInstanceParam && !minMode)
 		SBUtil::SetAbsoluteForegroundWindow(pFrame->m_hWnd, TRUE);
 
 	return TRUE;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/12

# What this PR does / why we need it:


ThinApp化したChronos（Chronos-SG）を終了しようとした際に、「Chronos SystemGuradを終了してもよろしいですか？」のダイアログの選択で「いいえ」を押下した場合、Chronos-SGが再起動する。

そのとき、起動関連設定->起動時の表示パラメータ に `/MIN` を指定していても最小化された状態で開かない問題の修正。

パラメータは「起動時の表示」である一方、この問題は上記の手順で再起動した場合のみ発生する。
そのため、これはこういう仕様と考えて、このパッチを適用しなくても良いかもしれない。

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

* ChronosをThinApp化する
* 起動関連設定->起動時の表示パラメータ に `/MIN` を指定する
* その後、右上のバツなどからChronosを終了しようとし、「Chronos SystemGuradを終了してもよろしいですか？」のダイアログの選択で「いいえ」を押下してChronosを再起動する

## Expected result:

* `/MIN` オプションが働き、最小化された状態で再起動すること