### PR TITLE
github: switch to node 20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ windows-2022 ]
     steps:
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.3
+      - uses: microsoft/setup-msbuild@v2
         with:
           vs-version: '[17, 18)'
       - if: matrix.version == 'stable'
@@ -24,7 +24,7 @@ jobs:
         run: |
           bash .github/rewrite-cef-version.sh ${{ matrix.version }}
       - name: Setup cache for CEF
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: cef-cache/*/
           key: cef-${{ runner.os }}-${{ hashFiles('setup-cef.bat') }}


### PR DESCRIPTION

# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

node 16 actions were deprecated.
It fixes the following warning:

```
  Node.js 16 actions are deprecated. Please update the following actions
  to use Node.js 20: microsoft/setup-msbuild@v1.3, actions/cache@v3. For
  more information see:
  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

# How to verify the fixed issue:

Check https://github.com/ThinBridge/Chronos/actions

## Expected result:

No warning about GitHub actions (node 16).
