### PR TITLE
Follow to latest beta CEF

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -588,9 +588,9 @@ BOOL CChildView::IsRedirectURLChk(const CString& strURL, BOOL bTop)
 		CefString cfHost(&cfURLparts.host);
 		CefString cfPath(&cfURLparts.path);
 
-		CString strScheme((LPCTSTR)cfScheme.c_str());
-		CString strHost((LPCTSTR)cfHost.c_str());
-		CString strPath((LPCTSTR)cfPath.c_str());
+		CString strScheme((LPCWSTR)cfScheme.c_str());
+		CString strHost((LPCWSTR)cfHost.c_str());
+		CString strPath((LPCWSTR)cfPath.c_str());
 
 		//http httpsのみフィルターを利用する。about: notes: vwmare-view: mailto:を考慮する。
 		if (strScheme.Find(_T("http")) != 0) //http|https
@@ -2430,7 +2430,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 				if (CefParseURL(cefURL, cfURLpa))
 				{
 					CefString cfHost(&cfURLpa.host);
-					strHost = (LPCTSTR)cfHost.c_str();
+					strHost = (LPCWSTR)cfHost.c_str();
 				}
 			}
 			if (theApp.m_pLogDisp)

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -588,9 +588,9 @@ BOOL CChildView::IsRedirectURLChk(const CString& strURL, BOOL bTop)
 		CefString cfHost(&cfURLparts.host);
 		CefString cfPath(&cfURLparts.path);
 
-		CString strScheme(cfScheme.c_str());
-		CString strHost(cfHost.c_str());
-		CString strPath(cfPath.c_str());
+		CString strScheme(cfScheme.ToWString().c_str());
+		CString strHost(cfHost.ToWString().c_str());
+		CString strPath(cfPath.ToWString().c_str());
 
 		//http httpsのみフィルターを利用する。about: notes: vwmare-view: mailto:を考慮する。
 		if (strScheme.Find(_T("http")) != 0) //http|https
@@ -2430,7 +2430,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 				if (CefParseURL(cefURL, cfURLpa))
 				{
 					CefString cfHost(&cfURLpa.host);
-					strHost = cfHost.c_str();
+					strHost = cfHost.ToWString().c_str();
 				}
 			}
 			if (theApp.m_pLogDisp)

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -588,9 +588,9 @@ BOOL CChildView::IsRedirectURLChk(const CString& strURL, BOOL bTop)
 		CefString cfHost(&cfURLparts.host);
 		CefString cfPath(&cfURLparts.path);
 
-		CString strScheme(cfScheme.ToWString().c_str());
-		CString strHost(cfHost.ToWString().c_str());
-		CString strPath(cfPath.ToWString().c_str());
+		CString strScheme(cfScheme.c_str());
+		CString strHost(cfHost.c_str());
+		CString strPath(cfPath.c_str());
 
 		//http httpsのみフィルターを利用する。about: notes: vwmare-view: mailto:を考慮する。
 		if (strScheme.Find(_T("http")) != 0) //http|https
@@ -2430,7 +2430,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 				if (CefParseURL(cefURL, cfURLpa))
 				{
 					CefString cfHost(&cfURLpa.host);
-					strHost = cfHost.ToWString().c_str();
+					strHost = cfHost.c_str();
 				}
 			}
 			if (theApp.m_pLogDisp)

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -588,9 +588,9 @@ BOOL CChildView::IsRedirectURLChk(const CString& strURL, BOOL bTop)
 		CefString cfHost(&cfURLparts.host);
 		CefString cfPath(&cfURLparts.path);
 
-		CString strScheme(cfScheme.c_str());
-		CString strHost(cfHost.c_str());
-		CString strPath(cfPath.c_str());
+		CString strScheme((LPCTSTR)cfScheme.c_str());
+		CString strHost((LPCTSTR)cfHost.c_str());
+		CString strPath((LPCTSTR)cfPath.c_str());
 
 		//http httpsのみフィルターを利用する。about: notes: vwmare-view: mailto:を考慮する。
 		if (strScheme.Find(_T("http")) != 0) //http|https
@@ -2430,7 +2430,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 				if (CefParseURL(cefURL, cfURLpa))
 				{
 					CefString cfHost(&cfURLpa.host);
-					strHost = cfHost.c_str();
+					strHost = (LPCTSTR)cfHost.c_str();
 				}
 			}
 			if (theApp.m_pLogDisp)

--- a/BroView.h
+++ b/BroView.h
@@ -71,7 +71,7 @@ public:
 		{
 			CefString strURL;
 			strURL = m_cefBrowser->GetMainFrame()->GetURL();
-			strRet = strURL.ToWString().c_str();
+			strRet = strURL.c_str();
 		}
 		return strRet;
 	}

--- a/BroView.h
+++ b/BroView.h
@@ -71,7 +71,7 @@ public:
 		{
 			CefString strURL;
 			strURL = m_cefBrowser->GetMainFrame()->GetURL();
-			strRet = strURL.c_str();
+			strRet = strURL.ToWString().c_str();
 		}
 		return strRet;
 	}

--- a/BroView.h
+++ b/BroView.h
@@ -71,7 +71,7 @@ public:
 		{
 			CefString strURL;
 			strURL = m_cefBrowser->GetMainFrame()->GetURL();
-			strRet = strURL.c_str();
+			strRet = (LPCTSTR)strURL.c_str();
 		}
 		return strRet;
 	}

--- a/BroView.h
+++ b/BroView.h
@@ -71,7 +71,7 @@ public:
 		{
 			CefString strURL;
 			strURL = m_cefBrowser->GetMainFrame()->GetURL();
-			strRet = (LPCTSTR)strURL.c_str();
+			strRet = (LPCWSTR)strURL.c_str();
 		}
 		return strRet;
 	}

--- a/DlgCertification.cpp
+++ b/DlgCertification.cpp
@@ -85,13 +85,13 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	CString principalString;
 	std::vector<CefString> values;
 	principalString += _T("CN=");
-	principalString += principal->GetCommonName().c_str();
+	principalString += principal->GetCommonName().ToWString().c_str();
 	principalString += _T(", O=");
 	principal->GetOrganizationNames(values);
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.c_str();
+		principalString += value.ToWString().c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
@@ -102,29 +102,31 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.c_str();
+		principalString += value.ToWString().c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
 		}
 	}
+#if CHROME_VERSION_MAJOR < 115
 	principalString += _T(", STREET=");
 	principal->GetStreetAddresses(values);
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.c_str();
+		principalString += value.ToWString().c_str();
 		if (i > 0)
 		{
 			principalString += _T("-");
 		}
 	}
+#endif
 	principalString += _T(", L=");
-	principalString += principal->GetLocalityName().c_str();
+	principalString += principal->GetLocalityName().ToWString().c_str();
 	principalString += _T(", ST=");
-	principalString += principal->GetStateOrProvinceName().c_str();
+	principalString += principal->GetStateOrProvinceName().ToWString().c_str();
 	principalString += _T(", C=");
-	principalString += principal->GetCountryName().c_str();
+	principalString += principal->GetCountryName().ToWString().c_str();
 	return principalString;
 }
 
@@ -186,7 +188,7 @@ void CDlgCertification::OnBnClickedOk()
 BOOL CDlgCertification::OnInitDialog()
 {
 	BOOL superResult = CDialogEx::OnInitDialog();
-	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, m_host.c_str());
+	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, m_host.ToWString().c_str());
 
 	for (CefRefPtr<CefX509Certificate> certificate : m_certificates)
 	{
@@ -194,7 +196,7 @@ BOOL CDlgCertification::OnInitDialog()
 		CString displayItemName;
 		displayItemName.Format(
 		    _T("%s [%s]"),
-		    (LPCTSTR)certificate->GetSubject()->GetDisplayName().c_str(),
+		    (LPCTSTR)certificate->GetSubject()->GetDisplayName().ToWString().c_str(),
 		    (LPCTSTR)serialNumber);
 
 		certificationComboBox.AddString(displayItemName);

--- a/DlgCertification.cpp
+++ b/DlgCertification.cpp
@@ -85,13 +85,13 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	CString principalString;
 	std::vector<CefString> values;
 	principalString += _T("CN=");
-	principalString += principal->GetCommonName().ToWString().c_str();
+	principalString += principal->GetCommonName().c_str();
 	principalString += _T(", O=");
 	principal->GetOrganizationNames(values);
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.ToWString().c_str();
+		principalString += value.c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
@@ -102,7 +102,7 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.ToWString().c_str();
+		principalString += value.c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
@@ -114,7 +114,7 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.ToWString().c_str();
+		principalString += value.c_str();
 		if (i > 0)
 		{
 			principalString += _T("-");
@@ -122,11 +122,11 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	}
 #endif
 	principalString += _T(", L=");
-	principalString += principal->GetLocalityName().ToWString().c_str();
+	principalString += principal->GetLocalityName().c_str();
 	principalString += _T(", ST=");
-	principalString += principal->GetStateOrProvinceName().ToWString().c_str();
+	principalString += principal->GetStateOrProvinceName().c_str();
 	principalString += _T(", C=");
-	principalString += principal->GetCountryName().ToWString().c_str();
+	principalString += principal->GetCountryName().c_str();
 	return principalString;
 }
 
@@ -188,7 +188,7 @@ void CDlgCertification::OnBnClickedOk()
 BOOL CDlgCertification::OnInitDialog()
 {
 	BOOL superResult = CDialogEx::OnInitDialog();
-	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, m_host.ToWString().c_str());
+	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, m_host.c_str());
 
 	for (CefRefPtr<CefX509Certificate> certificate : m_certificates)
 	{
@@ -196,7 +196,7 @@ BOOL CDlgCertification::OnInitDialog()
 		CString displayItemName;
 		displayItemName.Format(
 		    _T("%s [%s]"),
-		    (LPCTSTR)certificate->GetSubject()->GetDisplayName().ToWString().c_str(),
+		    (LPCTSTR)certificate->GetSubject()->GetDisplayName().c_str(),
 		    (LPCTSTR)serialNumber);
 
 		certificationComboBox.AddString(displayItemName);

--- a/DlgCertification.cpp
+++ b/DlgCertification.cpp
@@ -85,13 +85,13 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	CString principalString;
 	std::vector<CefString> values;
 	principalString += _T("CN=");
-	principalString += (LPCTSTR)principal->GetCommonName().c_str();
+	principalString += (LPCWSTR)principal->GetCommonName().c_str();
 	principalString += _T(", O=");
 	principal->GetOrganizationNames(values);
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += (LPCTSTR)value.c_str();
+		principalString += (LPCWSTR)value.c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
@@ -102,7 +102,7 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += (LPCTSTR)value.c_str();
+		principalString += (LPCWSTR)value.c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
@@ -114,7 +114,7 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += (LPCTSTR)value.c_str();
+		principalString += (LPCWSTR)value.c_str();
 		if (i > 0)
 		{
 			principalString += _T("-");
@@ -122,11 +122,11 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	}
 #endif
 	principalString += _T(", L=");
-	principalString += (LPCTSTR)principal->GetLocalityName().c_str();
+	principalString += (LPCWSTR)principal->GetLocalityName().c_str();
 	principalString += _T(", ST=");
-	principalString += (LPCTSTR)principal->GetStateOrProvinceName().c_str();
+	principalString += (LPCWSTR)principal->GetStateOrProvinceName().c_str();
 	principalString += _T(", C=");
-	principalString += (LPCTSTR)principal->GetCountryName().c_str();
+	principalString += (LPCWSTR)principal->GetCountryName().c_str();
 	return principalString;
 }
 
@@ -188,7 +188,7 @@ void CDlgCertification::OnBnClickedOk()
 BOOL CDlgCertification::OnInitDialog()
 {
 	BOOL superResult = CDialogEx::OnInitDialog();
-	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, (LPCTSTR)m_host.c_str());
+	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, (LPCWSTR)m_host.c_str());
 
 	for (CefRefPtr<CefX509Certificate> certificate : m_certificates)
 	{
@@ -196,7 +196,7 @@ BOOL CDlgCertification::OnInitDialog()
 		CString displayItemName;
 		displayItemName.Format(
 		    _T("%s [%s]"),
-		    (LPCTSTR)certificate->GetSubject()->GetDisplayName().c_str(),
+		    (LPCWSTR)certificate->GetSubject()->GetDisplayName().c_str(),
 		    (LPCTSTR)serialNumber);
 
 		certificationComboBox.AddString(displayItemName);

--- a/DlgCertification.cpp
+++ b/DlgCertification.cpp
@@ -85,13 +85,13 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	CString principalString;
 	std::vector<CefString> values;
 	principalString += _T("CN=");
-	principalString += principal->GetCommonName().c_str();
+	principalString += (LPCTSTR)principal->GetCommonName().c_str();
 	principalString += _T(", O=");
 	principal->GetOrganizationNames(values);
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.c_str();
+		principalString += (LPCTSTR)value.c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
@@ -102,7 +102,7 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.c_str();
+		principalString += (LPCTSTR)value.c_str();
 		if (i > 0)
 		{
 			principalString += _T(" ");
@@ -114,7 +114,7 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	for (size_t i = 0; i < values.size(); i++)
 	{
 		CefString value = values[i];
-		principalString += value.c_str();
+		principalString += (LPCTSTR)value.c_str();
 		if (i > 0)
 		{
 			principalString += _T("-");
@@ -122,11 +122,11 @@ CString CDlgCertification::GetPrincipalString(const CefRefPtr<CefX509CertPrincip
 	}
 #endif
 	principalString += _T(", L=");
-	principalString += principal->GetLocalityName().c_str();
+	principalString += (LPCTSTR)principal->GetLocalityName().c_str();
 	principalString += _T(", ST=");
-	principalString += principal->GetStateOrProvinceName().c_str();
+	principalString += (LPCTSTR)principal->GetStateOrProvinceName().c_str();
 	principalString += _T(", C=");
-	principalString += principal->GetCountryName().c_str();
+	principalString += (LPCTSTR)principal->GetCountryName().c_str();
 	return principalString;
 }
 
@@ -188,7 +188,7 @@ void CDlgCertification::OnBnClickedOk()
 BOOL CDlgCertification::OnInitDialog()
 {
 	BOOL superResult = CDialogEx::OnInitDialog();
-	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, m_host.c_str());
+	SetDlgItemText(IDC_CERTIFICATE_STATIC_SITE_INFO, (LPCTSTR)m_host.c_str());
 
 	for (CefRefPtr<CefX509Certificate> certificate : m_certificates)
 	{

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4229,7 +4229,11 @@ void CSazabi::InitializeCef()
 	CString strUserDataPath;
 	strUserDataPath = m_strCEFCachePath;
 	strUserDataPath += _T("\\UserData");
+#if CHROME_VERSION_MAJOR >= 115
+	CefString(&settings.root_cache_path) = strUserDataPath;
+#else
 	CefString(&settings.user_data_path) = strUserDataPath;
+#endif
 	settings.persist_user_preferences = true;
 
 	// ƒƒO‚ð—LŒø‰»‚·‚é (ChronosDefault.conf > EnableAdvancedLogMode)

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -484,7 +484,7 @@ public:
 		CefString strIn(str);
 		CefString strOut;
 		strOut = CefURIEncode(strIn, false);
-		CString strRet = (LPCTSTR)strOut.c_str();
+		CString strRet = (LPCWSTR)strOut.c_str();
 		return strRet;
 	}
 	UINT m_VEcache;

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -484,7 +484,7 @@ public:
 		CefString strIn(str);
 		CefString strOut;
 		strOut = CefURIEncode(strIn, false);
-		CString strRet = strOut.c_str();
+		CString strRet = strOut.ToWString().c_str();
 		return strRet;
 	}
 	UINT m_VEcache;

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -484,7 +484,7 @@ public:
 		CefString strIn(str);
 		CefString strOut;
 		strOut = CefURIEncode(strIn, false);
-		CString strRet = strOut.c_str();
+		CString strRet = (LPCTSTR)strOut.c_str();
 		return strRet;
 	}
 	UINT m_VEcache;

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -484,7 +484,7 @@ public:
 		CefString strIn(str);
 		CefString strOut;
 		strOut = CefURIEncode(strIn, false);
-		CString strRet = strOut.ToWString().c_str();
+		CString strRet = strOut.c_str();
 		return strRet;
 	}
 	UINT m_VEcache;

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -171,9 +171,9 @@ void DownloadFaviconCB::OnDownloadImageFinished(const CefString& image_url,
 					//CefString cfScheme(&cfURLparts.scheme);
 					CefString cfHost(&cfURLparts.host);
 					CefString cfPath(&cfURLparts.path);
-					//CString strScheme(cfScheme.c_str());
-					CString strHost(cfHost.c_str());
-					CString strPath(cfPath.c_str());
+					//CString strScheme(cfScheme.ToWString().c_str());
+					CString strHost(cfHost.ToWString().c_str());
+					CString strPath(cfPath.ToWString().c_str());
 					CString strFileName;
 					strFileName += strHost;
 					//strFileName += _T("");

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -171,9 +171,9 @@ void DownloadFaviconCB::OnDownloadImageFinished(const CefString& image_url,
 					//CefString cfScheme(&cfURLparts.scheme);
 					CefString cfHost(&cfURLparts.host);
 					CefString cfPath(&cfURLparts.path);
-					//CString strScheme((LPCTSTR)cfScheme.c_str());
-					CString strHost((LPCTSTR)cfHost.c_str());
-					CString strPath((LPCTSTR)cfPath.c_str());
+					//CString strScheme((LPCWSTR)cfScheme.c_str());
+					CString strHost((LPCWSTR)cfHost.c_str());
+					CString strPath((LPCWSTR)cfPath.c_str());
 					CString strFileName;
 					strFileName += strHost;
 					//strFileName += _T("");

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -171,9 +171,9 @@ void DownloadFaviconCB::OnDownloadImageFinished(const CefString& image_url,
 					//CefString cfScheme(&cfURLparts.scheme);
 					CefString cfHost(&cfURLparts.host);
 					CefString cfPath(&cfURLparts.path);
-					//CString strScheme(cfScheme.ToWString().c_str());
-					CString strHost(cfHost.ToWString().c_str());
-					CString strPath(cfPath.ToWString().c_str());
+					//CString strScheme(cfScheme.c_str());
+					CString strHost(cfHost.c_str());
+					CString strPath(cfPath.c_str());
 					CString strFileName;
 					strFileName += strHost;
 					//strFileName += _T("");

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -171,9 +171,9 @@ void DownloadFaviconCB::OnDownloadImageFinished(const CefString& image_url,
 					//CefString cfScheme(&cfURLparts.scheme);
 					CefString cfHost(&cfURLparts.host);
 					CefString cfPath(&cfURLparts.path);
-					//CString strScheme(cfScheme.c_str());
-					CString strHost(cfHost.c_str());
-					CString strPath(cfPath.c_str());
+					//CString strScheme((LPCTSTR)cfScheme.c_str());
+					CString strHost((LPCTSTR)cfHost.c_str());
+					CString strPath((LPCTSTR)cfPath.c_str());
 					CString strFileName;
 					strFileName += strHost;
 					//strFileName += _T("");

--- a/client_app.h
+++ b/client_app.h
@@ -58,7 +58,7 @@ public:
 		CString strTitle;
 		CefString strcefTitle;
 		strcefTitle = entry->GetTitle();
-		strTitle = strcefTitle.ToWString().c_str();
+		strTitle = strcefTitle.c_str();
 		strTitle.TrimLeft();
 		strTitle.TrimRight();
 		if (strTitle.IsEmpty())
@@ -66,7 +66,7 @@ public:
 			CString strURL;
 			CefString strcefURL;
 			strcefURL = entry->GetDisplayURL();
-			strURL = strcefURL.ToWString().c_str();
+			strURL = strcefURL.c_str();
 			strTitle = strURL;
 		}
 		m_strArrayRet.SetAt(iIndex, strTitle);

--- a/client_app.h
+++ b/client_app.h
@@ -58,7 +58,7 @@ public:
 		CString strTitle;
 		CefString strcefTitle;
 		strcefTitle = entry->GetTitle();
-		strTitle = strcefTitle.c_str();
+		strTitle = (LPCTSTR)strcefTitle.c_str();
 		strTitle.TrimLeft();
 		strTitle.TrimRight();
 		if (strTitle.IsEmpty())
@@ -66,7 +66,7 @@ public:
 			CString strURL;
 			CefString strcefURL;
 			strcefURL = entry->GetDisplayURL();
-			strURL = strcefURL.c_str();
+			strURL = (LPCTSTR)strcefURL.c_str();
 			strTitle = strURL;
 		}
 		m_strArrayRet.SetAt(iIndex, strTitle);

--- a/client_app.h
+++ b/client_app.h
@@ -58,7 +58,7 @@ public:
 		CString strTitle;
 		CefString strcefTitle;
 		strcefTitle = entry->GetTitle();
-		strTitle = (LPCTSTR)strcefTitle.c_str();
+		strTitle = (LPCWSTR)strcefTitle.c_str();
 		strTitle.TrimLeft();
 		strTitle.TrimRight();
 		if (strTitle.IsEmpty())
@@ -66,7 +66,7 @@ public:
 			CString strURL;
 			CefString strcefURL;
 			strcefURL = entry->GetDisplayURL();
-			strURL = (LPCTSTR)strcefURL.c_str();
+			strURL = (LPCWSTR)strcefURL.c_str();
 			strTitle = strURL;
 		}
 		m_strArrayRet.SetAt(iIndex, strTitle);

--- a/client_app.h
+++ b/client_app.h
@@ -58,7 +58,7 @@ public:
 		CString strTitle;
 		CefString strcefTitle;
 		strcefTitle = entry->GetTitle();
-		strTitle = strcefTitle.c_str();
+		strTitle = strcefTitle.ToWString().c_str();
 		strTitle.TrimLeft();
 		strTitle.TrimRight();
 		if (strTitle.IsEmpty())
@@ -66,7 +66,7 @@ public:
 			CString strURL;
 			CefString strcefURL;
 			strcefURL = entry->GetDisplayURL();
-			strURL = strcefURL.c_str();
+			strURL = strcefURL.ToWString().c_str();
 			strTitle = strURL;
 		}
 		m_strArrayRet.SetAt(iIndex, strTitle);

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -136,8 +136,8 @@ bool ClientHandler::OnOpenURLFromTab(CefRefPtr<CefBrowser> browser,
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (SafeWnd(hWindow))
 	{
-		LPCTSTR pszURL = NULL;
-		pszURL = (LPCTSTR)target_url.c_str();
+		LPCWSTR pszURL = NULL;
+		pszURL = (LPCWSTR)target_url.c_str();
 		switch (target_disposition)
 		{
 		case cef_window_open_disposition_t::WOD_NEW_FOREGROUND_TAB:
@@ -345,7 +345,7 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = (LPCTSTR)strCfSt.c_str();
+			strSelText = (LPCWSTR)strCfSt.c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			if (!strSelText.IsEmpty())
@@ -394,7 +394,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = (LPCTSTR)strCfSt.c_str();
+			strSelText = (LPCWSTR)strCfSt.c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_SEARCH_URL, (WPARAM)(LPCTSTR)strSelText, (LPARAM)TRUE, SMTO_NORMAL, 1000, NULL);
@@ -404,8 +404,8 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 		{
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
-			LPCTSTR pszURL = {0};
-			pszURL = (LPCTSTR)strURLC.c_str();
+			LPCWSTR pszURL = {0};
+			pszURL = (LPCWSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -413,8 +413,8 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 		{
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
-			LPCTSTR pszURL = {0};
-			pszURL = (LPCTSTR)strURLC.c_str();
+			LPCWSTR pszURL = {0};
+			pszURL = (LPCWSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -422,8 +422,8 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 		{
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			LPCTSTR pszURL = {0};
-			pszURL = (LPCTSTR)strURLC.c_str();
+			LPCWSTR pszURL = {0};
+			pszURL = (LPCWSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -431,8 +431,8 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 		{
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			LPCTSTR pszURL = {0};
-			pszURL = (LPCTSTR)strURLC.c_str();
+			LPCWSTR pszURL = {0};
+			pszURL = (LPCWSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -456,7 +456,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = (LPCTSTR)strURLC.c_str();
+			str = (LPCWSTR)strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				//data:image/pngの場合があるので、IsURL判定を行わない。
@@ -488,11 +488,11 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = (LPCTSTR)strURLC.c_str();
+			str = (LPCWSTR)strURLC.c_str();
 			if (!str.IsEmpty())
 			{
-				LPCTSTR pszURL = {0};
-				pszURL = (LPCTSTR)strURLC.c_str();
+				LPCWSTR pszURL = {0};
+				pszURL = (LPCWSTR)strURLC.c_str();
 				::SendMessageTimeout(hWindow, WM_COPY_IMAGE, (WPARAM)(LPCTSTR)str, NULL, SMTO_NORMAL, 1000, NULL);
 				return true;
 			}
@@ -503,7 +503,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetUnfilteredLinkUrl();
-			str = (LPCTSTR)strURLC.c_str();
+			str = (LPCWSTR)strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				if (::OpenClipboard(NULL))
@@ -565,7 +565,7 @@ void ClientHandler::OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 	{
 		if (frame->IsMain())
 		{
-			LPCTSTR pszURL = (LPCTSTR)url.c_str();
+			LPCWSTR pszURL = (LPCWSTR)url.c_str();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_ADDRESS_CHANGE, (WPARAM)pszURL, NULL, SMTO_NORMAL, 1000, NULL);
 		}
 	}
@@ -613,9 +613,9 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (SafeWnd(hWindow))
 	{
-		LPCTSTR pszTitle = NULL;
+		LPCWSTR pszTitle = NULL;
 		std::wstring hoge = title.ToWString();
-		pszTitle = (LPCTSTR)hoge.c_str();
+		pszTitle = (LPCWSTR)hoge.c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_TITLE_CHANGE, (WPARAM)pszTitle, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -630,11 +630,11 @@ void ClientHandler::OnFaviconURLChange(CefRefPtr<CefBrowser> browser, const std:
 	if (SafeWnd(hWindow))
 	{
 		CefString strIconList;
-		LPCTSTR pszFavURL = NULL;
+		LPCWSTR pszFavURL = NULL;
 		for (UINT i = 0; i < icon_urls.size(); i++)
 		{
 			strIconList = icon_urls[i];
-			pszFavURL = (LPCTSTR)strIconList.c_str();
+			pszFavURL = (LPCWSTR)strIconList.c_str();
 		}
 		if (pszFavURL)
 		{
@@ -653,8 +653,8 @@ void ClientHandler::OnStatusMessage(CefRefPtr<CefBrowser> browser, const CefStri
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (SafeWnd(hWindow))
 	{
-		LPCTSTR pszStatus = NULL;
-		pszStatus = (LPCTSTR)value.c_str();
+		LPCWSTR pszStatus = NULL;
+		pszStatus = (LPCWSTR)value.c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_STATUS_MESSAGE, (WPARAM)pszStatus, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -710,9 +710,9 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			DebugWndLogData dwLogData;
 			dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 			dwLogData.mFUNCTION_NAME = _T("ConsoleMessage");
-			dwLogData.mMESSAGE1 = (LPCTSTR)message.c_str();
+			dwLogData.mMESSAGE1 = (LPCWSTR)message.c_str();
 			dwLogData.mMESSAGE2 = strLogLevel;
-			dwLogData.mMESSAGE3.Format(_T("Source:%s"), (LPCTSTR)source.c_str());
+			dwLogData.mMESSAGE3.Format(_T("Source:%s"), (LPCWSTR)source.c_str());
 			dwLogData.mMESSAGE4.Format(_T("Line:%d"), line);
 			theApp.AppendDebugViewLog(dwLogData);
 		}
@@ -725,7 +725,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			CString strLogPath;
 			strLogPath = theApp.m_strCEFCachePath;
 			strLogPath += _T("\\console.log");
-			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), (LPCTSTR)message.c_str(), (LPCTSTR)source.c_str(), line);
+			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), (LPCWSTR)message.c_str(), (LPCWSTR)source.c_str(), line);
 			_wsetlocale(LC_ALL, _T("jpn"));
 			CStdioFile stdFile;
 			if (stdFile.Open(strLogPath, CFile::modeWrite | CFile::shareDenyNone | CFile::modeCreate | CFile::modeNoTruncate))
@@ -771,7 +771,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 
 	m_bDownLoadStartFlg = TRUE;
 	CString strFileName;
-	strFileName = (LPCTSTR)suggested_name.c_str();
+	strFileName = (LPCWSTR)suggested_name.c_str();
 	strFileName.TrimLeft();
 	strFileName.TrimRight();
 	//ファイル名に使えない文字を置き換える。
@@ -807,7 +807,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 		CString strURL;
 		CefString strURLC;
 		strURLC = browser->GetMainFrame()->GetURL();
-		strURL = (LPCTSTR)strURLC.c_str();
+		strURL = (LPCWSTR)strURLC.c_str();
 		if (strURL.IsEmpty())
 			::SendMessageTimeout(hWindow, WM_APP_CEF_DOWNLOAD_BLANK_PAGE, (WPARAM)TRUE, NULL, SMTO_NORMAL, 1000, NULL);
 		else
@@ -878,7 +878,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 					}
 					if (strURL.IsEmpty())
 					{
-						strURL = (LPCTSTR)download_item->GetURL().c_str();
+						strURL = (LPCWSTR)download_item->GetURL().c_str();
 					}
 					theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strURL);
 				}
@@ -930,7 +930,7 @@ void ClientHandler::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
 	if (download_item->IsValid())
 	{
 		CefString cefFulPath = download_item->GetFullPath();
-		LPCWSTR fullPath = (LPCTSTR)cefFulPath.c_str();
+		LPCWSTR fullPath = (LPCWSTR)cefFulPath.c_str();
 		if (fullPath)
 			lstrcpyn(values.szFullPath, fullPath, 512);
 	}
@@ -1058,7 +1058,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	request->SetHeaderMap(cefHeaders);
 
 	CefString cefURL = request->GetURL();
-	CString strTranURL((LPCTSTR)cefURL.c_str());
+	CString strTranURL((LPCWSTR)cefURL.c_str());
 	CString logmsg;
 
 	HWND hWindow = GetSafeParentWnd(browser);
@@ -1069,7 +1069,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 		dwLogData.mFUNCTION_NAME = _T("OnBeforeResourceLoad");
 		dwLogData.mMESSAGE1 = strTranURL;
-		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), (LPCTSTR)frame->GetName().c_str());
+		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), (LPCWSTR)frame->GetName().c_str());
 		dwLogData.mMESSAGE3.Format(_T("IsMain:%s"), frame->IsMain() ? _T("TRUE") : _T("FALSE"));
 		theApp.AppendDebugViewLog(dwLogData);
 		logmsg = dwLogData.GetString();
@@ -1083,7 +1083,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		if (CefParseURL(cefURL, cfURLpa))
 		{
 			CefString cfHost(&cfURLpa.host);
-			strHost = (LPCTSTR)cfHost.c_str();
+			strHost = (LPCWSTR)cfHost.c_str();
 		}
 		if (SBUtil::IsURL_HTTP(strTranURL))
 		{
@@ -1097,8 +1097,8 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	// get URL requested
 	CefString newURL = request->GetURL();
 	CefURLParts cfURLparts;
-	LPCTSTR pszURL = NULL;
-	pszURL = (LPCTSTR)newURL.c_str();
+	LPCWSTR pszURL = NULL;
+	pszURL = (LPCWSTR)newURL.c_str();
 	if (CefParseURL(newURL, cfURLparts))
 	{
 		CefString cfScheme(&cfURLparts.scheme);
@@ -1106,9 +1106,9 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		CefString cfPath(&cfURLparts.path);
 		//CefString cfQuery(&cfURLparts.query);
 
-		CString strScheme((LPCTSTR)cfScheme.c_str());
-		CString strHost((LPCTSTR)cfHost.c_str());
-		CString strPath((LPCTSTR)cfPath.c_str());
+		CString strScheme((LPCWSTR)cfScheme.c_str());
+		CString strHost((LPCWSTR)cfHost.c_str());
+		CString strPath((LPCWSTR)cfPath.c_str());
 
 		if (strScheme.Find(_T("http")) != 0) //http|https
 			return RV_CONTINUE;
@@ -1201,7 +1201,7 @@ void ClientHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
 					CString strURL;
 					CefString strURLC;
 					strURLC = browser->GetMainFrame()->GetURL();
-					strURL = (LPCTSTR)strURLC.c_str();
+					strURL = (LPCWSTR)strURLC.c_str();
 					CString strRetFileName;
 					CStringArray stArr;
 					if (theApp.m_cCustomScriptList.HitWildCardURL(strURL, &stArr))
@@ -1568,7 +1568,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	CString errorPageHeadingName;
 	errorPageHeadingName.LoadString(ID_ERROR_PAGE_HEADING_NAME);
 
-	CString strFaildUrl((LPCTSTR)failedUrl.c_str());
+	CString strFaildUrl((LPCWSTR)failedUrl.c_str());
 	strFaildUrl.Replace(_T("<"), _T(""));
 	strFaildUrl.Replace(_T(">"), _T(""));
 	strFaildUrl.Replace(_T("&"), _T(""));
@@ -1620,7 +1620,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	strErrorHTMLFmt += _T("</h4>");
 	strErrorHTMLFmt += _T("<h4>");
 	strErrorHTMLFmt += errorPageHeadingName;
-	strErrorHTMLFmt += (LPCTSTR)errorText.c_str();
+	strErrorHTMLFmt += (LPCWSTR)errorText.c_str();
 	strErrorHTMLFmt += _T("</h4></div></div></div></div></body></html>");
 
 	CefString strCefErrorHTML(strErrorHTMLFmt);
@@ -1658,8 +1658,8 @@ bool ClientHandler::GetAuthCredentials(CefRefPtr<CefBrowser> browser,
 	HWND hWindow = GetSafeParentWnd(browser);
 
 	CEFAuthenticationValues values = {0};
-	values.lpszHost = (LPCTSTR)host.c_str();
-	values.lpszRealm = (LPCTSTR)realm.c_str();
+	values.lpszHost = (LPCWSTR)host.c_str();
+	values.lpszRealm = (LPCWSTR)realm.c_str();
 	_tcscpy_s(values.szUserName, _T(""));
 	_tcscpy_s(values.szUserPass, _T(""));
 	if (SafeWnd(hWindow))
@@ -1712,7 +1712,7 @@ bool ClientHandler::OnCertificateError(CefRefPtr<CefBrowser> browser,
 
 	CString confirmMsg;
 	confirmMsg.LoadString(IDS_STRING_CONFIRM_INSECURE_CONNECTION);
-	szMessage.Format(confirmMsg, (LPCTSTR)request_url.c_str());
+	szMessage.Format(confirmMsg, (LPCWSTR)request_url.c_str());
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (hWindow)
 	{
@@ -1780,8 +1780,8 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 		// get URL requested
 		CefString newURL = request->GetURL();
 		UINT bTopPage = FALSE;
-		LPCTSTR pszURL = NULL;
-		pszURL = (LPCTSTR)newURL.c_str();
+		LPCWSTR pszURL = NULL;
+		pszURL = (LPCWSTR)newURL.c_str();
 
 		if (frame)
 		{
@@ -1799,7 +1799,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 			CefString strName;
 			strName = frame->GetName();
 			CString strWindowName;
-			strWindowName = (LPCTSTR)strName.c_str();
+			strWindowName = (LPCWSTR)strName.c_str();
 			if (!strWindowName.IsEmpty())
 			{
 				HWND hWindowFrame = {0};
@@ -1851,7 +1851,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 
 	CString confirmMessage;
 	CString enableMediaConfirmation;
-	CString requestOrigin = (LPCTSTR)requesting_origin.c_str();
+	CString requestOrigin = (LPCWSTR)requesting_origin.c_str();
 	enableMediaConfirmation.LoadString(ID_ENABLE_MEDIA_CONFIRMATION);
 	confirmMessage.Format(enableMediaConfirmation, (LPCTSTR)requestOrigin);
 	confirmMessage += "\n";
@@ -1884,7 +1884,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 	dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 	dwLogData.mFUNCTION_NAME = _T("OnRequestMediaAccessPermission");
 	dwLogData.mMESSAGE1 = requestOrigin;
-	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), (LPCTSTR)frame->GetName().c_str());
+	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), (LPCWSTR)frame->GetName().c_str());
 	dwLogData.mMESSAGE3.Format(_T("Approved permission type:%d"), requested_permissions);
 	theApp.AppendDebugViewLog(dwLogData);
 	theApp.WriteDebugTraceDateTime(dwLogData.GetString(), DEBUG_LOG_TYPE_URL);
@@ -1910,7 +1910,7 @@ bool ClientHandler::OnJSDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = (LPCTSTR)message_text.c_str();
+	pszMessage = (LPCWSTR)message_text.c_str();
 	if (dialog_type == JSDIALOGTYPE_ALERT)
 	{
 		int iRet = theApp.SB_MessageBox(hWindow, pszMessage, NULL, MB_ICONWARNING | MB_OK | MB_TASKMODAL, TRUE);
@@ -1939,7 +1939,7 @@ bool ClientHandler::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = (LPCTSTR)message_text.c_str();
+	pszMessage = (LPCWSTR)message_text.c_str();
 	CString strMsg;
 	strMsg = pszMessage;
 	//if(strMsg==_T("Is it OK to leave/reload this page?"))
@@ -1994,7 +1994,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				for (UINT i = 0; i < cefstrFiles.size(); i++)
 				{
 					cstrFileName = cefstrFiles[i];
-					strFileName = (LPCTSTR)cstrFileName.c_str();
+					strFileName = (LPCWSTR)cstrFileName.c_str();
 					{
 						theApp.SendLoggingMsg(LOG_UPLOAD, strFileName, hWindow);
 					}
@@ -2008,7 +2008,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				CefString cstrFileName;
 				CString strFileName;
 				cstrFileName = dragData->GetLinkURL();
-				strFileName = (LPCTSTR)cstrFileName.c_str();
+				strFileName = (LPCWSTR)cstrFileName.c_str();
 				theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strFileName);
 			}
 		}
@@ -2029,7 +2029,7 @@ bool ClientHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 {
 	CefString strName = message->GetName();
 	CString strFilterName;
-	strFilterName = (LPCTSTR)strName.c_str();
+	strFilterName = (LPCWSTR)strName.c_str();
 	strFilterName.TrimLeft();
 	strFilterName.TrimRight();
 	if (strFilterName == _T("SET_PID"))
@@ -2063,9 +2063,9 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 3 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString())
 		{
-			CString strText((LPCTSTR)arguments[0]->GetStringValue().c_str());
-			CString strCaption((LPCTSTR)arguments[1]->GetStringValue().c_str());
-			CString strChronosExtParentWnd((LPCTSTR)arguments[2]->GetStringValue().c_str());
+			CString strText((LPCWSTR)arguments[0]->GetStringValue().c_str());
+			CString strCaption((LPCWSTR)arguments[1]->GetStringValue().c_str());
+			CString strChronosExtParentWnd((LPCWSTR)arguments[2]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2120,10 +2120,10 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 4 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString() && arguments[3]->IsString())
 		{
-			CString strID((LPCTSTR)arguments[0]->GetStringValue().c_str());
-			CString strText((LPCTSTR)arguments[1]->GetStringValue().c_str());
-			CString strCaption((LPCTSTR)arguments[2]->GetStringValue().c_str());
-			CString strChronosExtParentWnd((LPCTSTR)arguments[3]->GetStringValue().c_str());
+			CString strID((LPCWSTR)arguments[0]->GetStringValue().c_str());
+			CString strText((LPCWSTR)arguments[1]->GetStringValue().c_str());
+			CString strCaption((LPCWSTR)arguments[2]->GetStringValue().c_str());
+			CString strChronosExtParentWnd((LPCWSTR)arguments[3]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2191,7 +2191,7 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 1 && arguments[0]->IsString())
 		{
-			CString strChronosExtParentWnd((LPCTSTR)arguments[0]->GetStringValue().c_str());
+			CString strChronosExtParentWnd((LPCWSTR)arguments[0]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -137,7 +137,7 @@ bool ClientHandler::OnOpenURLFromTab(CefRefPtr<CefBrowser> browser,
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszURL = NULL;
-		pszURL = target_url.c_str();
+		pszURL = target_url.ToWString().c_str();
 		switch (target_disposition)
 		{
 		case cef_window_open_disposition_t::WOD_NEW_FOREGROUND_TAB:
@@ -345,7 +345,7 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = strCfSt.c_str();
+			strSelText = strCfSt.ToWString().c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			if (!strSelText.IsEmpty())
@@ -394,7 +394,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = strCfSt.c_str();
+			strSelText = strCfSt.ToWString().c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_SEARCH_URL, (WPARAM)(LPCTSTR)strSelText, (LPARAM)TRUE, SMTO_NORMAL, 1000, NULL);
@@ -405,7 +405,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = strURLC.ToWString().c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -414,7 +414,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = strURLC.ToWString().c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -423,7 +423,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = strURLC.ToWString().c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -432,7 +432,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = strURLC.ToWString().c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -456,7 +456,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = strURLC.c_str();
+			str = strURLC.ToWString().c_str();
 			if (!str.IsEmpty())
 			{
 				//data:image/pngの場合があるので、IsURL判定を行わない。
@@ -488,11 +488,11 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = strURLC.c_str();
+			str = strURLC.ToWString().c_str();
 			if (!str.IsEmpty())
 			{
 				LPCTSTR pszURL = {0};
-				pszURL = strURLC.c_str();
+				pszURL = strURLC.ToWString().c_str();
 				::SendMessageTimeout(hWindow, WM_COPY_IMAGE, (WPARAM)(LPCTSTR)str, NULL, SMTO_NORMAL, 1000, NULL);
 				return true;
 			}
@@ -503,7 +503,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetUnfilteredLinkUrl();
-			str = strURLC.c_str();
+			str = strURLC.ToWString().c_str();
 			if (!str.IsEmpty())
 			{
 				if (::OpenClipboard(NULL))
@@ -566,7 +566,7 @@ void ClientHandler::OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 		if (frame->IsMain())
 		{
 			LPCTSTR pszURL = NULL;
-			pszURL = url.c_str();
+			pszURL = url.ToWString().c_str();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_ADDRESS_CHANGE, (WPARAM)pszURL, NULL, SMTO_NORMAL, 1000, NULL);
 		}
 	}
@@ -615,7 +615,7 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszTitle = NULL;
-		pszTitle = title.c_str();
+		pszTitle = title.ToWString().c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_TITLE_CHANGE, (WPARAM)pszTitle, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -634,7 +634,7 @@ void ClientHandler::OnFaviconURLChange(CefRefPtr<CefBrowser> browser, const std:
 		for (UINT i = 0; i < icon_urls.size(); i++)
 		{
 			strIconList = icon_urls[i];
-			pszFavURL = strIconList.c_str();
+			pszFavURL = strIconList.ToWString().c_str();
 		}
 		if (pszFavURL)
 		{
@@ -654,7 +654,7 @@ void ClientHandler::OnStatusMessage(CefRefPtr<CefBrowser> browser, const CefStri
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszStatus = NULL;
-		pszStatus = value.c_str();
+		pszStatus = value.ToWString().c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_STATUS_MESSAGE, (WPARAM)pszStatus, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -710,9 +710,9 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			DebugWndLogData dwLogData;
 			dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 			dwLogData.mFUNCTION_NAME = _T("ConsoleMessage");
-			dwLogData.mMESSAGE1 = message.c_str();
+			dwLogData.mMESSAGE1 = message.ToWString().c_str();
 			dwLogData.mMESSAGE2 = strLogLevel;
-			dwLogData.mMESSAGE3.Format(_T("Source:%s"), source.c_str());
+			dwLogData.mMESSAGE3.Format(_T("Source:%s"), source.ToWString().c_str());
 			dwLogData.mMESSAGE4.Format(_T("Line:%d"), line);
 			theApp.AppendDebugViewLog(dwLogData);
 		}
@@ -725,7 +725,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			CString strLogPath;
 			strLogPath = theApp.m_strCEFCachePath;
 			strLogPath += _T("\\console.log");
-			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), message.c_str(), source.c_str(), line);
+			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), message.ToWString().c_str(), source.ToWString().c_str(), line);
 			_wsetlocale(LC_ALL, _T("jpn"));
 			CStdioFile stdFile;
 			if (stdFile.Open(strLogPath, CFile::modeWrite | CFile::shareDenyNone | CFile::modeCreate | CFile::modeNoTruncate))
@@ -771,7 +771,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 
 	m_bDownLoadStartFlg = TRUE;
 	CString strFileName;
-	strFileName = suggested_name.c_str();
+	strFileName = suggested_name.ToWString().c_str();
 	strFileName.TrimLeft();
 	strFileName.TrimRight();
 	//ファイル名に使えない文字を置き換える。
@@ -807,7 +807,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 		CString strURL;
 		CefString strURLC;
 		strURLC = browser->GetMainFrame()->GetURL();
-		strURL = strURLC.c_str();
+		strURL = strURLC.ToWString().c_str();
 		if (strURL.IsEmpty())
 			::SendMessageTimeout(hWindow, WM_APP_CEF_DOWNLOAD_BLANK_PAGE, (WPARAM)TRUE, NULL, SMTO_NORMAL, 1000, NULL);
 		else
@@ -878,7 +878,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 					}
 					if (strURL.IsEmpty())
 					{
-						strURL = download_item->GetURL().c_str();
+						strURL = download_item->GetURL().ToWString().c_str();
 					}
 					theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strURL);
 				}
@@ -930,8 +930,9 @@ void ClientHandler::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
 	if (download_item->IsValid())
 	{
 		CefString cefFulPath = download_item->GetFullPath();
-		if (cefFulPath.c_str())
-			lstrcpyn(values.szFullPath, cefFulPath.c_str(), 512);
+		LPCWSTR fullPath = cefFulPath.ToWString().c_str();
+		if (fullPath)
+			lstrcpyn(values.szFullPath, fullPath, 512);
 	}
 	HWND hWindow = GetSafeParentWnd(browser);
 	UINT nBrowserId = browser->GetIdentifier();
@@ -1057,7 +1058,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	request->SetHeaderMap(cefHeaders);
 
 	CefString cefURL = request->GetURL();
-	CString strTranURL(cefURL.c_str());
+	CString strTranURL(cefURL.ToWString().c_str());
 	CString logmsg;
 
 	HWND hWindow = GetSafeParentWnd(browser);
@@ -1068,7 +1069,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 		dwLogData.mFUNCTION_NAME = _T("OnBeforeResourceLoad");
 		dwLogData.mMESSAGE1 = strTranURL;
-		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().c_str());
+		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().ToWString().c_str());
 		dwLogData.mMESSAGE3.Format(_T("IsMain:%s"), frame->IsMain() ? _T("TRUE") : _T("FALSE"));
 		theApp.AppendDebugViewLog(dwLogData);
 		logmsg = dwLogData.GetString();
@@ -1082,7 +1083,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		if (CefParseURL(cefURL, cfURLpa))
 		{
 			CefString cfHost(&cfURLpa.host);
-			strHost = cfHost.c_str();
+			strHost = cfHost.ToWString().c_str();
 		}
 		if (SBUtil::IsURL_HTTP(strTranURL))
 		{
@@ -1097,7 +1098,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	CefString newURL = request->GetURL();
 	CefURLParts cfURLparts;
 	LPCTSTR pszURL = NULL;
-	pszURL = newURL.c_str();
+	pszURL = newURL.ToWString().c_str();
 	if (CefParseURL(newURL, cfURLparts))
 	{
 		CefString cfScheme(&cfURLparts.scheme);
@@ -1105,9 +1106,9 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		CefString cfPath(&cfURLparts.path);
 		//CefString cfQuery(&cfURLparts.query);
 
-		CString strScheme(cfScheme.c_str());
-		CString strHost(cfHost.c_str());
-		CString strPath(cfPath.c_str());
+		CString strScheme(cfScheme.ToWString().c_str());
+		CString strHost(cfHost.ToWString().c_str());
+		CString strPath(cfPath.ToWString().c_str());
 
 		if (strScheme.Find(_T("http")) != 0) //http|https
 			return RV_CONTINUE;
@@ -1200,7 +1201,7 @@ void ClientHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
 					CString strURL;
 					CefString strURLC;
 					strURLC = browser->GetMainFrame()->GetURL();
-					strURL = strURLC.c_str();
+					strURL = strURLC.ToWString().c_str();
 					CString strRetFileName;
 					CStringArray stArr;
 					if (theApp.m_cCustomScriptList.HitWildCardURL(strURL, &stArr))
@@ -1567,7 +1568,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	CString errorPageHeadingName;
 	errorPageHeadingName.LoadString(ID_ERROR_PAGE_HEADING_NAME);
 
-	CString strFaildUrl(failedUrl.c_str());
+	CString strFaildUrl(failedUrl.ToWString().c_str());
 	strFaildUrl.Replace(_T("<"), _T(""));
 	strFaildUrl.Replace(_T(">"), _T(""));
 	strFaildUrl.Replace(_T("&"), _T(""));
@@ -1619,7 +1620,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	strErrorHTMLFmt += _T("</h4>");
 	strErrorHTMLFmt += _T("<h4>");
 	strErrorHTMLFmt += errorPageHeadingName;
-	strErrorHTMLFmt += errorText.c_str();
+	strErrorHTMLFmt += errorText.ToWString().c_str();
 	strErrorHTMLFmt += _T("</h4></div></div></div></div></body></html>");
 
 	CefString strCefErrorHTML(strErrorHTMLFmt);
@@ -1657,8 +1658,8 @@ bool ClientHandler::GetAuthCredentials(CefRefPtr<CefBrowser> browser,
 	HWND hWindow = GetSafeParentWnd(browser);
 
 	CEFAuthenticationValues values = {0};
-	values.lpszHost = host.c_str();
-	values.lpszRealm = realm.c_str();
+	values.lpszHost = host.ToWString().c_str();
+	values.lpszRealm = realm.ToWString().c_str();
 	_tcscpy_s(values.szUserName, _T(""));
 	_tcscpy_s(values.szUserPass, _T(""));
 	if (SafeWnd(hWindow))
@@ -1711,7 +1712,7 @@ bool ClientHandler::OnCertificateError(CefRefPtr<CefBrowser> browser,
 
 	CString confirmMsg;
 	confirmMsg.LoadString(IDS_STRING_CONFIRM_INSECURE_CONNECTION);
-	szMessage.Format(confirmMsg, request_url.c_str());
+	szMessage.Format(confirmMsg, request_url.ToWString().c_str());
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (hWindow)
 	{
@@ -1780,7 +1781,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 		CefString newURL = request->GetURL();
 		UINT bTopPage = FALSE;
 		LPCTSTR pszURL = NULL;
-		pszURL = newURL.c_str();
+		pszURL = newURL.ToWString().c_str();
 
 		if (frame)
 		{
@@ -1798,7 +1799,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 			CefString strName;
 			strName = frame->GetName();
 			CString strWindowName;
-			strWindowName = strName.c_str();
+			strWindowName = strName.ToWString().c_str();
 			if (!strWindowName.IsEmpty())
 			{
 				HWND hWindowFrame = {0};
@@ -1850,7 +1851,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 
 	CString confirmMessage;
 	CString enableMediaConfirmation;
-	CString requestOrigin = requesting_origin.c_str();
+	CString requestOrigin = requesting_origin.ToWString().c_str();
 	enableMediaConfirmation.LoadString(ID_ENABLE_MEDIA_CONFIRMATION);
 	confirmMessage.Format(enableMediaConfirmation, (LPCTSTR)requestOrigin);
 	confirmMessage += "\n";
@@ -1883,7 +1884,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 	dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 	dwLogData.mFUNCTION_NAME = _T("OnRequestMediaAccessPermission");
 	dwLogData.mMESSAGE1 = requestOrigin;
-	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().c_str());
+	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().ToWString().c_str());
 	dwLogData.mMESSAGE3.Format(_T("Approved permission type:%d"), requested_permissions);
 	theApp.AppendDebugViewLog(dwLogData);
 	theApp.WriteDebugTraceDateTime(dwLogData.GetString(), DEBUG_LOG_TYPE_URL);
@@ -1909,7 +1910,7 @@ bool ClientHandler::OnJSDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = message_text.c_str();
+	pszMessage = message_text.ToWString().c_str();
 	if (dialog_type == JSDIALOGTYPE_ALERT)
 	{
 		int iRet = theApp.SB_MessageBox(hWindow, pszMessage, NULL, MB_ICONWARNING | MB_OK | MB_TASKMODAL, TRUE);
@@ -1938,7 +1939,7 @@ bool ClientHandler::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = message_text.c_str();
+	pszMessage = message_text.ToWString().c_str();
 	CString strMsg;
 	strMsg = pszMessage;
 	//if(strMsg==_T("Is it OK to leave/reload this page?"))
@@ -1993,7 +1994,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				for (UINT i = 0; i < cefstrFiles.size(); i++)
 				{
 					cstrFileName = cefstrFiles[i];
-					strFileName = cstrFileName.c_str();
+					strFileName = cstrFileName.ToWString().c_str();
 					{
 						theApp.SendLoggingMsg(LOG_UPLOAD, strFileName, hWindow);
 					}
@@ -2007,7 +2008,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				CefString cstrFileName;
 				CString strFileName;
 				cstrFileName = dragData->GetLinkURL();
-				strFileName = cstrFileName.c_str();
+				strFileName = cstrFileName.ToWString().c_str();
 				theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strFileName);
 			}
 		}
@@ -2028,7 +2029,7 @@ bool ClientHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 {
 	CefString strName = message->GetName();
 	CString strFilterName;
-	strFilterName = strName.c_str();
+	strFilterName = strName.ToWString().c_str();
 	strFilterName.TrimLeft();
 	strFilterName.TrimRight();
 	if (strFilterName == _T("SET_PID"))
@@ -2062,9 +2063,9 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 3 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString())
 		{
-			CString strText(arguments[0]->GetStringValue().c_str());
-			CString strCaption(arguments[1]->GetStringValue().c_str());
-			CString strChronosExtParentWnd(arguments[2]->GetStringValue().c_str());
+			CString strText(arguments[0]->GetStringValue().ToWString().c_str());
+			CString strCaption(arguments[1]->GetStringValue().ToWString().c_str());
+			CString strChronosExtParentWnd(arguments[2]->GetStringValue().ToWString().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2119,10 +2120,10 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 4 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString() && arguments[3]->IsString())
 		{
-			CString strID(arguments[0]->GetStringValue().c_str());
-			CString strText(arguments[1]->GetStringValue().c_str());
-			CString strCaption(arguments[2]->GetStringValue().c_str());
-			CString strChronosExtParentWnd(arguments[3]->GetStringValue().c_str());
+			CString strID(arguments[0]->GetStringValue().ToWString().c_str());
+			CString strText(arguments[1]->GetStringValue().ToWString().c_str());
+			CString strCaption(arguments[2]->GetStringValue().ToWString().c_str());
+			CString strChronosExtParentWnd(arguments[3]->GetStringValue().ToWString().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2190,7 +2191,7 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 1 && arguments[0]->IsString())
 		{
-			CString strChronosExtParentWnd(arguments[0]->GetStringValue().c_str());
+			CString strChronosExtParentWnd(arguments[0]->GetStringValue().ToWString().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -137,7 +137,7 @@ bool ClientHandler::OnOpenURLFromTab(CefRefPtr<CefBrowser> browser,
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszURL = NULL;
-		pszURL = target_url.ToWString().c_str();
+		pszURL = target_url.c_str();
 		switch (target_disposition)
 		{
 		case cef_window_open_disposition_t::WOD_NEW_FOREGROUND_TAB:
@@ -345,7 +345,7 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = strCfSt.ToWString().c_str();
+			strSelText = strCfSt.c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			if (!strSelText.IsEmpty())
@@ -394,7 +394,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = strCfSt.ToWString().c_str();
+			strSelText = strCfSt.c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_SEARCH_URL, (WPARAM)(LPCTSTR)strSelText, (LPARAM)TRUE, SMTO_NORMAL, 1000, NULL);
@@ -405,7 +405,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.ToWString().c_str();
+			pszURL = strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -414,7 +414,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.ToWString().c_str();
+			pszURL = strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -423,7 +423,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.ToWString().c_str();
+			pszURL = strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -432,7 +432,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.ToWString().c_str();
+			pszURL = strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -456,7 +456,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = strURLC.ToWString().c_str();
+			str = strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				//data:image/pngの場合があるので、IsURL判定を行わない。
@@ -488,11 +488,11 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = strURLC.ToWString().c_str();
+			str = strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				LPCTSTR pszURL = {0};
-				pszURL = strURLC.ToWString().c_str();
+				pszURL = strURLC.c_str();
 				::SendMessageTimeout(hWindow, WM_COPY_IMAGE, (WPARAM)(LPCTSTR)str, NULL, SMTO_NORMAL, 1000, NULL);
 				return true;
 			}
@@ -503,7 +503,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetUnfilteredLinkUrl();
-			str = strURLC.ToWString().c_str();
+			str = strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				if (::OpenClipboard(NULL))
@@ -565,8 +565,7 @@ void ClientHandler::OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 	{
 		if (frame->IsMain())
 		{
-			LPCTSTR pszURL = NULL;
-			pszURL = url.ToWString().c_str();
+			LPCTSTR pszURL = url.c_str();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_ADDRESS_CHANGE, (WPARAM)pszURL, NULL, SMTO_NORMAL, 1000, NULL);
 		}
 	}
@@ -615,7 +614,8 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszTitle = NULL;
-		pszTitle = title.ToWString().c_str();
+		std::wstring hoge = title.ToWString();
+		pszTitle = hoge.c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_TITLE_CHANGE, (WPARAM)pszTitle, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -634,7 +634,7 @@ void ClientHandler::OnFaviconURLChange(CefRefPtr<CefBrowser> browser, const std:
 		for (UINT i = 0; i < icon_urls.size(); i++)
 		{
 			strIconList = icon_urls[i];
-			pszFavURL = strIconList.ToWString().c_str();
+			pszFavURL = strIconList.c_str();
 		}
 		if (pszFavURL)
 		{
@@ -654,7 +654,7 @@ void ClientHandler::OnStatusMessage(CefRefPtr<CefBrowser> browser, const CefStri
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszStatus = NULL;
-		pszStatus = value.ToWString().c_str();
+		pszStatus = value.c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_STATUS_MESSAGE, (WPARAM)pszStatus, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -710,9 +710,9 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			DebugWndLogData dwLogData;
 			dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 			dwLogData.mFUNCTION_NAME = _T("ConsoleMessage");
-			dwLogData.mMESSAGE1 = message.ToWString().c_str();
+			dwLogData.mMESSAGE1 = message.c_str();
 			dwLogData.mMESSAGE2 = strLogLevel;
-			dwLogData.mMESSAGE3.Format(_T("Source:%s"), source.ToWString().c_str());
+			dwLogData.mMESSAGE3.Format(_T("Source:%s"), source.c_str());
 			dwLogData.mMESSAGE4.Format(_T("Line:%d"), line);
 			theApp.AppendDebugViewLog(dwLogData);
 		}
@@ -725,7 +725,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			CString strLogPath;
 			strLogPath = theApp.m_strCEFCachePath;
 			strLogPath += _T("\\console.log");
-			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), message.ToWString().c_str(), source.ToWString().c_str(), line);
+			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), message.c_str(), source.c_str(), line);
 			_wsetlocale(LC_ALL, _T("jpn"));
 			CStdioFile stdFile;
 			if (stdFile.Open(strLogPath, CFile::modeWrite | CFile::shareDenyNone | CFile::modeCreate | CFile::modeNoTruncate))
@@ -771,7 +771,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 
 	m_bDownLoadStartFlg = TRUE;
 	CString strFileName;
-	strFileName = suggested_name.ToWString().c_str();
+	strFileName = suggested_name.c_str();
 	strFileName.TrimLeft();
 	strFileName.TrimRight();
 	//ファイル名に使えない文字を置き換える。
@@ -807,7 +807,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 		CString strURL;
 		CefString strURLC;
 		strURLC = browser->GetMainFrame()->GetURL();
-		strURL = strURLC.ToWString().c_str();
+		strURL = strURLC.c_str();
 		if (strURL.IsEmpty())
 			::SendMessageTimeout(hWindow, WM_APP_CEF_DOWNLOAD_BLANK_PAGE, (WPARAM)TRUE, NULL, SMTO_NORMAL, 1000, NULL);
 		else
@@ -878,7 +878,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 					}
 					if (strURL.IsEmpty())
 					{
-						strURL = download_item->GetURL().ToWString().c_str();
+						strURL = download_item->GetURL().c_str();
 					}
 					theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strURL);
 				}
@@ -930,7 +930,7 @@ void ClientHandler::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
 	if (download_item->IsValid())
 	{
 		CefString cefFulPath = download_item->GetFullPath();
-		LPCWSTR fullPath = cefFulPath.ToWString().c_str();
+		LPCWSTR fullPath = cefFulPath.c_str();
 		if (fullPath)
 			lstrcpyn(values.szFullPath, fullPath, 512);
 	}
@@ -1058,7 +1058,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	request->SetHeaderMap(cefHeaders);
 
 	CefString cefURL = request->GetURL();
-	CString strTranURL(cefURL.ToWString().c_str());
+	CString strTranURL(cefURL.c_str());
 	CString logmsg;
 
 	HWND hWindow = GetSafeParentWnd(browser);
@@ -1069,7 +1069,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 		dwLogData.mFUNCTION_NAME = _T("OnBeforeResourceLoad");
 		dwLogData.mMESSAGE1 = strTranURL;
-		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().ToWString().c_str());
+		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().c_str());
 		dwLogData.mMESSAGE3.Format(_T("IsMain:%s"), frame->IsMain() ? _T("TRUE") : _T("FALSE"));
 		theApp.AppendDebugViewLog(dwLogData);
 		logmsg = dwLogData.GetString();
@@ -1083,7 +1083,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		if (CefParseURL(cefURL, cfURLpa))
 		{
 			CefString cfHost(&cfURLpa.host);
-			strHost = cfHost.ToWString().c_str();
+			strHost = cfHost.c_str();
 		}
 		if (SBUtil::IsURL_HTTP(strTranURL))
 		{
@@ -1098,7 +1098,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	CefString newURL = request->GetURL();
 	CefURLParts cfURLparts;
 	LPCTSTR pszURL = NULL;
-	pszURL = newURL.ToWString().c_str();
+	pszURL = newURL.c_str();
 	if (CefParseURL(newURL, cfURLparts))
 	{
 		CefString cfScheme(&cfURLparts.scheme);
@@ -1106,9 +1106,9 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		CefString cfPath(&cfURLparts.path);
 		//CefString cfQuery(&cfURLparts.query);
 
-		CString strScheme(cfScheme.ToWString().c_str());
-		CString strHost(cfHost.ToWString().c_str());
-		CString strPath(cfPath.ToWString().c_str());
+		CString strScheme(cfScheme.c_str());
+		CString strHost(cfHost.c_str());
+		CString strPath(cfPath.c_str());
 
 		if (strScheme.Find(_T("http")) != 0) //http|https
 			return RV_CONTINUE;
@@ -1201,7 +1201,7 @@ void ClientHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
 					CString strURL;
 					CefString strURLC;
 					strURLC = browser->GetMainFrame()->GetURL();
-					strURL = strURLC.ToWString().c_str();
+					strURL = strURLC.c_str();
 					CString strRetFileName;
 					CStringArray stArr;
 					if (theApp.m_cCustomScriptList.HitWildCardURL(strURL, &stArr))
@@ -1568,7 +1568,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	CString errorPageHeadingName;
 	errorPageHeadingName.LoadString(ID_ERROR_PAGE_HEADING_NAME);
 
-	CString strFaildUrl(failedUrl.ToWString().c_str());
+	CString strFaildUrl(failedUrl.c_str());
 	strFaildUrl.Replace(_T("<"), _T(""));
 	strFaildUrl.Replace(_T(">"), _T(""));
 	strFaildUrl.Replace(_T("&"), _T(""));
@@ -1620,7 +1620,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	strErrorHTMLFmt += _T("</h4>");
 	strErrorHTMLFmt += _T("<h4>");
 	strErrorHTMLFmt += errorPageHeadingName;
-	strErrorHTMLFmt += errorText.ToWString().c_str();
+	strErrorHTMLFmt += errorText.c_str();
 	strErrorHTMLFmt += _T("</h4></div></div></div></div></body></html>");
 
 	CefString strCefErrorHTML(strErrorHTMLFmt);
@@ -1658,8 +1658,8 @@ bool ClientHandler::GetAuthCredentials(CefRefPtr<CefBrowser> browser,
 	HWND hWindow = GetSafeParentWnd(browser);
 
 	CEFAuthenticationValues values = {0};
-	values.lpszHost = host.ToWString().c_str();
-	values.lpszRealm = realm.ToWString().c_str();
+	values.lpszHost = host.c_str();
+	values.lpszRealm = realm.c_str();
 	_tcscpy_s(values.szUserName, _T(""));
 	_tcscpy_s(values.szUserPass, _T(""));
 	if (SafeWnd(hWindow))
@@ -1712,7 +1712,7 @@ bool ClientHandler::OnCertificateError(CefRefPtr<CefBrowser> browser,
 
 	CString confirmMsg;
 	confirmMsg.LoadString(IDS_STRING_CONFIRM_INSECURE_CONNECTION);
-	szMessage.Format(confirmMsg, request_url.ToWString().c_str());
+	szMessage.Format(confirmMsg, request_url.c_str());
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (hWindow)
 	{
@@ -1781,7 +1781,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 		CefString newURL = request->GetURL();
 		UINT bTopPage = FALSE;
 		LPCTSTR pszURL = NULL;
-		pszURL = newURL.ToWString().c_str();
+		pszURL = newURL.c_str();
 
 		if (frame)
 		{
@@ -1799,7 +1799,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 			CefString strName;
 			strName = frame->GetName();
 			CString strWindowName;
-			strWindowName = strName.ToWString().c_str();
+			strWindowName = strName.c_str();
 			if (!strWindowName.IsEmpty())
 			{
 				HWND hWindowFrame = {0};
@@ -1851,7 +1851,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 
 	CString confirmMessage;
 	CString enableMediaConfirmation;
-	CString requestOrigin = requesting_origin.ToWString().c_str();
+	CString requestOrigin = requesting_origin.c_str();
 	enableMediaConfirmation.LoadString(ID_ENABLE_MEDIA_CONFIRMATION);
 	confirmMessage.Format(enableMediaConfirmation, (LPCTSTR)requestOrigin);
 	confirmMessage += "\n";
@@ -1884,7 +1884,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 	dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 	dwLogData.mFUNCTION_NAME = _T("OnRequestMediaAccessPermission");
 	dwLogData.mMESSAGE1 = requestOrigin;
-	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().ToWString().c_str());
+	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().c_str());
 	dwLogData.mMESSAGE3.Format(_T("Approved permission type:%d"), requested_permissions);
 	theApp.AppendDebugViewLog(dwLogData);
 	theApp.WriteDebugTraceDateTime(dwLogData.GetString(), DEBUG_LOG_TYPE_URL);
@@ -1910,7 +1910,7 @@ bool ClientHandler::OnJSDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = message_text.ToWString().c_str();
+	pszMessage = message_text.c_str();
 	if (dialog_type == JSDIALOGTYPE_ALERT)
 	{
 		int iRet = theApp.SB_MessageBox(hWindow, pszMessage, NULL, MB_ICONWARNING | MB_OK | MB_TASKMODAL, TRUE);
@@ -1939,7 +1939,7 @@ bool ClientHandler::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = message_text.ToWString().c_str();
+	pszMessage = message_text.c_str();
 	CString strMsg;
 	strMsg = pszMessage;
 	//if(strMsg==_T("Is it OK to leave/reload this page?"))
@@ -1994,7 +1994,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				for (UINT i = 0; i < cefstrFiles.size(); i++)
 				{
 					cstrFileName = cefstrFiles[i];
-					strFileName = cstrFileName.ToWString().c_str();
+					strFileName = cstrFileName.c_str();
 					{
 						theApp.SendLoggingMsg(LOG_UPLOAD, strFileName, hWindow);
 					}
@@ -2008,7 +2008,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				CefString cstrFileName;
 				CString strFileName;
 				cstrFileName = dragData->GetLinkURL();
-				strFileName = cstrFileName.ToWString().c_str();
+				strFileName = cstrFileName.c_str();
 				theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strFileName);
 			}
 		}
@@ -2029,7 +2029,7 @@ bool ClientHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 {
 	CefString strName = message->GetName();
 	CString strFilterName;
-	strFilterName = strName.ToWString().c_str();
+	strFilterName = strName.c_str();
 	strFilterName.TrimLeft();
 	strFilterName.TrimRight();
 	if (strFilterName == _T("SET_PID"))
@@ -2063,9 +2063,9 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 3 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString())
 		{
-			CString strText(arguments[0]->GetStringValue().ToWString().c_str());
-			CString strCaption(arguments[1]->GetStringValue().ToWString().c_str());
-			CString strChronosExtParentWnd(arguments[2]->GetStringValue().ToWString().c_str());
+			CString strText(arguments[0]->GetStringValue().c_str());
+			CString strCaption(arguments[1]->GetStringValue().c_str());
+			CString strChronosExtParentWnd(arguments[2]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2120,10 +2120,10 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 4 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString() && arguments[3]->IsString())
 		{
-			CString strID(arguments[0]->GetStringValue().ToWString().c_str());
-			CString strText(arguments[1]->GetStringValue().ToWString().c_str());
-			CString strCaption(arguments[2]->GetStringValue().ToWString().c_str());
-			CString strChronosExtParentWnd(arguments[3]->GetStringValue().ToWString().c_str());
+			CString strID(arguments[0]->GetStringValue().c_str());
+			CString strText(arguments[1]->GetStringValue().c_str());
+			CString strCaption(arguments[2]->GetStringValue().c_str());
+			CString strChronosExtParentWnd(arguments[3]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2191,7 +2191,7 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 1 && arguments[0]->IsString())
 		{
-			CString strChronosExtParentWnd(arguments[0]->GetStringValue().ToWString().c_str());
+			CString strChronosExtParentWnd(arguments[0]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -615,7 +615,7 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString
 	{
 		LPCTSTR pszTitle = NULL;
 		std::wstring hoge = title.ToWString();
-		pszTitle = hoge.c_str();
+		pszTitle = (LPCTSTR)hoge.c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_TITLE_CHANGE, (WPARAM)pszTitle, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -712,7 +712,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			dwLogData.mFUNCTION_NAME = _T("ConsoleMessage");
 			dwLogData.mMESSAGE1 = (LPCTSTR)message.c_str();
 			dwLogData.mMESSAGE2 = strLogLevel;
-			dwLogData.mMESSAGE3.Format(_T("Source:%s"), source.c_str());
+			dwLogData.mMESSAGE3.Format(_T("Source:%s"), (LPCTSTR)source.c_str());
 			dwLogData.mMESSAGE4.Format(_T("Line:%d"), line);
 			theApp.AppendDebugViewLog(dwLogData);
 		}
@@ -725,7 +725,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			CString strLogPath;
 			strLogPath = theApp.m_strCEFCachePath;
 			strLogPath += _T("\\console.log");
-			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), message.c_str(), source.c_str(), line);
+			strWriteLine.Format(_T("Message:%s\nSource:%s\nLine:%d\n"), (LPCTSTR)message.c_str(), (LPCTSTR)source.c_str(), line);
 			_wsetlocale(LC_ALL, _T("jpn"));
 			CStdioFile stdFile;
 			if (stdFile.Open(strLogPath, CFile::modeWrite | CFile::shareDenyNone | CFile::modeCreate | CFile::modeNoTruncate))
@@ -1069,7 +1069,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 		dwLogData.mFUNCTION_NAME = _T("OnBeforeResourceLoad");
 		dwLogData.mMESSAGE1 = strTranURL;
-		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().c_str());
+		dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), (LPCTSTR)frame->GetName().c_str());
 		dwLogData.mMESSAGE3.Format(_T("IsMain:%s"), frame->IsMain() ? _T("TRUE") : _T("FALSE"));
 		theApp.AppendDebugViewLog(dwLogData);
 		logmsg = dwLogData.GetString();
@@ -1712,7 +1712,7 @@ bool ClientHandler::OnCertificateError(CefRefPtr<CefBrowser> browser,
 
 	CString confirmMsg;
 	confirmMsg.LoadString(IDS_STRING_CONFIRM_INSECURE_CONNECTION);
-	szMessage.Format(confirmMsg, request_url.c_str());
+	szMessage.Format(confirmMsg, (LPCTSTR)request_url.c_str());
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (hWindow)
 	{
@@ -1884,7 +1884,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 	dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 	dwLogData.mFUNCTION_NAME = _T("OnRequestMediaAccessPermission");
 	dwLogData.mMESSAGE1 = requestOrigin;
-	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), frame->GetName().c_str());
+	dwLogData.mMESSAGE2.Format(_T("FrameName:%s"), (LPCTSTR)frame->GetName().c_str());
 	dwLogData.mMESSAGE3.Format(_T("Approved permission type:%d"), requested_permissions);
 	theApp.AppendDebugViewLog(dwLogData);
 	theApp.WriteDebugTraceDateTime(dwLogData.GetString(), DEBUG_LOG_TYPE_URL);

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -614,8 +614,7 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString
 	if (SafeWnd(hWindow))
 	{
 		LPCWSTR pszTitle = NULL;
-		std::wstring hoge = title.ToWString();
-		pszTitle = (LPCWSTR)hoge.c_str();
+		pszTitle = (LPCWSTR)title.c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_TITLE_CHANGE, (WPARAM)pszTitle, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -137,7 +137,7 @@ bool ClientHandler::OnOpenURLFromTab(CefRefPtr<CefBrowser> browser,
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszURL = NULL;
-		pszURL = target_url.c_str();
+		pszURL = (LPCTSTR)target_url.c_str();
 		switch (target_disposition)
 		{
 		case cef_window_open_disposition_t::WOD_NEW_FOREGROUND_TAB:
@@ -345,7 +345,7 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = strCfSt.c_str();
+			strSelText = (LPCTSTR)strCfSt.c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			if (!strSelText.IsEmpty())
@@ -394,7 +394,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString strSelText;
 			CefString strCfSt;
 			strCfSt = params->GetSelectionText();
-			strSelText = strCfSt.c_str();
+			strSelText = (LPCTSTR)strCfSt.c_str();
 			strSelText.TrimLeft();
 			strSelText.TrimRight();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_SEARCH_URL, (WPARAM)(LPCTSTR)strSelText, (LPARAM)TRUE, SMTO_NORMAL, 1000, NULL);
@@ -405,7 +405,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = (LPCTSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -414,7 +414,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetLinkUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = (LPCTSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -423,7 +423,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = (LPCTSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_WINDOW, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -432,7 +432,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
 			LPCTSTR pszURL = {0};
-			pszURL = strURLC.c_str();
+			pszURL = (LPCTSTR)strURLC.c_str();
 			::SendMessageTimeout(hWindow, WM_NEW_WINDOW_URL, (WPARAM)cef_window_open_disposition_t::WOD_NEW_BACKGROUND_TAB, (LPARAM)pszURL, SMTO_NORMAL, 1000, NULL);
 			return true;
 		}
@@ -456,7 +456,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = strURLC.c_str();
+			str = (LPCTSTR)strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				//data:image/pngの場合があるので、IsURL判定を行わない。
@@ -488,11 +488,11 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetSourceUrl();
-			str = strURLC.c_str();
+			str = (LPCTSTR)strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				LPCTSTR pszURL = {0};
-				pszURL = strURLC.c_str();
+				pszURL = (LPCTSTR)strURLC.c_str();
 				::SendMessageTimeout(hWindow, WM_COPY_IMAGE, (WPARAM)(LPCTSTR)str, NULL, SMTO_NORMAL, 1000, NULL);
 				return true;
 			}
@@ -503,7 +503,7 @@ bool ClientHandler::OnContextMenuCommand(CefRefPtr<CefBrowser> browser,
 			CString str;
 			CefString strURLC;
 			strURLC = params->GetUnfilteredLinkUrl();
-			str = strURLC.c_str();
+			str = (LPCTSTR)strURLC.c_str();
 			if (!str.IsEmpty())
 			{
 				if (::OpenClipboard(NULL))
@@ -565,7 +565,7 @@ void ClientHandler::OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<Cef
 	{
 		if (frame->IsMain())
 		{
-			LPCTSTR pszURL = url.c_str();
+			LPCTSTR pszURL = (LPCTSTR)url.c_str();
 			::SendMessageTimeout(hWindow, WM_APP_CEF_ADDRESS_CHANGE, (WPARAM)pszURL, NULL, SMTO_NORMAL, 1000, NULL);
 		}
 	}
@@ -634,7 +634,7 @@ void ClientHandler::OnFaviconURLChange(CefRefPtr<CefBrowser> browser, const std:
 		for (UINT i = 0; i < icon_urls.size(); i++)
 		{
 			strIconList = icon_urls[i];
-			pszFavURL = strIconList.c_str();
+			pszFavURL = (LPCTSTR)strIconList.c_str();
 		}
 		if (pszFavURL)
 		{
@@ -654,7 +654,7 @@ void ClientHandler::OnStatusMessage(CefRefPtr<CefBrowser> browser, const CefStri
 	if (SafeWnd(hWindow))
 	{
 		LPCTSTR pszStatus = NULL;
-		pszStatus = value.c_str();
+		pszStatus = (LPCTSTR)value.c_str();
 		::SendMessageTimeout(hWindow, WM_APP_CEF_STATUS_MESSAGE, (WPARAM)pszStatus, NULL, SMTO_NORMAL, 1000, NULL);
 	}
 	// call parent
@@ -710,7 +710,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 			DebugWndLogData dwLogData;
 			dwLogData.mHWND.Format(_T("CV_WND:0x%08p"), hWindow);
 			dwLogData.mFUNCTION_NAME = _T("ConsoleMessage");
-			dwLogData.mMESSAGE1 = message.c_str();
+			dwLogData.mMESSAGE1 = (LPCTSTR)message.c_str();
 			dwLogData.mMESSAGE2 = strLogLevel;
 			dwLogData.mMESSAGE3.Format(_T("Source:%s"), source.c_str());
 			dwLogData.mMESSAGE4.Format(_T("Line:%d"), line);
@@ -771,7 +771,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 
 	m_bDownLoadStartFlg = TRUE;
 	CString strFileName;
-	strFileName = suggested_name.c_str();
+	strFileName = (LPCTSTR)suggested_name.c_str();
 	strFileName.TrimLeft();
 	strFileName.TrimRight();
 	//ファイル名に使えない文字を置き換える。
@@ -807,7 +807,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 		CString strURL;
 		CefString strURLC;
 		strURLC = browser->GetMainFrame()->GetURL();
-		strURL = strURLC.c_str();
+		strURL = (LPCTSTR)strURLC.c_str();
 		if (strURL.IsEmpty())
 			::SendMessageTimeout(hWindow, WM_APP_CEF_DOWNLOAD_BLANK_PAGE, (WPARAM)TRUE, NULL, SMTO_NORMAL, 1000, NULL);
 		else
@@ -878,7 +878,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 					}
 					if (strURL.IsEmpty())
 					{
-						strURL = download_item->GetURL().c_str();
+						strURL = (LPCTSTR)download_item->GetURL().c_str();
 					}
 					theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strURL);
 				}
@@ -930,7 +930,7 @@ void ClientHandler::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
 	if (download_item->IsValid())
 	{
 		CefString cefFulPath = download_item->GetFullPath();
-		LPCWSTR fullPath = cefFulPath.c_str();
+		LPCWSTR fullPath = (LPCTSTR)cefFulPath.c_str();
 		if (fullPath)
 			lstrcpyn(values.szFullPath, fullPath, 512);
 	}
@@ -1058,7 +1058,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	request->SetHeaderMap(cefHeaders);
 
 	CefString cefURL = request->GetURL();
-	CString strTranURL(cefURL.c_str());
+	CString strTranURL((LPCTSTR)cefURL.c_str());
 	CString logmsg;
 
 	HWND hWindow = GetSafeParentWnd(browser);
@@ -1083,7 +1083,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		if (CefParseURL(cefURL, cfURLpa))
 		{
 			CefString cfHost(&cfURLpa.host);
-			strHost = cfHost.c_str();
+			strHost = (LPCTSTR)cfHost.c_str();
 		}
 		if (SBUtil::IsURL_HTTP(strTranURL))
 		{
@@ -1098,7 +1098,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 	CefString newURL = request->GetURL();
 	CefURLParts cfURLparts;
 	LPCTSTR pszURL = NULL;
-	pszURL = newURL.c_str();
+	pszURL = (LPCTSTR)newURL.c_str();
 	if (CefParseURL(newURL, cfURLparts))
 	{
 		CefString cfScheme(&cfURLparts.scheme);
@@ -1106,9 +1106,9 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		CefString cfPath(&cfURLparts.path);
 		//CefString cfQuery(&cfURLparts.query);
 
-		CString strScheme(cfScheme.c_str());
-		CString strHost(cfHost.c_str());
-		CString strPath(cfPath.c_str());
+		CString strScheme((LPCTSTR)cfScheme.c_str());
+		CString strHost((LPCTSTR)cfHost.c_str());
+		CString strPath((LPCTSTR)cfPath.c_str());
 
 		if (strScheme.Find(_T("http")) != 0) //http|https
 			return RV_CONTINUE;
@@ -1201,7 +1201,7 @@ void ClientHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
 					CString strURL;
 					CefString strURLC;
 					strURLC = browser->GetMainFrame()->GetURL();
-					strURL = strURLC.c_str();
+					strURL = (LPCTSTR)strURLC.c_str();
 					CString strRetFileName;
 					CStringArray stArr;
 					if (theApp.m_cCustomScriptList.HitWildCardURL(strURL, &stArr))
@@ -1568,7 +1568,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	CString errorPageHeadingName;
 	errorPageHeadingName.LoadString(ID_ERROR_PAGE_HEADING_NAME);
 
-	CString strFaildUrl(failedUrl.c_str());
+	CString strFaildUrl((LPCTSTR)failedUrl.c_str());
 	strFaildUrl.Replace(_T("<"), _T(""));
 	strFaildUrl.Replace(_T(">"), _T(""));
 	strFaildUrl.Replace(_T("&"), _T(""));
@@ -1620,7 +1620,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 	strErrorHTMLFmt += _T("</h4>");
 	strErrorHTMLFmt += _T("<h4>");
 	strErrorHTMLFmt += errorPageHeadingName;
-	strErrorHTMLFmt += errorText.c_str();
+	strErrorHTMLFmt += (LPCTSTR)errorText.c_str();
 	strErrorHTMLFmt += _T("</h4></div></div></div></div></body></html>");
 
 	CefString strCefErrorHTML(strErrorHTMLFmt);
@@ -1658,8 +1658,8 @@ bool ClientHandler::GetAuthCredentials(CefRefPtr<CefBrowser> browser,
 	HWND hWindow = GetSafeParentWnd(browser);
 
 	CEFAuthenticationValues values = {0};
-	values.lpszHost = host.c_str();
-	values.lpszRealm = realm.c_str();
+	values.lpszHost = (LPCTSTR)host.c_str();
+	values.lpszRealm = (LPCTSTR)realm.c_str();
 	_tcscpy_s(values.szUserName, _T(""));
 	_tcscpy_s(values.szUserPass, _T(""));
 	if (SafeWnd(hWindow))
@@ -1781,7 +1781,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 		CefString newURL = request->GetURL();
 		UINT bTopPage = FALSE;
 		LPCTSTR pszURL = NULL;
-		pszURL = newURL.c_str();
+		pszURL = (LPCTSTR)newURL.c_str();
 
 		if (frame)
 		{
@@ -1799,7 +1799,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 			CefString strName;
 			strName = frame->GetName();
 			CString strWindowName;
-			strWindowName = strName.c_str();
+			strWindowName = (LPCTSTR)strName.c_str();
 			if (!strWindowName.IsEmpty())
 			{
 				HWND hWindowFrame = {0};
@@ -1851,7 +1851,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 
 	CString confirmMessage;
 	CString enableMediaConfirmation;
-	CString requestOrigin = requesting_origin.c_str();
+	CString requestOrigin = (LPCTSTR)requesting_origin.c_str();
 	enableMediaConfirmation.LoadString(ID_ENABLE_MEDIA_CONFIRMATION);
 	confirmMessage.Format(enableMediaConfirmation, (LPCTSTR)requestOrigin);
 	confirmMessage += "\n";
@@ -1910,7 +1910,7 @@ bool ClientHandler::OnJSDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = message_text.c_str();
+	pszMessage = (LPCTSTR)message_text.c_str();
 	if (dialog_type == JSDIALOGTYPE_ALERT)
 	{
 		int iRet = theApp.SB_MessageBox(hWindow, pszMessage, NULL, MB_ICONWARNING | MB_OK | MB_TASKMODAL, TRUE);
@@ -1939,7 +1939,7 @@ bool ClientHandler::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
 		hWindow = GetParent(hWindow);
 	}
 	LPCTSTR pszMessage = NULL;
-	pszMessage = message_text.c_str();
+	pszMessage = (LPCTSTR)message_text.c_str();
 	CString strMsg;
 	strMsg = pszMessage;
 	//if(strMsg==_T("Is it OK to leave/reload this page?"))
@@ -1994,7 +1994,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				for (UINT i = 0; i < cefstrFiles.size(); i++)
 				{
 					cstrFileName = cefstrFiles[i];
-					strFileName = cstrFileName.c_str();
+					strFileName = (LPCTSTR)cstrFileName.c_str();
 					{
 						theApp.SendLoggingMsg(LOG_UPLOAD, strFileName, hWindow);
 					}
@@ -2008,7 +2008,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				CefString cstrFileName;
 				CString strFileName;
 				cstrFileName = dragData->GetLinkURL();
-				strFileName = cstrFileName.c_str();
+				strFileName = (LPCTSTR)cstrFileName.c_str();
 				theApp.m_pLogDisp->SendLog(LOG_DOWNLOAD, strFileName, strFileName);
 			}
 		}
@@ -2029,7 +2029,7 @@ bool ClientHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
 {
 	CefString strName = message->GetName();
 	CString strFilterName;
-	strFilterName = strName.c_str();
+	strFilterName = (LPCTSTR)strName.c_str();
 	strFilterName.TrimLeft();
 	strFilterName.TrimRight();
 	if (strFilterName == _T("SET_PID"))
@@ -2063,9 +2063,9 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 3 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString())
 		{
-			CString strText(arguments[0]->GetStringValue().c_str());
-			CString strCaption(arguments[1]->GetStringValue().c_str());
-			CString strChronosExtParentWnd(arguments[2]->GetStringValue().c_str());
+			CString strText((LPCTSTR)arguments[0]->GetStringValue().c_str());
+			CString strCaption((LPCTSTR)arguments[1]->GetStringValue().c_str());
+			CString strChronosExtParentWnd((LPCTSTR)arguments[2]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2120,10 +2120,10 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 4 && arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsString() && arguments[3]->IsString())
 		{
-			CString strID(arguments[0]->GetStringValue().c_str());
-			CString strText(arguments[1]->GetStringValue().c_str());
-			CString strCaption(arguments[2]->GetStringValue().c_str());
-			CString strChronosExtParentWnd(arguments[3]->GetStringValue().c_str());
+			CString strID((LPCTSTR)arguments[0]->GetStringValue().c_str());
+			CString strText((LPCTSTR)arguments[1]->GetStringValue().c_str());
+			CString strCaption((LPCTSTR)arguments[2]->GetStringValue().c_str());
+			CString strChronosExtParentWnd((LPCTSTR)arguments[3]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())
@@ -2191,7 +2191,7 @@ bool MyV8Handler::Execute(const CefString& name,
 	{
 		if (iArgSize == 1 && arguments[0]->IsString())
 		{
-			CString strChronosExtParentWnd(arguments[0]->GetStringValue().c_str());
+			CString strChronosExtParentWnd((LPCTSTR)arguments[0]->GetStringValue().c_str());
 			CWnd* pWnd = NULL;
 			HWND hW = 0;
 			if (!strChronosExtParentWnd.IsEmpty())

--- a/client_handler.h
+++ b/client_handler.h
@@ -187,7 +187,7 @@ public:
 			CString strURL;
 			CefString strURLC;
 			strURLC = browser->GetMainFrame()->GetURL();
-			strURL = strURLC.c_str();
+			strURL = (LPCTSTR)strURLC.c_str();
 			if (strURL.IsEmpty())
 			{
 				HWND hRetNULL = {0};
@@ -345,7 +345,7 @@ public:
 	{
 		CefString strName = message->GetName();
 		CString strFilterName;
-		strFilterName = strName.c_str();
+		strFilterName = (LPCTSTR)strName.c_str();
 		strFilterName.TrimLeft();
 		strFilterName.TrimRight();
 		if (strFilterName == _T("GET_PID"))

--- a/client_handler.h
+++ b/client_handler.h
@@ -187,7 +187,7 @@ public:
 			CString strURL;
 			CefString strURLC;
 			strURLC = browser->GetMainFrame()->GetURL();
-			strURL = strURLC.ToWString().c_str();
+			strURL = strURLC.c_str();
 			if (strURL.IsEmpty())
 			{
 				HWND hRetNULL = {0};
@@ -345,7 +345,7 @@ public:
 	{
 		CefString strName = message->GetName();
 		CString strFilterName;
-		strFilterName = strName.ToWString().c_str();
+		strFilterName = strName.c_str();
 		strFilterName.TrimLeft();
 		strFilterName.TrimRight();
 		if (strFilterName == _T("GET_PID"))

--- a/client_handler.h
+++ b/client_handler.h
@@ -187,7 +187,7 @@ public:
 			CString strURL;
 			CefString strURLC;
 			strURLC = browser->GetMainFrame()->GetURL();
-			strURL = (LPCTSTR)strURLC.c_str();
+			strURL = (LPCWSTR)strURLC.c_str();
 			if (strURL.IsEmpty())
 			{
 				HWND hRetNULL = {0};
@@ -345,7 +345,7 @@ public:
 	{
 		CefString strName = message->GetName();
 		CString strFilterName;
-		strFilterName = (LPCTSTR)strName.c_str();
+		strFilterName = (LPCWSTR)strName.c_str();
 		strFilterName.TrimLeft();
 		strFilterName.TrimRight();
 		if (strFilterName == _T("GET_PID"))

--- a/client_handler.h
+++ b/client_handler.h
@@ -19,6 +19,9 @@
 
 #pragma warning(push, 0)
 #pragma warning(disable : 26812)
+#if CHROME_VERSION_MAJOR >= 115
+#define uint32 uint32_t
+#endif
 
 class MyV8Handler : public CefV8Handler
 {
@@ -184,7 +187,7 @@ public:
 			CString strURL;
 			CefString strURLC;
 			strURLC = browser->GetMainFrame()->GetURL();
-			strURL = strURLC.c_str();
+			strURL = strURLC.ToWString().c_str();
 			if (strURL.IsEmpty())
 			{
 				HWND hRetNULL = {0};
@@ -342,7 +345,7 @@ public:
 	{
 		CefString strName = message->GetName();
 		CString strFilterName;
-		strFilterName = strName.c_str();
+		strFilterName = strName.ToWString().c_str();
 		strFilterName.TrimLeft();
 		strFilterName.TrimRight();
 		if (strFilterName == _T("GET_PID"))


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#93

# What this PR does / why we need it:

最新のCEFに追従。

* CEFが独自定義していたcef_basictypesが廃止され、標準のタイプが使用されるされるようになっていたため、それに追従
  * https://bitbucket.org/chromiumembedded/cef/src/5735/include/base/cef_basictypes.h が廃止された
  * `uint32`から`uint32_t`になった
  * `char16`から`char16_t`になった
* `CefSettings.user_data_path`が廃止され`root_cache_path`となったので追従
* `CefX509CertPrincipal.GetStreetAddresses`が廃止されたので追従

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1.
2.

## Expected result:

> Describe the obvious situation to verify.
