### PR TITLE
Fix typo in comment

### DIFF
--- a/CWnd.h
+++ b/CWnd.h
@@ -158,7 +158,7 @@ protected:
 	virtual DECLH(OnSize);		  // WM_SIZE
 	virtual DECLH(OnMove);		  // WM_MOVE
 	virtual DECLH(OnClose);		  // WM_CLOSE
-	virtual DECLH(OnDestroy);	  // WM_DSESTROY
+	virtual DECLH(OnDestroy);	  // WM_DESTROY
 	virtual DECLH(OnQueryEndSession); // WM_QUERYENDSESSION
 
 	virtual DECLH(OnMeasureItem);	 // WM_MEASUREITEM

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -308,7 +308,7 @@ public:
 	virtual BOOL PreTranslateMessage(MSG* pMsg);
 
 protected:
-	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV supportk
+	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 	// Implementation

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1939,7 +1939,7 @@ void CSazabi::CloseVOSProcessOther()
 				continue;
 			HWND hWndTop = {0};
 			hWndTop = GetTopWindowHandle(pid);
-			//filenamagerは特別な対応
+			//filemanagerは特別な対応
 			if (strValue.CompareNoCase(strThinFilerPath) == 0)
 			{
 				CString strFWM;
@@ -4383,7 +4383,7 @@ BOOL CSazabi::IsLimitChkEx()
 		//check max limit
 		unsigned long long iMemSize = GetMemoryUsageSize();
 		size_t iMemL = m_AppSettings.GetMemoryUsageLimit();
-		//GDI/ User /Mamory Limits
+		//GDI/ User /Memory Limits
 		if (iMemSize > (unsigned long long)iMemL * 1024 * 1024)
 		{
 			CString alertMsg;

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -3360,7 +3360,7 @@ public:
 				TB_Global_URL_EXTRAINFO = urlcomponents.lpszExtraInfo;
 				TB_Global_URL_EXTRAINFO.Replace(_T("\""), _T("\"\""));
 
-				//We had mis-spelled TB_Global_SCHEME as TB_Global_SCHME in v13.1.112.0 or ealier.
+				//We had mis-spelled TB_Global_SCHEME as TB_Global_SCHME in v13.1.112.0 or earlier.
 				//So we accept not only TB_Global_SCHME but also TB_Global_SCHME for backward compatibility.
 				strHelper.Format(_T("Const TB_Global_SCHME=\"%s\"\r\nConst TB_Global_SCHEME=\"%s\"\r\nConst TB_Global_HOSTNAME=\"%s\"\r\nConst TB_Global_PORT=\"%s\"\r\nConst TB_Global_URL_PATH=\"%s\"\r\nConst TB_Global_URL_EXTRAINFO=\"%s\"\r\n"),
 						 (LPCTSTR)TB_Global_SCHEME,


### PR DESCRIPTION

# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This is cosmetic change, but there is no reason to keep it ambiguous.

* DSESTROY => DESTROY
* Mamory => Memory
* supportk => support
* ealier => earlier
* filenamager => filemanager


# How to verify the fixed issue:

This is internal change.

