### PR TITLE
message loop: fix a bug that a file dialog freezes

### DIFF
--- a/MessageLoopWorker.cpp
+++ b/MessageLoopWorker.cpp
@@ -61,6 +61,7 @@ void MessageLoopWorker::OnScheduleWork(int64_t delayMs)
 		return;
 	}
 
+	KillTimer();
 	if (delayMs <= 0)
 	{
 		DoWork();
@@ -69,8 +70,6 @@ void MessageLoopWorker::OnScheduleWork(int64_t delayMs)
 	{
 		// If | delayMs | is > 0 then the call should be scheduled to happen after the specified delay 
 		// and any currently pending scheduled call should be cancelled. 
-		KillTimer();
-
 		if (delayMs > m_nMaxTimerDelay)
 		{
 			delayMs = m_nMaxTimerDelay;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A(Not issued yet).

This PR fixes a bug that a file dialog freezes.

# What this PR does / why we need it:

Execute `KillTimer()` even if `delayMS <= 0`.

While a dialog is showing, `CefDoMessageLoopWork` waits until the dialog is closed.
The `CefDoMessageLoopWork()` for that case is called by the case `delayMs <= 0`.
Before this patch, a timer was not reset, so while running that `CefDoMessageLoopWork()` (`m_bIsActive_` was `true`),  next `OnTimerTimeout()` was fired, and `DoWork()` is executed with `m_bIsActive_` was `true`.
Then, `m_bReentrancyDetected_` became `true` because `m_bIsActive_` is `true`, and `PostScheduleMessage(0)` was executed at the end of `DoWork()`.
And then, `OnScheduleWork()` -> `DoWork()` -> `PostScheduleMessage(0)` looped because `m_bIsActive_` was still `true` as the ` CefDoMessageLoopWork()` still be waiting for closing dialog.
That loop blocked the user input.

This is fixed by executing `KillTimer()` even if `delayMS <= 0` because `OnTimerTimeout()` become to be not executed while running `CefDoMessageLoopWork()`.

# How to verify the fixed issue:

## The steps to verify:

Try to save some images and show a file dialog.

## Expected result:

The file dialog doesn't freeze.
