### PR TITLE
certification: Do not use any certificate when canceling select dialog

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1800,7 +1800,12 @@ bool ClientHandler::OnSelectClientCertificate(
 			dwLogData.mMESSAGE1.Format(_T("Failed to open certificate selection dialog."));
 			theApp.WriteDebugTraceDateTime(dwLogData.GetString(), DEBUG_LOG_TYPE_DE);
 			CertCloseStore(hCertStore, 0);
-			return false;
+			// When it returns false here without selecting client certicate file,
+			// it works as if the first certificate was selected by default.
+			// As client certificate is not selected, above behavior is not suitable
+			// and it should be canceled correctly (as same as the other Browser raise error.)
+			// This is incompatible change since 14.1.119.0.
+			return true;
 		}
 
 		// Find mapped index between cef given certificates and win32 API call results.

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1847,7 +1847,12 @@ bool ClientHandler::OnSelectClientCertificate(
 			return true;
 		}
 	}
-	return false;
+	// When it returns false here without selecting client certicate file, 
+	// it works as if the first certificate was selected by default.
+	// As client certificate is not selected, above behavior is not suitable
+	// and it should be canceled correctly (as same as the other Browser raise error.)
+	// This is incompatible change since 14.1.119.0.
+	return true;
 }
 
 void ClientHandler::OnProtocolExecution(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool& allow_os_execution)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/111

# What this PR does / why we need it:

Currently, Chronos uses the default certificate when canceling a certificate selection.
This patch modifies Chronos to not use any certificate when canceling a certificate selection.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Install the following two certificate from Chronos-SG/Documents/Tools
    *  john.doe_example.p12
    *  john.doe.ghost_example.org.p12
2. Access to https://sx509.w0.dk/
3. Select a cancel button on a displayed dialog

Execute tests on each Windows11 and Windows 10.

## Expected result:

The following error page is displayed at https://sx509.w0.dk/

```
Client Certificate Demo
Error: The server did not receive a PKCS#12 certificate from your browser.

Something went wrong. You have not imported the client certificate correctly.

Go back to https://x509.w0.dk/ and import the client certificate.
```