### PR TITLE
Suppress warning C26812 in fav.h

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -1537,7 +1537,7 @@ void CBrowserFrame::OnFavMenu(UINT nID)
 	if (!tmp1)
 		return;
 
-	if (tmp1->GetType() == IEFavURL)
+	if (tmp1->GetType() == FAV_TYPE::IEFavURL)
 	{
 		strURL = tmp1->strURL;
 
@@ -1630,8 +1630,8 @@ void CBrowserFrame::CrateFavoriteMenu(CMenu* pMenu, CFavoriteItem* parentItem)
 	if (!parentItem) return;
 	CString strTitle;
 
-	if (parentItem->GetType() == IEFavDIR ||
-	    parentItem->GetType() == IEFavROOT)
+	if (parentItem->GetType() == FAV_TYPE::IEFavDIR ||
+	    parentItem->GetType() == FAV_TYPE::IEFavROOT)
 	{
 		INT_PTR iMax = parentItem->GetSize();
 		for (INT_PTR i = 0; i < iMax; i++)
@@ -1640,7 +1640,7 @@ void CBrowserFrame::CrateFavoriteMenu(CMenu* pMenu, CFavoriteItem* parentItem)
 			tmp = (CFavoriteItem*)parentItem->GetItem(i);
 			if (tmp)
 			{
-				if (tmp->GetType() == IEFavDIR)
+				if (tmp->GetType() == FAV_TYPE::IEFavDIR)
 				{
 					SBUtil::GetDivChar(tmp->strTitle, 60, strTitle);
 					strTitle.Replace(_T("&"), _T("&&"));
@@ -1671,11 +1671,11 @@ void CBrowserFrame::CrateFavoriteMenu(CMenu* pMenu, CFavoriteItem* parentItem)
 	else
 	{
 		strTitle = parentItem->strTitle;
-		if (parentItem->GetType() == IEFavURL)
+		if (parentItem->GetType() == FAV_TYPE::IEFavURL)
 		{
 			strTitle = strTitle.Mid(0, strTitle.ReverseFind(_T('.')));
 		}
-		else if (parentItem->GetType() == IEFavFILE)
+		else if (parentItem->GetType() == FAV_TYPE::IEFavFILE)
 		{
 			strTitle = strTitle.Mid(0, strTitle.ReverseFind(_T('.')));
 		}

--- a/fav.h
+++ b/fav.h
@@ -5,7 +5,7 @@
 #ifdef _DEBUG
 #include <locale.h>
 #endif
-enum TYPE
+enum class FAV_TYPE
 {
 	IEFavERR,
 	IEFavROOT,
@@ -172,9 +172,9 @@ public:
 class CFavoriteItem
 {
 public:
-	CFavoriteItem(int iType = IEFavURL)
+	CFavoriteItem(FAV_TYPE type = FAV_TYPE::IEFavURL)
 	{
-		bType = iType;
+		m_type = type;
 		commandID = 0;
 	}
 	virtual ~CFavoriteItem()
@@ -197,9 +197,9 @@ public:
 		}
 		m_aFavItems.RemoveAll();
 	}
-	CFavoriteItem* AddChild(LPCTSTR strTitle, LPCTSTR strURL, int iType)
+	CFavoriteItem* AddChild(LPCTSTR strTitle, LPCTSTR strURL, FAV_TYPE iType)
 	{
-		if (bType == IEFavDIR || bType == IEFavROOT)
+		if (m_type == FAV_TYPE::IEFavDIR || m_type == FAV_TYPE::IEFavROOT)
 		{
 			CFavoriteItem* tmp = NULL;
 			tmp = new CFavoriteItem;
@@ -207,20 +207,20 @@ public:
 			{
 				tmp->strTitle = strTitle;
 				tmp->strURL = strURL;
-				tmp->bType = iType;
+				tmp->m_type = iType;
 				m_aFavItems.Add(tmp);
 			}
 			return tmp;
 		}
 		return NULL;
 	}
-	int GetType()
+	FAV_TYPE GetType()
 	{
-		return bType;
+		return m_type;
 	}
 	void SortItem(CFavoritesOrder& order)
 	{
-		if (bType != IEFavDIR && bType != IEFavROOT)
+		if (m_type != FAV_TYPE::IEFavDIR && m_type != FAV_TYPE::IEFavROOT)
 			return;
 		INT_PTR iColSize = m_aFavItems.GetSize();
 		INT_PTR iOrderSize = order.GetCount();
@@ -292,7 +292,7 @@ public:
 	}
 	void SortItem()
 	{
-		if (bType != IEFavDIR && bType != IEFavROOT)
+		if (m_type != FAV_TYPE::IEFavDIR && m_type != FAV_TYPE::IEFavROOT)
 			return;
 		INT_PTR iColSize = m_aFavItems.GetSize();
 		if (iColSize <= 1)
@@ -313,12 +313,12 @@ public:
 			pFavTmp = (CFavoriteItem*)m_aFavItems.GetAt(i);
 			if (pFavTmp)
 			{
-				if (pFavTmp->bType == IEFavDIR)
+				if (pFavTmp->m_type == FAV_TYPE::IEFavDIR)
 				{
 					SortedItemArray1[iIndex1] = (INT_PTR)pFavTmp;
 					iIndex1++;
 				}
-				else if (pFavTmp->bType == IEFavURL || pFavTmp->bType == IEFavFILE)
+				else if (pFavTmp->m_type == FAV_TYPE::IEFavURL || pFavTmp->m_type == FAV_TYPE::IEFavFILE)
 				{
 					SortedItemArray2[iIndex2] = (INT_PTR)pFavTmp;
 					iIndex2++;
@@ -399,7 +399,7 @@ public:
 	{
 		this->commandID = ptraFavItem->GetSize();
 		ptraFavItem->Add(this);
-		if (bType == IEFavDIR || bType == IEFavROOT)
+		if (m_type == FAV_TYPE::IEFavDIR || m_type == FAV_TYPE::IEFavROOT)
 		{
 			for (int i = 0; i < m_aFavItems.GetSize(); i++)
 			{
@@ -415,7 +415,7 @@ public:
 
 protected:
 	CPtrArray m_aFavItems;
-	BOOL bType;
+	FAV_TYPE m_type;
 };
 class CFavoriteItemManager
 {
@@ -436,7 +436,7 @@ public:
 	{
 		CleanUP();
 		bIEOrder = IEOrder;
-		m_FavRootItem = new CFavoriteItem(IEFavROOT);
+		m_FavRootItem = new CFavoriteItem(FAV_TYPE::IEFavROOT);
 		m_FavRootItem->strURL = strPath;
 		m_FavRootItem->strTitle = _T("FAVROOT");
 		m_ptraFavItemDir.RemoveAll();
@@ -452,13 +452,13 @@ public:
 		}
 	}
 
-	CFavoriteItem* AddChild(CFavoriteItem* parentItem, LPCTSTR strTitle, LPCTSTR strURL, int iType)
+	CFavoriteItem* AddChild(CFavoriteItem* parentItem, LPCTSTR strTitle, LPCTSTR strURL, FAV_TYPE iType)
 	{
 		if (!parentItem) return NULL;
 
 		CFavoriteItem* tmp = NULL;
 		tmp = parentItem->AddChild(strTitle, strURL, iType);
-		if (iType == IEFavDIR)
+		if (iType == FAV_TYPE::IEFavDIR)
 		{
 			m_ptraFavItemDir.Add(tmp);
 		}
@@ -544,7 +544,7 @@ public:
 				strDirectoryPath = strPath + wfd.cFileName;
 				ord.MtlMakeSureTrailingBackSlash(strDirectoryPath);
 				CFavoriteItem* parentItemSub = NULL;
-				parentItemSub = this->AddChild(parentItem, wfd.cFileName, strDirectoryPath, IEFavDIR);
+				parentItemSub = this->AddChild(parentItem, wfd.cFileName, strDirectoryPath, FAV_TYPE::IEFavDIR);
 				if (parentItemSub)
 					this->Reflect(parentItemSub, strDirectoryPath);
 			}
@@ -560,13 +560,13 @@ public:
 					GetInternetShortcutUrl(URLPATH, URLString);
 					if (!URLString.IsEmpty())
 					{
-						this->AddChild(parentItem, strFileNameTemp, URLString, IEFavURL);
+						this->AddChild(parentItem, strFileNameTemp, URLString, FAV_TYPE::IEFavURL);
 					}
 				}
 				else
 				{
 					URLPATH = strPath + wfd.cFileName;
-					this->AddChild(parentItem, strFileNameTemp, URLPATH, IEFavFILE);
+					this->AddChild(parentItem, strFileNameTemp, URLPATH, FAV_TYPE::IEFavFILE);
 				}
 			}
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告を抑止。

```
C:\gitdir\Chronos\fav.h(8): warning C26812: 列挙型 'TYPE' は対象範囲外です。'enum' (Enum.3) より 'enum class' を優先します。
```

列挙型として相応しい使い方がされていたので、enum classにすることで対応。
その際、`TYPE`では一般的すぎるので、`FAV_TYPE`に名前を変更。

また、`BOOL bType`に`enum`の値が代入され使われていたので、この変数もFAV_TYPE型に変更している。

# How to verify the fixed issue:
## The steps to verify:

**警告の解消の確認**

* Code Analysisを実行する。また、Chronosをリビルドする。

**リグレッションテスト**

準備:

お気に入り周りのソースコードの修正のため、お気に入りの動作が変わっていないかを確認する。
お気に入りの追加、お気に入りの整理はThinApp化された状態でないと動かないので、ThinApp化されたChronosを用意する。

1. [本PRのChronos.zip](https://github.com/HashidaTKS/Chronos/actions/runs/8533102725)使って、[Chronos-SGのインストーラー作成手順](https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88)の手順でChronosのインストーラーを作成
2. インストーラーを実行し、Chronosをインストール
3. [Projectファイル](https://github.com/ThinBridge/Chronos-SG/tree/main/Projects/ChronosSG_Project)を使ってChronos.exe/Chronos.exe.altを作成し、C:\Chronosに配置
4. Chronos SGを起動

テスト:

* 上部のメニューからお気に入りを選択
  * お気に入り一覧が表示されていること
* お気に入りの追加を選択
  * 指定した場所に現在のページがお気に入り追加できること
* お気に入りの整理を選択
  * お気に入りの整理の画面が表示されること
  * お気に入りのサイトのフォルダを移動する、順番を入れ替えるなどして、問題なく動作すること

## Expected result:

**警告の解消の確認**

以下の警告が表示されないこと

```
C:\gitdir\Chronos\fav.h(8): warning C26812: 列挙型 'TYPE' は対象範囲外です。'enum' (Enum.3) より 'enum class' を優先します。
```

**リグレッションテスト**

テスト手順に記載した、各お気に入りの動作が問題なく動作すること