### PR TITLE
client_handler: enable to login to Google

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1144,7 +1144,8 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		{
 			request->GetHeaderMap(cefHeaders);
 			cefHeaders.erase("User-Agent");
-			cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0"));
+			cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0"));
+			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 Edg/87.0.664.66"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 Edg/87.0.0.0"));
 			request->SetHeaderMap(cefHeaders);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/166

# What this PR does / why we need it:

Modify a dummy User-Agent to the latest Firefox in order to login to Google.

# How to verify the fixed issue:

## The steps to verify:

1. Try to login Google from https://accounts.google.com

## Expected result:

Being able to login to Google.