### PR TITLE
Disable clang-format for SB_CHROME_VERSION

### DIFF
--- a/sbcommon.h
+++ b/sbcommon.h
@@ -55,7 +55,13 @@ static TCHAR gstrThisAppNameR[] = _T("Chronos");
 static TCHAR gstrThisAppNameSG[] = _T("Chronos SystemGuard");
 static TCHAR sgSZB_UA_START[] = _T("Mozilla/5.0 (");
 
-#define SB_CHROME_VERSION MAKE_STRING(CHROME_VERSION_MAJOR) "." MAKE_STRING(CHROME_VERSION_MINOR) "." MAKE_STRING(CHROME_VERSION_BUILD) "." MAKE_STRING(CHROME_VERSION_PATCH)
+// clang-format off
+#define SB_CHROME_VERSION MAKE_STRING(CHROME_VERSION_MAJOR) "." \
+                          MAKE_STRING(CHROME_VERSION_MINOR) "." \
+                          MAKE_STRING(CHROME_VERSION_BUILD) "." \
+                          MAKE_STRING(CHROME_VERSION_PATCH)
+// clang-format on
+
 //2021-01-07Googleにログインできない CEF経由ではNGになった。
 //調査結果、FirefoxにすればOK, Edge/87.0.0.0をつけてもOK
 //デフォルトのUAをEdgeに変更する対応にする。


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/77

# What this PR does / why we need it:

SB_CHROME_VERSION の自動整形が上手くいかないので、clang-formatの対象から除外するように修正。
本来はclang-formatの設定を変更していい感じの整形結果になるようにするべきだと思うが、いい感じにできそうな設定が見つけられなかったため、無視するように変更。

参考: https://clang.llvm.org/docs/ClangFormatStyleOptions.html

# How to verify the fixed issue:

## The steps to verify:

DevToolsのネットワークタブを開き、適当な通信を選んで User-Agentの項目を確認する

## Expected result:

User-AgentのChromeバージョンが最新のChromiumのものになっていることを確認