### PR TITLE
Avoid exceptions at cef_log during shutting down

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4306,7 +4306,14 @@ void CSazabi::UnInitializeCef()
 		m_bCEFInitialized = FALSE;
 		m_cefApp = nullptr;
 		if (!m_bMultiThreadedMessageLoop)
-			CefDoMessageLoopWork();
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				CefDoMessageLoopWork();
+				// Sleep to allow the CEF proc to do work.
+				Sleep(50);
+			}
+		}
 		// shutdown CEF
 		CefShutdown();
 	}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Exceptions may occur at `cef_log` during closing Chronos.
The reason why the cef_log throws the exceptions seems that there leave some tasks for CEF.
It seems better to call `CefDoMessageLoopWork()` multiple times on shutting down.

FYI: https://github.com/chromiumembedded/cef/blob/master/tests/shared/browser/main_message_loop_external_pump_win.cc#L93

# How to verify the fixed issue:
## The steps to verify:

Shutdown Chronos multiple times.

## Expected result:

No exception occurs at `cef_log` during shutting down.