### PR TITLE
Fix build error with recent CEF beta

### DIFF
--- a/Sazabi.h
+++ b/Sazabi.h
@@ -30,9 +30,9 @@
 #define CEF_PROC_GPU	  2
 #define CEF_PROC_OTHER	  3
 
-#if CHROME_VERSION_MAJOR < 119
-// Since CEF 119, cef_window_open_disposition_t was changed to
-// add CEF_ prefix.
+#if CHROME_VERSION_MAJOR < 119 || (CHROME_VERSION_MAJOR == 119 && CHROME_VERSION_PATCH < 124)
+// Since CEF 119.4.2, cef_window_open_disposition_t was changed to
+// add CEF_ prefix. (chromium-119.0.6045.124)
 #define CEF_WOD_CURRENT_TAB			WOD_CURRENT_TAB
 #define CEF_WOD_SINGLETON_TAB		WOD_SINGLETON_TAB
 #define CEF_WOD_NEW_FOREGROUND_TAB	WOD_NEW_FOREGROUND_TAB


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Since cef_binary_119.4.2+g2d7731b+chromium-119.0.6045.124, enum type was changed. Thus only CHROME_MAJOR_VERSION condition is inappropriate.

# How to verify the fixed issue:

See CI result.

https://github.com/kenhys/Chronos/actions/runs/6924358736

## Expected result:

Chronos(beta) build will pass CI.
