### PR TITLE
Reset m_pSettingDlg if the key combination is invalid.

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3477,6 +3477,8 @@ void CSazabi::ShowSettingDlg(CWnd* pParentWnd)
 		//隠し設定画面を表示する。Shiftキーを押している場合のみ表示
 		if (!bValidKeyCombi())
 		{
+			delete m_pSettingDlg;
+			this->m_pSettingDlg = NULL;
 			return;
 		}
 	}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/3

# What this PR does / why we need it:

Reset  m_pSettingDlg if the key combination is invalid.

After this patch applied, Chronos always displays "System administrator restricted access to this feature. " if the key combination to display the setting dialog is invalid.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Set a key combination for display the setting dialog from general setting.
2. Try to display the setting dialog with clicking tools -> settings multiple times
  * Don't press any keys and try to display the "System administrator restricted access to this feature. " dialog.

## Expected result:

* Display "System administrator restricted access to this feature. "  every time ...OK