### PR TITLE
Bump version to 13.1.112.0

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -590,8 +590,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 13,0,112,1
- PRODUCTVERSION 13,0,112,1
+ FILEVERSION 13,1,112,0
+ PRODUCTVERSION 13,1,112,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -607,12 +607,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "13.0.112.1"
+            VALUE "FileVersion", "13.1.112.0"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "13.0.112.1"
+            VALUE "ProductVersion", "13.1.112.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -1947,8 +1947,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 13,0,112,1
- PRODUCTVERSION 13,0,112,1
+ FILEVERSION 13,1,112,0
+ PRODUCTVERSION 13,1,112,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -1964,12 +1964,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "13.0.112.1"
+            VALUE "FileVersion", "13.1.112.0"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "13.0.112.1"
+            VALUE "ProductVersion", "13.1.112.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Bump version to 13.1.112.0

# How to verify the fixed issue:

## The steps to verify:

1. ヘルプ -> バージョン情報から、Chronosのバージョンを確認する

## Expected result:

* `13.1.112.0` であること
![image](https://github.com/ThinBridge/Chronos/assets/15982708/a6a725e7-b692-4130-8a02-19b8742e3a13)
