### PR TITLE
Support CEF117 and above

### DIFF
--- a/Sazabi.vcxproj
+++ b/Sazabi.vcxproj
@@ -81,6 +81,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalOptions>/source-charset:.932 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -143,6 +144,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <ExceptionHandling>Async</ExceptionHandling>
       <AdditionalOptions>/source-charset:.932 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION

# Which issue(s) this PR fixes:

*  #108 

# What this PR does / why we need it:

This is still WIP draft need to resolve remained failures.

* sazabi: apply C++17 to enable std::in_place_t
 
It fixes the following error:

```
  D:\a\Chronos\Chronos\include\base\cef_ref_counted.h(487,1): error C2061: syntax error: identifier 'in_place_t' [D:\a\Chronos\Chronos\Sazabi.vcxproj]
  D:\a\Chronos\Chronos\include\base\cef_ref_counted.h(495): message : see reference to class template instantiation 'base::RefCountedData<T>' being compiled [D:\a\Chronos\Chronos\Sazabi.vcxproj]
```


# How to verify the fixed issue:

See ralated GitHub Actions and check succeeding stable and beta results.

## Expected result:

stable and beta build process succeeds.

