### PR TITLE
Bump version number to 13.0.112.1

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -576,8 +576,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 13,0,112,0
- PRODUCTVERSION 13,0,112,0
+ FILEVERSION 13,0,112,1
+ PRODUCTVERSION 13,0,112,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -593,12 +593,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "13.0.112.0"
+            VALUE "FileVersion", "13.0.112.1"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "13.0.112.0"
+            VALUE "ProductVersion", "13.0.112.1"
         END
     END
     BLOCK "VarFileInfo"
@@ -1893,8 +1893,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 13,0,112,0
- PRODUCTVERSION 13,0,112,0
+ FILEVERSION 13,0,112,1
+ PRODUCTVERSION 13,0,112,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -1910,12 +1910,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "13.0.112.0"
+            VALUE "FileVersion", "13.0.112.1"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "13.0.112.0"
+            VALUE "ProductVersion", "13.0.112.1"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

リリース用にバージョンを 13.0.112.1 に更新。

# How to verify the fixed issue:

## The steps to verify:

* Chronosを起動し、ヘルプからChronosのバージョンを確認
  * 日英の両方で確認

## Expected result:

バージョンが13.0.112.1になっていること
