### PR TITLE
Use more meaningful label for output logging configuration

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -1599,7 +1599,7 @@ BEGIN
     CONTROL         "1:Output to OutputDebugString only (no file output)",IDC_RADIO_LOG_NOFILE,
                     "Button",BS_AUTORADIOBUTTON,27,46,171,10
     CONTROL         "2:Output only general information [GE] and URL [URL] to a log file",IDC_RADIO_LOG_GE_URL,
-                    "Button",BS_AUTORADIOBUTTON,27,58,173,10
+                    "Button",BS_AUTORADIOBUTTON,27,58,231,10
     PUSHBUTTON      "Open TRACE Log Monitor Window...",IDC_BUTTON1,8,76,117,14
     GROUPBOX        "Audit log options",IDC_STATIC,10,97,350,185,WS_GROUP
     CONTROL         "Enable audit logs output",IDC_CHECK_EnableLogging,

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -243,7 +243,7 @@ CAPTION "ログ出力設定"
 FONT 9, "MS UI Gothic", 0, 0, 0x1
 BEGIN
     GROUPBOX        "DebugLog",IDC_STATIC,10,7,350,66,WS_GROUP
-    CONTROL         "DebugLog出力を有効にする",IDC_CHECK_ENABLE_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,20,105,10
+    CONTROL         "ログをファイルへ出力する",IDC_CHECK_ENABLE_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,20,105,10
     CONTROL         "0:全てのログ種別を出力",IDC_RADIO_LOG_ALL,"Button",BS_AUTORADIOBUTTON,27,34,93,10
     CONTROL         "1:ファイル出力なし、OutputDebugString出力のみ",IDC_RADIO_LOG_NOFILE,
                     "Button",BS_AUTORADIOBUTTON,27,46,171,10
@@ -1594,7 +1594,7 @@ CAPTION "Logging"
 FONT 9, "MS UI Gothic", 0, 0, 0x1
 BEGIN
     GROUPBOX        "DebugLog",IDC_STATIC,10,7,350,66,WS_GROUP
-    CONTROL         "Enable DebugLog output",IDC_CHECK_ENABLE_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,20,105,10
+    CONTROL         "Enable logging to file",IDC_CHECK_ENABLE_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,20,82,10
     CONTROL         "0:Output all logs",IDC_RADIO_LOG_ALL,"Button",BS_AUTORADIOBUTTON,27,34,93,10
     CONTROL         "1:Output to OutputDebugString only (no file output)",IDC_RADIO_LOG_NOFILE,
                     "Button",BS_AUTORADIOBUTTON,27,46,171,10


### PR DESCRIPTION

# Which issue(s) this PR fixes:

CSG#14

# What this PR does / why we need it:

Even though this option is disabled, it is still enabled for loggging with TRACE Log Monitor Window.
Thus this option actually controls whether output to Chronos trace.log or not.

It should represent actual behaviour precisely.

# How to verify the fixed issue:

1. Launch ChronosN.exe
2. Click Tools > Preferences menu
3. Check Logging category and DebugLog preference  

## Expected result:

* Label is changed to "Enable logging output to file"