### PR TITLE
Fix pDetelnetopWnd to pDesktopWnd

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -2891,9 +2891,9 @@ void CBrowserFrame::OnCloseDelay()
 	this->EnableWindow(FALSE);
 	ShowWindow(SW_HIDE);
 }
-int CBrowserFrame::OnMouseActivate(CWnd* pDetelnetopWnd, UINT nHitTest, UINT message)
+int CBrowserFrame::OnMouseActivate(CWnd* pDesktopWnd, UINT nHitTest, UINT message)
 {
-	int iRet = CFrameWnd::OnMouseActivate(pDetelnetopWnd, nHitTest, message);
+	int iRet = CFrameWnd::OnMouseActivate(pDesktopWnd, nHitTest, message);
 	return iRet;
 }
 

--- a/BroFrame.h
+++ b/BroFrame.h
@@ -282,7 +282,7 @@ public:
 	afx_msg void OnFavoriteOrganize();
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnFullScreen();
-	afx_msg int OnMouseActivate(CWnd* pDetelnetopWnd, UINT nHitTest, UINT message);
+	afx_msg int OnMouseActivate(CWnd* pDesktopWnd, UINT nHitTest, UINT message);
 	afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
 	afx_msg void OnPrevWnd();
 	afx_msg void OnNextWnd();


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This is a cosmetic change, but there is no reason to keep it ambiguous.

See https://learn.microsoft.com/ja-jp/cpp/mfc/reference/cwnd-class?view=msvc-170#onmouseactivatep why it should be pDesktopWnd.

```
  afx_msg int OnMouseActivate(
    CWnd* pDesktopWnd,
    UINT nHitTest,
    UINT message);
```


# How to verify the fixed issue:

N/A. 
it's internal change.
