### PR TITLE
Rename TB_Global_SCHME to TB_Global_SCHEME

### DIFF
--- a/sbcommon.h
+++ b/sbcommon.h
@@ -3321,7 +3321,7 @@ public:
 				CString strHelper;
 				CString strURL;
 				strURL = sURL;
-				CString TB_Global_SCHME;
+				CString TB_Global_SCHEME;
 				CString TB_Global_HOSTNAME;
 				CString TB_Global_PORT;
 				CString TB_Global_URL_PATH;
@@ -3349,8 +3349,8 @@ public:
 				urlcomponents.dwExtraInfoLength = URLBUFFER_SIZE;
 
 				InternetCrackUrl(strURL, 0, 0, &urlcomponents);
-				TB_Global_SCHME = urlcomponents.lpszScheme;
-				TB_Global_SCHME.Replace(_T("\""), _T("\"\""));
+				TB_Global_SCHEME = urlcomponents.lpszScheme;
+				TB_Global_SCHEME.Replace(_T("\""), _T("\"\""));
 				TB_Global_HOSTNAME = urlcomponents.lpszHostName;
 				TB_Global_HOSTNAME.Replace(_T("\""), _T("\"\""));
 				TB_Global_PORT.Format(_T("%d"), urlcomponents.nPort);
@@ -3360,8 +3360,11 @@ public:
 				TB_Global_URL_EXTRAINFO = urlcomponents.lpszExtraInfo;
 				TB_Global_URL_EXTRAINFO.Replace(_T("\""), _T("\"\""));
 
-				strHelper.Format(_T("Const TB_Global_SCHME=\"%s\"\r\nConst TB_Global_HOSTNAME=\"%s\"\r\nConst TB_Global_PORT=\"%s\"\r\nConst TB_Global_URL_PATH=\"%s\"\r\nConst TB_Global_URL_EXTRAINFO=\"%s\"\r\n"),
-						 (LPCTSTR)TB_Global_SCHME,
+				//We had mis-spelled TB_Global_SCHEME as TB_Global_SCHME in v13.1.112.0 or ealier.
+				//So we accept not only TB_Global_SCHME but also TB_Global_SCHME for backward compatibility.
+				strHelper.Format(_T("Const TB_Global_SCHME=\"%s\"\r\nConst TB_Global_SCHEME=\"%s\"\r\nConst TB_Global_HOSTNAME=\"%s\"\r\nConst TB_Global_PORT=\"%s\"\r\nConst TB_Global_URL_PATH=\"%s\"\r\nConst TB_Global_URL_EXTRAINFO=\"%s\"\r\n"),
+						 (LPCTSTR)TB_Global_SCHEME,
+						 (LPCTSTR)TB_Global_SCHEME,
 						 (LPCTSTR)TB_Global_HOSTNAME,
 						 (LPCTSTR)TB_Global_PORT,
 						 (LPCTSTR)TB_Global_URL_PATH,


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/49

# What this PR does / why we need it:

Fix a typo that TB_Global_SCHME should be TB_Global_SCHEME .
Some users may already use `TB_Global_SCHME`, so Chronos accepts not only TB_Global_SCHEME but also TB_Global_SCHME for backward compatibility.

# How to verify the fixed issue:

## The steps to verify:

Check if TB_Global_SCHME and TB_Global_SCHEME work fine.

1. Create a redirect script to log TB_Global_SCHEME and TB_Global_SCHME like below.
  ```
  Function OnRedirect()
    TB_TRACE_LOG("TB_Global_SCHEME："&TB_Global_SCHEME)
    TB_TRACE_LOG("TB_Global_SCHME："&TB_Global_SCHME)
  End Function
  ```
2. Open TRACE Log Monitor Window
3. Open any site

## Expected result:

TB_Global_SCHME and TB_Global_SCHEME have appropriate scheme. ...OK
They are displayed in TRACE Log Monitor Window like below.

```
#	Time	WndType	Function	Message1	Message2	Message3	Message4	Message5	Message6
26	10:15:27	APP_WND:0x00000000	CSG_Script	TB_Global_SCHEME：https
27	10:15:27	APP_WND:0x00000000	CSG_Script	TB_Global_SCHME：https
```