### PR TITLE
APIHook: fix to set api hooks only when target dlls exists

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -1052,46 +1052,48 @@ void APIHookC::DoHookComDlgAPI()
 	}
 
 	hModule = GetModuleHandleW(L"comdlg32.dll");
-
-	if (!pORG_GetSaveFileNameW)
+	if (hModule)
 	{
-		if (hModule)
+		if (!pORG_GetSaveFileNameW)
+		{
 			pTargetW = GetProcAddress(hModule, "GetSaveFileNameW");
-		if (MH_CreateHookApiEx(
-			L"comdlg32.dll", "GetSaveFileNameW", &Hook_GetSaveFileNameW, &pORG_GetSaveFileNameW) != MH_OK)
-			return;
+			if (MH_CreateHookApiEx(
+				L"comdlg32.dll", "GetSaveFileNameW", &Hook_GetSaveFileNameW, &pORG_GetSaveFileNameW) != MH_OK)
+				return;
 
-		if (pTargetW == NULL) return;
-		if (MH_EnableHook(pTargetW) != MH_OK)
-			return;
-	}
+			if (pTargetW == NULL) return;
+			if (MH_EnableHook(pTargetW) != MH_OK)
+				return;
+		}
 
-	if (!pORG_GetOpenFileNameW)
-	{
-		if (hModule)
+		if (!pORG_GetOpenFileNameW)
+		{
 			pTargetW = GetProcAddress(hModule, "GetOpenFileNameW");
-		if (MH_CreateHookApiEx(
-			L"comdlg32.dll", "GetOpenFileNameW", &Hook_GetOpenFileNameW, &pORG_GetOpenFileNameW) != MH_OK)
-			return;
+			if (MH_CreateHookApiEx(
+				L"comdlg32.dll", "GetOpenFileNameW", &Hook_GetOpenFileNameW, &pORG_GetOpenFileNameW) != MH_OK)
+				return;
 
-		if (pTargetW == NULL) return;
-		if (MH_EnableHook(pTargetW) != MH_OK)
-			return;
+			if (pTargetW == NULL) return;
+			if (MH_EnableHook(pTargetW) != MH_OK)
+				return;
+		}
 	}
 
 	////////////////////////////////////////////////////////////
 	hModule = GetModuleHandleW(L"shell32.dll");
-	if (!pORG_SHBrowseForFolderW)
+	if (hModule)
 	{
-		if (hModule)
+		if (!pORG_SHBrowseForFolderW)
+		{
 			pTargetW = GetProcAddress(hModule, "SHBrowseForFolderW");
-		if (MH_CreateHookApiEx(
-			L"shell32.dll", "SHBrowseForFolderW", &Hook_SHBrowseForFolderW, &pORG_SHBrowseForFolderW) != MH_OK)
-			return;
+			if (MH_CreateHookApiEx(
+				L"shell32.dll", "SHBrowseForFolderW", &Hook_SHBrowseForFolderW, &pORG_SHBrowseForFolderW) != MH_OK)
+				return;
 
-		if (pTargetW == NULL) return;
-		if (MH_EnableHook(pTargetW) != MH_OK)
-			return;
+			if (pTargetW == NULL) return;
+			if (MH_EnableHook(pTargetW) != MH_OK)
+				return;
+		}
 	}
 	if (!pORG_CoCreateInstance)
 	{


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/120

# What this PR does / why we need it:

When using CEF119, `GetModuleHandleW(L"comdlg32.dll")` returns `NULL`, and failing to override `GetSaveFileNameW`, and the `DoHookComDlgAPI` function ends(returns) just then.
But we should try to override rest of APIs because it seems that `NULL` of  `GetModuleHandleW(L"comdlg32.dll")` means just "CEF doesn't use `comdlg32.dll`".
[GetModuleHandleW](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandlew) returns null if the target module is not loaded.

So I have added existence checks for target modules and skip to set API Hook if they don't exist.

# How to verify the fixed issue:

## The steps to verify:

1. Specify "ファイルのアップロードを禁止する" in "機能制限設定"
2. Try to upload some files to a web site
   * e.g. https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/file

## Expected result:

Block to upload with "ファイル アップロードは、システム管理者により禁止されています"
