### PR TITLE
Avoid to display the certificate selection dialog when the certificates size is 1

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1741,6 +1741,12 @@ bool ClientHandler::OnSelectClientCertificate(
 	if (certificates.empty())
 		return false;
 
+	if (certificates.size() == 1)
+	{
+		callback->Select(certificates[0]);
+		return true;
+	}
+
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (SafeWnd(hWindow))
 	{


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#99

# What this PR does / why we need it:

We don't need to display the certificate selection dialog when the certificates size is 1
because we always use that certificate, even if we select "Cancel" at the dialog.

# How to verify the fixed issue:

## The steps to verify:

**Preparation**

Follow the steps in the PR below to install multiple certificates.

https://github.com/ThinBridge/Chronos/pull/59

1. Open https://x509.w0.dk/ with multiple certificates
2. Uninstall the certificate and open https://x509.w0.dk/ with only one certificate

## Expected result:

1. the certificate selection dialog is displayed ...OK
2. The certificate selection dialog is not displayed ...OK
  * Only one certificate is used ...OK
