### PR TITLE
Add support for in-memory cache if IsEnableMemcache is true.

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4209,7 +4209,10 @@ void CSazabi::InitializeCef()
 	}
 	settings.persist_session_cookies = true;
 	CefString(&settings.root_cache_path) = m_strCEFCachePath;
-	CefString(&settings.cache_path) = m_strCEFCachePath;
+	if (!this->m_AppSettings.IsEnableMemcache())
+	{
+		CefString(&settings.cache_path) = m_strCEFCachePath;
+	}
 
 	CString strUserDataPath;
 	strUserDataPath = m_strCEFCachePath;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/30

# What this PR does / why we need it:

Set `cache_path` empty if `IsEnableMemcache` is true.
If `cache_path` is empty, CEF uses in-memory caches for storage and no data is persisted to disk.

https://cef-builds.spotifycdn.com/docs/114.2/structcef__settings__t.html#ad1644a7eb23cad969181db010f007710

By this change, Chronos behaves like the label means.

# How to verify the fixed issue:

## The steps to verify:

"Cache path" used below is `C:\Program Files\Chronos\CEFCache` if SG mode, and `C:\Users\<user>\AppData\Local\ChronosCache` if native mode. 

1. Check "メモリーキャッシュモードを有効にする" in settings
2. Remove cache path manually.
3. Reboot Chronos
4. Check data in cache path
5. Uncheck "メモリーキャッシュモードを有効にする" in settings
6. Remove Cache path manually.
7. Reboot Chronos
8. Check data in cache path

## Expected result:

1. If "メモリーキャッシュモードを有効にする" is checked, cache files are not created in cache path.
    * Note that user data is stored in cache path when using CEF115+.
1. If "メモリーキャッシュモードを有効にする" is not checked, cache files are created in cache path.