### PR TITLE
Save only URL for window status file

### DIFF
--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -2709,7 +2709,6 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 		if (out.Open(strPath, uiFlg))
 		{
 			CString strURL;
-			CString strTitle;
 			CString strData;
 
 			POSITION pos1 = {0};
@@ -2745,9 +2744,6 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 				strURL = pView->GetLocationURL();
 				strURL.TrimLeft();
 				strURL.TrimRight();
-				strTitle = pView->m_strTitle;
-				strTitle.TrimLeft();
-				strTitle.TrimRight();
 				if (SBUtil::IsURL_HTTP(strURL))
 				{
 					if (iCnt == 0)
@@ -2758,15 +2754,8 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 
 					//CStdioFileはMBCSで書き込もうとする一方、入力値はUnicodeなので、
 					//タイトルに特殊文字が含まれていると文字変換に失敗して上手く書き込めない場合がある。
-					//なので、変換に失敗する場合はタイトルを書き込まないようにする。
-					if (CheckConvertabilityToMBCS(strTitle))
-					{
-						strData.Format(_T("%s\t%s\n"), (LPCTSTR)strTitle, (LPCTSTR)strURL);
-					}
-					else
-					{
-						strData.Format(_T("%s\n"), (LPCTSTR)strURL);
-					}
+					//そのため、タイトルは書きこまずURLのみとする
+					strData.Format(_T("%s\n"), (LPCTSTR)strURL);
 
 					out.WriteString(strData);
 					iCnt++;

--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -2755,7 +2755,19 @@ void CMainFrame::SaveWindowList(LPCTSTR strPath, BOOL bAppendMode /*=FALSE*/)
 						//日時を初めの行に出力する。
 						out.WriteString(strWriteTime);
 					}
-					strData.Format(_T("%s\t%s\n"), (LPCTSTR)strTitle, (LPCTSTR)strURL);
+
+					//CStdioFileはMBCSで書き込もうとする一方、入力値はUnicodeなので、
+					//タイトルに特殊文字が含まれていると文字変換に失敗して上手く書き込めない場合がある。
+					//なので、変換に失敗する場合はタイトルを書き込まないようにする。
+					if (CheckConvertabilityToMBCS(strTitle))
+					{
+						strData.Format(_T("%s\t%s\n"), (LPCTSTR)strTitle, (LPCTSTR)strURL);
+					}
+					else
+					{
+						strData.Format(_T("%s\n"), (LPCTSTR)strURL);
+					}
+
 					out.WriteString(strData);
 					iCnt++;
 				}

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -244,13 +244,6 @@ static void getTimeStringEx(LPFILETIME ftTime, CString& str)
 	return;
 }
 
-static BOOL CheckConvertabilityToMBCS(CString target)
-{
-	CStringA strA = target;
-	CString str = strA;
-	return str.Compare(target) == 0;
-}
-
 /////////////////////////////////////////////////////////////////////
 #include <winternl.h>
 #include <tlhelp32.h>

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -244,6 +244,13 @@ static void getTimeStringEx(LPFILETIME ftTime, CString& str)
 	return;
 }
 
+static BOOL CheckConvertabilityToMBCS(CString target)
+{
+	CStringA strA = target;
+	CString str = strA;
+	return str.Compare(target) == 0;
+}
+
 /////////////////////////////////////////////////////////////////////
 #include <winternl.h>
 #include <tlhelp32.h>


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/18

# What this PR does / why we need it:

表示しているURLのタイトルに[MBCS](https://learn.microsoft.com/ja-jp/cpp/atl-mfc-shared/unicode-and-multibyte-character-set-mbcs-support?view=msvc-170#mfc-support-for-mbcs-strings)で使えない文字が含まれていると、ウィンドウの保存ができていなかった。
これは、ファイル書き込みに[CStdioFile](https://learn.microsoft.com/ja-jp/cpp/mfc/reference/cstdiofile-class?view=msvc-170)を使っているのだが、これがMBCSを前提としているため。
内部的にはUnicodeで、それをCStdioFileで書き込むときに上手く変換できず、そこで文字列が途切れて正しく保存できていなかった。

# How to verify the fixed issue:

## The steps to verify:

1. https://www.mozilla.org/ を開く
2. メニュー -> ファイル -> ウィンドウの保存からウィンドウを保存する
3. メニュー -> ファイル -> ウィンドウの復元からウィンドウを復元する

## Expected result:

* https://www.mozilla.org/ が復元されること
* https://www.mozilla.org/ のタイトルが表示されていること
