### PR TITLE
Use win32 default dialog to select client certificate

### DIFF
--- a/client_handler.h
+++ b/client_handler.h
@@ -17,6 +17,8 @@
 #pragma warning(pop)
 #include "resource.h"
 
+#include <cryptuiapi.h>
+
 #pragma warning(push, 0)
 #pragma warning(disable : 26812)
 #if CHROME_VERSION_MAJOR >= 115
@@ -286,6 +288,9 @@ public:
 					      CefRefPtr<CefFrame> frame,
 					      CefProcessId source_process,
 					      CefRefPtr<CefProcessMessage> message) override;
+
+	CString GetSerialNumberAsHexString(const CefRefPtr<CefX509Certificate> certificate);
+	CString GetSerialNumberAsHexString(PCERT_INFO pCertInfo);
 
 protected:
 	BOOL m_bDownLoadStartFlg;

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -699,6 +699,33 @@ namespace SBUtil
 		AttachThreadInput(nTargetID, nForegroundID, FALSE); // FALSE で切り離し
 	}
 
+	// Usually IsWindowsXXOrGreater version helper API should be used,
+	// but there is no IsWindows11OrGreater API yet.
+	// NOTE: GetVersionEx return information which depends on manifest,
+	// so use RtlGetVersion API.
+	static inline bool IsWindows11OrLater()
+	{
+		auto versionInfo = RTL_OSVERSIONINFOW{sizeof(RTL_OSVERSIONINFOW), 0, 0, 0, 0, 0};
+		auto hModule = GetModuleHandle(L"ntdll.dll");
+		if (!hModule)
+		{
+			return false;
+		}
+
+		typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW lpVersionInformation);
+		auto RtlGetVersion = (RtlGetVersionPtr)GetProcAddress(hModule, "RtlGetVersion");
+		if (!RtlGetVersion)
+		{
+			return false;
+		}
+		if (RtlGetVersion(&versionInfo))
+		{
+			return false;
+		}
+		return (versionInfo.dwMajorVersion >= 11 || // for future version
+			(versionInfo.dwMajorVersion == 10 && versionInfo.dwBuildNumber >= 22000)); // for Windows 11
+	}
+
 	/////////////////////////////////////////////////////////////////
 	struct RTL_USER_PROCESS_PARAMETERS_I
 	{


### PR DESCRIPTION

# Which issue(s) this PR fixes:

#104 

# What this PR does / why we need it:

In the previous versions, we use custom dialog
which was implemented in DlgCertification class.

It works well, but there are some non user-friendly point to distinct client certificate
because it adopts custom user-interface which is
different from Edge or Chrome.

In this commit, we use Crypt UI API to show default dialog. this change improves user experience.

# How to verify the fixed issue:

* Import client certificate 2 or more.
  * https://x509.w0.dk/john.doe_example.org.p12
  * [john.doe.ghost_example.org.p12.zip](https://github.com/ThinBridge/Chronos/files/13344140/john.doe.ghost_example.org.p12.zip)
* Set StartURL=https://x509.w0.dk/ in ChronosDefault.conf
* Access https://sx509.w0.dk/
* It should show client certificate selection dialog
* If you select client certificate, you can get certificate information from navigated browser window.
