### PR TITLE
Show DevTools window correctly without resizing

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1545,9 +1545,11 @@ void CChildView::ShowDevTools()
 		{
 			CefWindowInfo windowInfo;
 			CefBrowserSettings settings;
-			OnNewWindow((WPARAM)WND_TYPE_DEV_TOOLS, (LPARAM)&windowInfo);
 			CefRefPtr<CefClient> client;
 			CefPoint inspect_element_at;
+			// Show DevTools window as popup
+			// See https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=17820
+			windowInfo.SetAsPopup(theApp.SafeWnd(this->m_hWnd), "ChronosDevTools");
 			m_cefBrowser->GetHost()->ShowDevTools(windowInfo, client, settings, inspect_element_at);
 		}
 	}


### PR DESCRIPTION

# Which issue(s) this PR fixes:

CSG#13

# What this PR does / why we need it:


In the previous versions, it needs to resize explicitly to show DevTools content correctly.

As setting as popup window and delegate creating window to cefBrowser, it can show DevTools window without resizing on startup.

See https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=17820

# How to verify the fixed issue:

1. Launch ChronosN.exe
2. Access Chronos - Settings > Custom Scripting
3. Launch Developer Tools

## Expected result:

DevTools window is shown correctly without resizing it.

