### PR TITLE
Correct the labels to open in new tab or window(if tabs are disabled)

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -267,24 +267,24 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			if (theApp.m_bTabEnable_Init)
 			{
 				CString contextMenuOpenLinkTabLabel;
-				contextMenuOpenLinkTabLabel.LoadString(ID_CONTEXT_MENU_OPEN_IMG_TAB);
+				contextMenuOpenLinkTabLabel.LoadString(ID_CONTEXT_MENU_OPEN_LINK_TAB);
 				CefString cefContextMenuOpenLinkTabLabel(contextMenuOpenLinkTabLabel);
 				model->InsertItemAt(0, CEF_MENU_ID_OPEN_LINK_NEW, cefContextMenuOpenLinkTabLabel);
 
 				CString contextMenuOpenLinkTabInactiveLabel;
-				contextMenuOpenLinkTabInactiveLabel.LoadString(ID_CONTEXT_MENU_OPEN_IMG_TAB_INACTIVE);
+				contextMenuOpenLinkTabInactiveLabel.LoadString(ID_CONTEXT_MENU_OPEN_LINK_TAB_INACTIVE);
 				CefString cefContextMenuOpenLinkTabInactiveLabel(contextMenuOpenLinkTabInactiveLabel);
 				model->InsertItemAt(1, CEF_MENU_ID_OPEN_LINK_NEW_NOACTIVE, cefContextMenuOpenLinkTabInactiveLabel);
 			}
 			else
 			{
 				CString contextMenuOpenLinkWindowLabel;
-				contextMenuOpenLinkWindowLabel.LoadString(ID_CONTEXT_MENU_OPEN_IMG_WINDOW);
+				contextMenuOpenLinkWindowLabel.LoadString(ID_CONTEXT_MENU_OPEN_LINK_WINDOW);
 				CefString cefContextMenuOpenLinkWindowLabel(contextMenuOpenLinkWindowLabel);
 				model->InsertItemAt(0, CEF_MENU_ID_OPEN_LINK_NEW, cefContextMenuOpenLinkWindowLabel);
 
 				CString contextMenuOpenLinkWindowInactiveLabel;
-				contextMenuOpenLinkWindowInactiveLabel.LoadString(ID_CONTEXT_MENU_OPEN_IMG_WINDOW_INACTIVE);
+				contextMenuOpenLinkWindowInactiveLabel.LoadString(ID_CONTEXT_MENU_OPEN_LINK_WINDOW_INACTIVE);
 				CefString cefContextMenuOpenLinkWindowInactiveLabel(contextMenuOpenLinkWindowInactiveLabel);
 				model->InsertItemAt(1, CEF_MENU_ID_OPEN_LINK_NEW_NOACTIVE, cefContextMenuOpenLinkWindowInactiveLabel);
 			}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

CSG Issue#10

# What this PR does / why we need it:

Correct the labels to show "open in new tab" and "open in new window"

# How to verify the fixed issue:

Read context menu on a hyperlink

## The steps to verify:

1. Start Chronos
2. Browse any page to find a text hyperlink
3. Right click on it
4. See the context menu

For window message, do the same with tabs disabled

## Expected result:

It reads "新しいタブで開く" rather than "新しいタブで画像を開く"
For window message that will be "新しいウィンドウで開く" rather than "新しいウィンドウで画像を開く"

In English environment, they will be "Open in New Tab" and "Open in New Window" respectively