### PR TITLE
Disable to edit default Upload/Download field

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -342,7 +342,7 @@ FONT 9, "MS UI Gothic", 0, 0, 0x1
 BEGIN
     GROUPBOX        "全体設定",IDC_STATIC,8,6,343,79
     LTEXT           "ダウンロード/アップロードアイテムの既定のパス",IDC_STATIC,12,18,132,8
-    EDITTEXT        IDC_RootPath,160,18,179,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_RootPath,160,18,179,14,ES_AUTOHSCROLL | ES_READONLY | WS_DISABLED
     LTEXT           "表示するアイテムの拡張子",IDC_STATIC,12,37,79,8
     EDITTEXT        IDC_ExtFilter,160,38,179,14,ES_AUTOHSCROLL
     LTEXT           "実行、開封、転送を禁止する拡張子",IDC_STATIC,12,56,111,8
@@ -1700,7 +1700,7 @@ FONT 9, "MS UI Gothic", 0, 0, 0x1
 BEGIN
     GROUPBOX        "General options",IDC_STATIC,8,6,343,79
     LTEXT           "Default path of downloaded and uploaded items",IDC_STATIC,12,18,132,8
-    EDITTEXT        IDC_RootPath,160,18,179,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_RootPath,160,18,179,14,ES_AUTOHSCROLL | ES_READONLY | WS_DISABLED
     LTEXT           "File extensions for visible items",IDC_STATIC,12,37,79,8
     EDITTEXT        IDC_ExtFilter,160,38,179,14,ES_AUTOHSCROLL
     LTEXT           "File extensions to forbid running, opening and transferring",IDC_STATIC,12,56,111,8


### PR DESCRIPTION
# Which issue(s) this PR fixes:

CSG#5

# What this PR does / why we need it:

Chronos doesn't expect the default Upload/Download path is changed from B: drive.
In other words, if changed from B: to something, it doesn't work expected.

This situation is not use-friendly, so disable it by default.

# How to verify the fixed issue:

1. Show Tool > Preferences > File Manager

## Expected result:

Text edit field about drive information is readonly.
