### PR TITLE
Fix a bug that some messages are not handled on Windows11

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1641,7 +1641,8 @@ int CSazabi::ExitInstance()
 						}
 						else
 						{
-							iRt = ::MessageBox(NULL, strMsg, m_strThisAppName, MB_YESNO | MB_ICONQUESTION | MB_SYSTEMMODAL);
+							//settings.external_message_pump = trueを指定した状態では、Exit処理中にはMB_DEFAULT_DESKTOP_ONLYがないとダイアログが表示されない
+							iRt = ::MessageBox(NULL, strMsg, m_strThisAppName, MB_YESNO | MB_ICONQUESTION | MB_SYSTEMMODAL | MB_DEFAULT_DESKTOP_ONLY);
 						}
 
 						if (iRt == IDCANCEL || iRt == IDNO || iRt == IDTIMEOUT)
@@ -4154,6 +4155,7 @@ void CSazabi::InitializeCef()
 	// (CefDoMessageLoopWork()をメインプログラムから呼び出す)
 	m_bMultiThreadedMessageLoop = FALSE;
 	settings.multi_threaded_message_loop = m_bMultiThreadedMessageLoop;
+	settings.external_message_pump = true;
 
 	settings.no_sandbox = true;
 	if (!m_IsSGMode)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/119

# What this PR does / why we need it:

Set CEF's `external_message_pump` setting `TRUE`.

This patch fixes a bug that shortcut keys like "Ctrl + N (new tab)" don't work on Windows 11.
Also, this patch fixes a bug that a Chronos process is left after exiting on Windows 11.

https://cef-builds.spotifycdn.com/docs/119.1/structcef__settings__t.html#af11b432414c7002991e3b6ae9b2f1f07

> This option is recommended for use in combination with the CefDoMessageLoopWork() function in cases where
> the CEF message loop must be integrated into an existing application message loop

This is the case for us.

# How to verify the fixed issue:

## The steps to verify:

1. Start CEF on Windows 10/11
2. Execute shortcut keys
    * Ctrl + N, T, P, W, Tab,1～9
3. Exit Chronos

## Expected result:

1. The shortcut keys works fine on Windows 10 and 11.
2. Chronos processes are not left after exiting.
3. Display "Chronos System Guardを終了してもよろしいですか？" dialog when exiting if SG mode