### PR TITLE
Hide "EnableUploadSync" configuration option from file manager settings

### DIFF
--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -2266,7 +2266,6 @@ void CDlgSetFileMgr::DoDataExchange(CDataExchange* pDX)
 
 BEGIN_MESSAGE_MAP(CDlgSetFileMgr, CPropertyPage)
 	ON_WM_DESTROY()
-	ON_BN_CLICKED(IDC_EnableUploadSync, &CDlgSetFileMgr::OnBnClickedULS)
 	ON_MESSAGE(ID_SETTING_OK, Set_OK)
 END_MESSAGE_MAP()
 
@@ -2304,35 +2303,15 @@ BOOL CDlgSetFileMgr::OnInitDialog()
 	else
 		((CButton*)GetDlgItem(IDC_ShowUploadTab))->SetCheck(0);
 
-	if (theApp.m_AppSettingsDlgCurrent.IsEnableUploadSync())
-		((CButton*)GetDlgItem(IDC_EnableUploadSync))->SetCheck(1);
-	else
-		((CButton*)GetDlgItem(IDC_EnableUploadSync))->SetCheck(0);
-
 	if (theApp.m_AppSettingsDlgCurrent.IsEnableUploadSyncMirror())
 		((CButton*)GetDlgItem(IDC_EnableUploadSyncMirror))->SetCheck(1);
 	else
 		((CButton*)GetDlgItem(IDC_EnableUploadSyncMirror))->SetCheck(0);
 
-	this->ChangeStateULS();
+	GetDlgItem(IDC_UploadSyncInterval)->EnableWindow(TRUE);
+	GetDlgItem(IDC_EnableUploadSyncMirror)->EnableWindow(TRUE);
+
 	return FALSE;
-}
-void CDlgSetFileMgr::OnBnClickedULS()
-{
-	this->ChangeStateULS();
-}
-void CDlgSetFileMgr::ChangeStateULS()
-{
-	if (((CButton*)GetDlgItem(IDC_EnableUploadSync))->GetCheck() == 1)
-	{
-		GetDlgItem(IDC_UploadSyncInterval)->EnableWindow(TRUE);
-		GetDlgItem(IDC_EnableUploadSyncMirror)->EnableWindow(TRUE);
-	}
-	else
-	{
-		GetDlgItem(IDC_UploadSyncInterval)->EnableWindow(FALSE);
-		GetDlgItem(IDC_EnableUploadSyncMirror)->EnableWindow(FALSE);
-	}
 }
 
 LRESULT CDlgSetFileMgr::Set_OK(WPARAM wParam, LPARAM lParam)
@@ -2386,11 +2365,6 @@ LRESULT CDlgSetFileMgr::Set_OK(WPARAM wParam, LPARAM lParam)
 		theApp.m_AppSettingsDlgCurrent.SetShowUploadTab(1);
 	else
 		theApp.m_AppSettingsDlgCurrent.SetShowUploadTab(0);
-
-	if (((CButton*)GetDlgItem(IDC_EnableUploadSync))->GetCheck() == 1)
-		theApp.m_AppSettingsDlgCurrent.SetEnableUploadSync(1);
-	else
-		theApp.m_AppSettingsDlgCurrent.SetEnableUploadSync(0);
 
 	if (((CButton*)GetDlgItem(IDC_EnableUploadSyncMirror))->GetCheck() == 1)
 		theApp.m_AppSettingsDlgCurrent.SetEnableUploadSyncMirror(1);

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -579,7 +579,6 @@ protected:
 	afx_msg void OnSize(UINT nType, int cx, int cy);
 	afx_msg void OnPaint();
 	afx_msg void OnEnableCtrl();
-	afx_msg void OnBnClickedULS();
 	LRESULT Set_OK(WPARAM wParam, LPARAM lParam);
 	DECLARE_MESSAGE_MAP()
 	void ChangeStateULS();

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -13,7 +13,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// 日本語 resources
+// 日本語 (ニュートラル) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
 LANGUAGE LANG_JAPANESE, SUBLANG_NEUTRAL
@@ -96,7 +96,7 @@ BEGIN
     END
 END
 
-#endif    // 日本語 resources
+#endif    // 日本語 (ニュートラル) resources
 /////////////////////////////////////////////////////////////////////////////
 
 
@@ -362,8 +362,7 @@ BEGIN
     CONTROL         "「開封済みにする」を行った場合に、確認メッセージを表示しない",IDC_DisableOpendOpAlert,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,266,202,10
     LTEXT           "※拡張子を複数設定する場合は、|で区切ります。例）|.elf|.lnk|",IDC_STATIC,12,74,187,8
-    CONTROL         "アップロードアイテムを自動更新する",IDC_EnableUploadSync,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,204,119,10
-    CONTROL         "ミラーリングモードを有効にする",IDC_EnableUploadSyncMirror,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,148,204,103,10
+    CONTROL         "ミラーリングモードを有効にする",IDC_EnableUploadSyncMirror,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,204,103,10
     LTEXT           "自動更新間隔(ミリ秒)",IDC_STATIC,17,220,68,8
     EDITTEXT        IDC_UploadSyncInterval,104,218,109,14,ES_AUTOHSCROLL
 END
@@ -1380,7 +1379,7 @@ END
 
 
 /////////////////////////////////////////////////////////////////////////////
-// 英語 resources
+// 英語 (ニュートラル) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_NEUTRAL
@@ -1716,9 +1715,8 @@ BEGIN
     CONTROL         "Never confirm for ""mark as opened"" command",IDC_DisableOpendOpAlert,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,266,202,10
     LTEXT           "*Separate multiple file extensions with a pipe |. For example: |.elf|.lnk|",IDC_STATIC,12,74,187,8
-    CONTROL         "Auto-sync upload items",IDC_EnableUploadSync,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,204,119,10
     CONTROL         "Enable mirroring mode for upload items",IDC_EnableUploadSyncMirror,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,148,204,103,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,204,103,10
     LTEXT           "Interval of auto-sync (in milliseconds)",IDC_STATIC,17,220,68,8
     EDITTEXT        IDC_UploadSyncInterval,104,218,109,14,ES_AUTOHSCROLL
 END
@@ -2758,7 +2756,7 @@ BEGIN
     ID_CERTIFICATION_VALID_PERIOD "Valid period: "
 END
 
-#endif    // 英語 resources
+#endif    // 英語 (ニュートラル) resources
 /////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

See Chronos-SG issue because of file manager feature.

# What this PR does / why we need it:

EnableUploadSync seems that itself is no role to change the behavior currently.
(Syncing file does not have nothing to do with this option)

# How to verify the fixed issue:

* Launch Chronos with system guard
* Confirm no auto update checkbox

## Expected result:

No "auto update" checkbox for file manager.

