### PR TITLE
Apply .gitattributes for DlgSetting.cpp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-*.cpp working-tree-encoding=cp932 eol=CRLF
-*.h working-tree-encoding=cp932 eol=CRLF
-*.rc working-tree-encoding=cp932 eol=CRLF
-minhook/*.h working-tree-encoding=utf-8 eol=CRLF
-minhook/*/*.h working-tree-encoding=utf-8 eol=CRLF
+*.cpp working-tree-encoding=cp932 eol=CRLF diff=cp932
+*.h working-tree-encoding=cp932 eol=CRLF diff=cp932
+*.rc working-tree-encoding=cp932 eol=CRLF diff=cp932
+minhook/*.h working-tree-encoding=utf-8 eol=CRLF diff=utf-8
+minhook/*/*.h working-tree-encoding=utf-8 eol=CRLF diff=utf-8

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,8 +1,14 @@
 # Development Guidelines
 
+* Git config guidelines
 * Branch guidelines
 * Issue guidelines
 * Release guidelines
+
+## Git config guidelines
+
+* Set `git config diff.cp932.textconv "iconv -f CP932 -t UTF-8"` to avoid diffs due to character code
+  * E.g. Execute `git clone --config diff.cp932.textconv="iconv -f CP932 -t UTF-8" git@github.com:ThinBridge/Chronos.git` when cloning.
 
 ## Branch guidelines
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

DlgSetting.cpp not be applied .gitattributes.

# How to verify the fixed issue:

## The steps to verify:

1. Check if we can build Chronos

## Expected result:

1. Success to build
