### PR TITLE
APIHook: try to LoadLibrary if the target module is not found

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -1052,6 +1052,10 @@ void APIHookC::DoHookComDlgAPI()
 	}
 
 	hModule = GetModuleHandleW(L"comdlg32.dll");
+	if (!hModule)
+	{
+		hModule = LoadLibrary(L"comdlg32.dll");
+	}	
 	if (hModule)
 	{
 		if (!pORG_GetSaveFileNameW)
@@ -1081,6 +1085,10 @@ void APIHookC::DoHookComDlgAPI()
 
 	////////////////////////////////////////////////////////////
 	hModule = GetModuleHandleW(L"shell32.dll");
+	if (!hModule)
+	{
+		hModule = LoadLibrary(L"shell32.dll");
+	}	
 	if (hModule)
 	{
 		if (!pORG_SHBrowseForFolderW)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

SGモードの時にファイルセーブダイアログがChronos独自のものに上書きできていない問題を修正。

# What this PR does / why we need it:

`comdlg32.dll`はAPI Hookを設定する時には読み込まれていないが、その後読み込まれる場合がある。
CEFのビルド時のパラメータにも、delay loadedに指定されているので、読み込まれるタイミングがあるのだろう。

https://github.com/chromiumembedded/cef/blob/master/cmake/cef_variables.cmake.in#L453

Chronosとしては、クラシカルなファイルロードダイアログを呼ぶなど、このdllに関連する関数を呼ぶことがある。
なので、この時点でCEF側がロードしていなくても、Chronos側でLoadLibraryしておく。

# How to verify the fixed issue:

## The steps to verify:

1. ThinApp化したChronosを起動する
2. 何かの画像をダウンロードするなどで、ファイルセーブダイアログを表示する

## Expected result:

* 左側のデスクトップアイコンなどの表示がないこと
* アップロードフォルダーに保存しようとすると、アップロードフォルダーへの保存は禁止されている旨の警告が出ること
  * Chronosが上書きしたダイアログの処理が行われていることの確認。