### PR TITLE
Suppress warning C23812 of MediaAccessPermission

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1952,7 +1952,7 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 
 	HWND hWindow = GetSafeParentWnd(browser);
 	CString requestOrigin = (LPCWSTR)requesting_origin.c_str();
-	if (theApp.m_AppSettings.GetMediaAccessPermission() == AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL)
+	if (theApp.m_AppSettings.GetMediaAccessPermission() == static_cast<int>(AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL))
 	{
 		std::tuple<CefString, uint32> permissionInfo = std::tie(requesting_origin, requested_permissions);
 		std::map<std::tuple<CefString, uint32>, bool>::iterator cachedPermissions = m_originAndPermissionsCache.find(permissionInfo);

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -906,7 +906,7 @@ public:
 	}
 	~AppSettings() {}
 
-	enum MediaAccessPermission
+	enum class MediaAccessPermission
 	{
 		NO_MEDIA_ACCESS,
 		MANUAL_MEDIA_APPROVAL,
@@ -948,8 +948,8 @@ public:
 
 		MemoryUsageLimit = 0;
 		WindowCountLimit = 0;
-		EnableMediaAccessByApproval = AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS;
-		EnableMediaAccessPermission = AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS;
+		EnableMediaAccessByApproval = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
+		EnableMediaAccessPermission = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
 
 		EnableDownloadRestriction = 0;
 		EnableUploadRestriction = 0;
@@ -1228,7 +1228,7 @@ public:
 		RunningLimitTime = 1440;
 		MemoryUsageLimit = 2040;
 		WindowCountLimit = 60;
-		EnableMediaAccessPermission = AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS;
+		EnableMediaAccessPermission = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
 
 		/////////////////////////////////////////////////////////////////////////////////////////////////
 		//リダイレクト設定
@@ -1631,7 +1631,7 @@ public:
 						// EnableMediaAccessByApproval was deprecated.
 						// 1: means manual approval, so it should be migrated to
 						// equivalent EnableMediaAccessPermission = 1 when EnableMediaAccessPermission is not set.
-						EnableMediaAccessByApproval = AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL;
+						EnableMediaAccessByApproval = static_cast<int>(AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL);
 					}
 					continue;
 				}
@@ -1639,8 +1639,8 @@ public:
 				{
 					int iW = 0;
 					iW = _ttoi(strTemp3);
-					if (AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS <= iW &&
-						iW <= AppSettings::MediaAccessPermission::DEFAULT_MEDIA_APPROVAL)
+					if (static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS) <= iW &&
+						iW <= static_cast<int>(AppSettings::MediaAccessPermission::DEFAULT_MEDIA_APPROVAL))
 					{
 						// 0: None
 						// 1: Manual Approval
@@ -1650,7 +1650,7 @@ public:
 					else
 					{
 						// Regard as no permission for invalid value
-						EnableMediaAccessPermission = AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS;
+						EnableMediaAccessPermission = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
 					}
 					bEnabledMediaAccessPermission = true;
 					continue;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42 

# What this PR does / why we need it:

MediaAccessPermissionの以下の警告を解消。

```
C:\gitdir\Chronos\sbcommon.h(907): warning C26812: 列挙型 'AppSettings::MediaAccessPermission' は対象範囲外です。'enum' (Enum.3) より 'enum class' を優先します。
```

元々列挙型としての相応しい使い方がされていそうなので、enumからenum classを使うように修正。

# How to verify the fixed issue:

## The steps to verify:

**警告の解消の確認**

1. Code Analysisを実行する。また、Chronosをリビルドする。

**リグレッションテスト**

ChronosDefault.confにて、EnableMediaAccessPermissionとEnableMediaAccessPermissionを設定してメディアアクセスの動作を確認する。

* EnableMediaAccessPermission=0、EnableMediaAccessByApprovalなしの状態で https://meet.jit.si/907281439702713 （適当に作成したjitsiのページ）を開く
  * マイク、カメラのメディアアクセスが拒否されていること
* EnableMediaAccessPermission=1、EnableMediaAccessByApprovalなしの状態で https://meet.jit.si/907281439702713 （適当に作成したjitsiのページ）を開く
  * マイク、カメラのメディアアクセスの許可が求められること
* EnableMediaAccessPermission=2、EnableMediaAccessByApprovalなしの状態で https://meet.jit.si/907281439702713 （適当に作成したjitsiのページ）を開く
  * マイク、カメラのメディアアクセスが許可されていること
* EnableMediaAccessByApproval=0、EnableMediaAccessPermissionなしの状態で https://meet.jit.si/907281439702713 （適当に作成したjitsiのページ）を開く
  * マイク、カメラのメディアアクセスが拒否されていること
* EnableMediaAccessByApproval=1、EnableMediaAccessPermissionなしの状態で https://meet.jit.si/907281439702713 （適当に作成したjitsiのページ）を開く
  * マイク、カメラのメディアアクセスの許可が求められること

## Expected result:

**警告の解消の確認**

```
C:\gitdir\Chronos\sbcommon.h(907): warning C26812: 列挙型 'AppSettings::MediaAccessPermission' は対象範囲外です。'enum' (Enum.3) より 'enum class' を優先します。
```

上記の警告が出ないこと。

**リグレッションテスト**

メディアアクセスの動作が、テスト手順に記載の期待値の通りであること。