### PR TITLE
Suppress C26812 warnings for automatically created enums.

### DIFF
--- a/DlgDL.h
+++ b/DlgDL.h
@@ -92,10 +92,15 @@ public:
 	void SetMsg(const CString& str);
 	void SetMsgExec(const CString& str);
 	UINT m_iCntg;
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_DLG_PROGRESS
 	};
+#pragma warning(pop)
 
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX);

--- a/DlgDebugWnd.h
+++ b/DlgDebugWnd.h
@@ -91,6 +91,11 @@ public:
 	CString mMESSAGE6;
 };
 
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはリスト用に自動生成されたenumなのか、独自定義したものなのか不明。
+// そのため、警告の抑止により対応する。
+#pragma warning(disable : 26812)
 enum
 {
 	LIST_INDEX,
@@ -105,6 +110,7 @@ enum
 	LIST_MESSAGE6,
 	LIST_MAX,
 };
+#pragma warning(pop)
 
 class CDlgDebugWnd : public CDialogEx
 {
@@ -118,10 +124,15 @@ public:
 	CString m_strEventLogDebugWnd;
 
 	// ダイアログ データ
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_DLG_DEBUG_WND
 	};
+#pragma warning(pop)
 
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV サポート
@@ -186,10 +197,15 @@ public:
 	autoresize::CAutoResize m_autoResize;
 	CString m_strFilePath;
 	// ダイアログ データ
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_DLG_SC_EDITOR
 	};
+#pragma warning(pop)
 
 protected:
 	BOOL bFirstFlg;

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -291,10 +291,15 @@ public:
 	WNDTREE_MAP m_wndMap;
 	CWnd* m_pParent;
 	//{{AFX_DATA(CSettingsDialog)
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG
 	};
+#pragma warning(pop)
 	CStatic m_PageFrame;
 	CTreeCtrl m_TreeCtrl;
 	CPrefsStatic m_CaptionBarCtrl;
@@ -338,10 +343,15 @@ class CDlgSetLog : public CPropertyPage
 public:
 	CDlgSetLog();
 	//{{AFX_DATA(CDlgSetTab1)
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_LOG
 	};
+#pragma warning(pop)
 	//}}AFX_DATA
 
 	// オーバーライド
@@ -371,10 +381,15 @@ class CDlgSetDSP : public CPropertyPage
 	DECLARE_DYNCREATE(CDlgSetDSP)
 public:
 	CDlgSetDSP();
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_DSP
 	};
+#pragma warning(pop)
 
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX);
@@ -393,10 +408,15 @@ class CDlgSetGen : public CPropertyPage
 	DECLARE_DYNCREATE(CDlgSetGen)
 public:
 	CDlgSetGen();
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_GEN
 	};
+#pragma warning(pop)
 
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX);
@@ -414,10 +434,15 @@ class CDlgSetSEC : public CPropertyPage
 	DECLARE_DYNCREATE(CDlgSetSEC)
 public:
 	CDlgSetSEC();
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_SEC
 	};
+#pragma warning(pop)
 	CComboBox m_ComboEmu;
 	void ChangeStateScriptEdit();
 
@@ -445,10 +470,15 @@ class CDlgSetConnectionSetting : public CPropertyPage
 	DECLARE_DYNCREATE(CDlgSetConnectionSetting)
 public:
 	CDlgSetConnectionSetting();
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_CONNECTION
 	};
+#pragma warning(pop)
 	void ChangeStateProxyEdit();
 
 protected:
@@ -469,12 +499,16 @@ class CDlgSetCAP : public CPropertyPage
 	DECLARE_DYNCREATE(CDlgSetCAP)
 public:
 	CDlgSetCAP();
+#pragma warning(push)
+//C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+//これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_CAP
 	};
 	void ChangeStateLimitTime();
-
+#pragma warning(pop)
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX);
 
@@ -491,12 +525,16 @@ class CDlgSetINIT : public CPropertyPage
 	DECLARE_DYNCREATE(CDlgSetINIT)
 public:
 	CDlgSetINIT();
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_INIT
 	};
+#pragma warning(pop)
 	CComboBox m_Combo;
-
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX);
 
@@ -514,17 +552,22 @@ public:
 	CDlgSetDomainFilter();
 	virtual ~CDlgSetDomainFilter();
 	autoresize::CAutoResize m_autoResize;
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum LIST_INDEX
 	{
 		URL,
 		ACTION,
 		ENABLE
 	};
-	int DuplicateChk(LPCTSTR sURL);
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_URL_FILTER
 	};
+#pragma warning(pop)
+	int DuplicateChk(LPCTSTR sURL);
 	CListCtrl m_List;
 	//	CComboBox	m_Combo;
 
@@ -557,6 +600,10 @@ public:
 	CDlgSetFileMgr();
 	virtual ~CDlgSetFileMgr(){};
 	autoresize::CAutoResize m_autoResize;
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum LIST_INDEX
 	{
 		URL,
@@ -567,6 +614,7 @@ public:
 	{
 		IDD = IDD_SETTINGS_DLG_FILEMGR
 	};
+#pragma warning(pop)
 	CComboBox m_Combo;
 
 protected:
@@ -592,17 +640,22 @@ public:
 	CDlgSetCustomScript();
 	virtual ~CDlgSetCustomScript();
 	autoresize::CAutoResize m_autoResize;
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum LIST_INDEX
 	{
 		URL,
 		FILENAME,
 		ENABLE
 	};
-	int DuplicateChk(LPCTSTR sURL, LPCTSTR sFileName);
 	enum
 	{
 		IDD = IDD_SETTINGS_DLG_CUSTOM_SCRIPT
 	};
+#pragma warning(pop)
+	int DuplicateChk(LPCTSTR sURL, LPCTSTR sFileName);
 	CListCtrl m_List;
 
 protected:

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -1011,10 +1011,15 @@ class CAboutDlg : public CDialog
 public:
 	CAboutDlg(CWnd* pParent = NULL);
 	CWnd* pParentFrm;
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
 	enum
 	{
 		IDD = IDD_ABOUTBOX
 	};
+#pragma warning(pop)
 
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/42

# What this PR does / why we need it:

Suppressing C26812 warnings for automatically created enums.
They are automatically created and we should not change them manually.
So they are simply suppressed by `pragma`. 

```
#pragma warning(disable : 26812)
```

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Execute "Code Analysis" and Rebuild Chronos

## Expected result:

The C26812 warnings are not displayed at the lines added `pragma`.