### PR TITLE
CDlgSCEditor: fix "Items" to "Count"

### DIFF
--- a/DlgDebugWnd.cpp
+++ b/DlgDebugWnd.cpp
@@ -672,7 +672,7 @@ BOOL CDlgSCEditor::PreTranslateMessage(MSG* pMsg)
 
 			dwLineIndex = (DWORD)m_Edit.SendMessage(EM_LINEFROMCHAR, -1, 0);
 			CString strLineCount;
-			strLineCount.LoadString(ID_DEBUG_ITEMS_COUNT);
+			strLineCount.LoadString(ID_DEBUG_LINES_COUNT);
 			strLine.Format(strLineCount, dwLineIndex + 1);
 			SetDlgItemText(IDC_STATIC_LINE, strLine);
 			return lr;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/16

# What this PR does / why we need it:

A count message at up right of Script Editor Window is "件（Items）" now,
but "行(Lines)" seems to be more appropriate.

# How to verify the fixed issue:
## The steps to verify:

1. Show Script Editor Window
2. Check the count message at up right of the window.

## Expected result:

The count message is "行"

![image](https://github.com/ThinBridge/Chronos/assets/15982708/82997c8d-0f7f-44ba-8e00-64dad875c6df)
