### PR TITLE
Suppress warning C26819

### DIFF
--- a/CTabWnd.cpp
+++ b/CTabWnd.cpp
@@ -281,7 +281,7 @@ LRESULT CTabWnd::OnTabMouseMove(WPARAM wParam, LPARAM lParam)
 			m_nTabBorderArray[i] = rc.right;
 		}
 		m_nTabBorderArray[i] = 0; // 最後の要素は番兵
-					  // ここに来たらドラッグ開始なので break しないでそのまま DRAG_DRAG 処理に入る
+		[[fallthrough]];	  // ここに来たらドラッグ開始なので break しないでそのまま DRAG_DRAG 処理に入る
 
 	case DragState::DRAG:
 		// ドラッグ中のマウスカーソルを表示する


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/42

# What this PR does / why we need it:

The fallthrough at this line is intended, no need to warn.
So having added a `[[fallthrough]];` statement to avoid warning C26819.

https://learn.microsoft.com/en-us/cpp/code-quality/c26819?view=msvc-170

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

**The warning is suppressed**

1. Execute Code Analysis

**Regression test**

1. Start Chronos
2. Open multiple tabs
3. Move a tab by mouse

## Expected result:

**The warning is suppressed**

The warning C26819 is suppressed, the warning is not displayed.

**Regression test**

The tab moves fine.