### PR TITLE
Window: limit the maximum size of popup windows

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -818,6 +818,10 @@ void CChildView::ResizeWindowPopupInpl()
 			//初期値(アクティブウインドウの幅)
 			rcFeature.right = rcCurrent.Width();
 
+			//タスクバーを除く画面サイズ
+			RECT rcDisp = {0};
+			SystemParametersInfo(SPI_GETWORKAREA, NULL, &rcDisp, NULL);
+
 			//高さを指定している場合はセット
 			if (m_popupFeatures->height)
 			{
@@ -832,6 +836,10 @@ void CChildView::ResizeWindowPopupInpl()
 					dScale = rcFeature.bottom * theApp.m_ScaleDPI;
 					iScale = (int)dScale;
 					rcFeature.bottom = iScale;
+				}
+				if (rcFeature.bottom > rcDisp.bottom)
+				{
+					rcFeature.bottom = rcDisp.bottom;
 				}
 			}
 
@@ -849,6 +857,10 @@ void CChildView::ResizeWindowPopupInpl()
 					dScale = rcFeature.right * theApp.m_ScaleDPI;
 					iScale = (int)dScale;
 					rcFeature.right = iScale;
+				}
+				if (rcFeature.right > rcDisp.right)
+				{
+					rcFeature.right = rcDisp.right;
 				}
 			}
 

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -820,7 +820,8 @@ void CChildView::ResizeWindowPopupInpl()
 
 			//タスクバーを除く画面サイズ
 			RECT rcDisp = {0};
-			SystemParametersInfo(SPI_GETWORKAREA, NULL, &rcDisp, NULL);
+			SystemParametersInfo(SPI_GETWORKAREA, 0, &rcDisp, 0);
+
 
 			//高さを指定している場合はセット
 			if (m_popupFeatures->height)


### PR DESCRIPTION
# Which issue(s) this PR fixes:



# What this PR does / why we need it:

ポップアップウィンドウの表示時、指定されたポップアップウィンドウのサイズが大きいと、（タスクバーを除いた）スクリーンサイズよりも大きなサイズで表示されてしまう。

サンプル: 


[popup.zip](https://github.com/ThinBridge/Chronos/files/13900165/popup.zip)

```
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja">
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
<script>
    function openPopup() {
      window.open(
        "https://www.google.co.jp/",
        "popup",
        `left=0, top=0, width=${screen.availWidth}, height=${screen.availHeight}`);
      }
</script>
</head>
<body>
    <button onclick="openPopup()">open popup</button>
</body>
</html>
```

上記のサンプルHTML（`popup.html`）を保存し、`open popup`ボタンをクリックするとGoogleが開く。
サンプルでは`screen.availHeight`とスクリーンの高さ自体を指定しているが、スクリーンサイズよりも大きなポップアップウィンドウが表示され、Google画面の下部がタスクバーに被って見切れてしまう。

![image](https://github.com/ThinBridge/Chronos/assets/15982708/e66df8aa-322b-491b-a1a5-b7d448321437)

# How to verify the fixed issue:

## The steps to verify:

* 上限確認
  * popup.htmlをChronosから開き、`open popup`をクリックする
* 上限以外での動作の確認
  * popup.htmlの``left=0, top=0, width=${screen.availWidth}, height=${screen.availHeight}`);``の部分の`screen.availWidth`と`screen.availHeight`を`200`/`200`など任意のある程度小さな値に変更し、`open popup`をクリックする

## Expected result:

* 上限確認
  * 以下のようにタスクバーなどを除いたスクリーンサイズでポップアップウィンドウが表示されること
  * ![image](https://github.com/ThinBridge/Chronos/assets/15982708/9f3a307f-4c34-40b9-b875-762dd0f8397d)
* 上限以外での動作の確認
  * 指定したサイズでポップアップウィンドウが表示されること（設定->画面表示設定->ポップアップウィンドウで指定するマージンが加算されることに注意）
  * ![image](https://github.com/ThinBridge/Chronos/assets/15982708/6d9b5a27-2ed6-445f-bd65-a6d0f4e93540)
