### PR TITLE
Suppress warning C26812 of ETabWndNotifyType

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -1283,12 +1283,12 @@ void CBrowserFrame::OnClose()
 							pWnd = theApp.GetNextGenerationActiveWindow(this);
 							if (theApp.IsWnd(pWnd))
 							{
-								((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_DEL, pWnd->GetSafeHwnd());
+								((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_DEL_COMMAND, pWnd->GetSafeHwnd());
 							}
 						}
 					}
 					((CMainFrame*)theApp.m_pMainWnd)->Delete_TabWindow(this);
-					((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH, NULL);
+					((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH_COMMAND, NULL);
 
 					delete m_cTabWnd;
 					m_cTabWnd = NULL;
@@ -1311,7 +1311,7 @@ void CBrowserFrame::SetWindowTitle(LPCTSTR ptr)
 	}
 	if (m_cTabWnd)
 	{
-		((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH, NULL);
+		((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH_COMMAND, NULL);
 	}
 }
 void CBrowserFrame::OnActiveFrm()
@@ -1337,7 +1337,7 @@ void CBrowserFrame::OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized)
 		{
 			if (((CMainFrame*)theApp.m_pMainWnd)->SetActiveFramePtr(this))
 			{
-				((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_ORDER, this->GetSafeHwnd());
+				((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_ORDER_COMMAND, this->GetSafeHwnd());
 			}
 		}
 		if (::IsWindow(theApp.m_hwndTaskDlg) && ::IsWindowEnabled(theApp.m_hwndTaskDlg))
@@ -2878,13 +2878,13 @@ void CBrowserFrame::OnCloseDelay()
 #ifdef _DEBUG
 						TRACE(_T("##TWNT_DEL##  Close[%s] NGen[%s]\n"), this->m_wndView.m_strTitle, pWnd->m_wndView.m_strTitle);
 #endif
-						((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_DEL, pWnd->GetSafeHwnd());
+						((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_DEL_COMMAND, pWnd->GetSafeHwnd());
 					}
 				}
 			}
 		}
 		((CMainFrame*)theApp.m_pMainWnd)->Delete_TabWindow(this);
-		((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH, NULL);
+		((CMainFrame*)theApp.m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH_COMMAND, NULL);
 
 		delete m_cTabWnd;
 		m_cTabWnd = NULL;

--- a/CTabWnd.cpp
+++ b/CTabWnd.cpp
@@ -211,7 +211,7 @@ LRESULT CTabWnd::OnTabLButtonUp(WPARAM wParam, LPARAM lParam)
 		break;
 	}
 	case DragState::DRAG:
-		m_pwndMainFrame->TabWindowMsgBSend(TWNT_REFRESH, NULL);
+		m_pwndMainFrame->TabWindowMsgBSend(TWNT_REFRESH_COMMAND, NULL);
 
 		if (m_nTabBorderArray)
 		{
@@ -848,13 +848,13 @@ void CTabWnd::TabWindowNotify(WPARAM wParam, LPARAM lParam)
 		bFlag = true;
 		//最初のときはすでに存在するウインドウの情報も登録する必要がある。
 		// 起動時、CTabWnd::Open()内のRefresh()ではまだグループ入り前のため既に別ウィンドウがあってもタブは空
-		if (wParam == TWNT_ADD)
+		if (wParam == TWNT_ADD_COMMAND)
 			Refresh(); // 続けてTWNT_ADD処理で自分以外のウィンドウを隠す
 	}
 
 	switch (wParam)
 	{
-	case TWNT_ADD: //ウインドウ登録
+	case TWNT_ADD_COMMAND: //ウインドウ登録
 		nIndex = FindTabIndexByHWND((HWND)lParam);
 		if (-1 == nIndex)
 		{
@@ -882,7 +882,7 @@ void CTabWnd::TabWindowNotify(WPARAM wParam, LPARAM lParam)
 		HideOtherWindows(m_pwndFrame->m_hWnd);
 		break;
 
-	case TWNT_DEL: //ウインドウ削除
+	case TWNT_DEL_COMMAND: //ウインドウ削除
 		nIndex = FindTabIndexByHWND((HWND)lParam);
 		if (-1 != nIndex)
 		{
@@ -904,7 +904,7 @@ void CTabWnd::TabWindowNotify(WPARAM wParam, LPARAM lParam)
 		}
 		break;
 
-	case TWNT_ORDER: //ウインドウ順序変更
+	case TWNT_ORDER_COMMAND: //ウインドウ順序変更
 		nIndex = FindTabIndexByHWND((HWND)lParam);
 		if (-1 != nIndex)
 		{
@@ -940,13 +940,13 @@ void CTabWnd::TabWindowNotify(WPARAM wParam, LPARAM lParam)
 		}
 		break;
 
-	case TWNT_REFRESH: //再表示
+	case TWNT_REFRESH_COMMAND: //再表示
 		Refresh((BOOL)lParam);
 		if (lParam)
 			::InvalidateRect(this->GetHwnd(), NULL, FALSE);
 		break;
 
-	case TWNT_WNDPL_ADJUST: // ウィンドウ位置合わせ
+	case TWNT_WNDPL_ADJUST_COMMAND: // ウィンドウ位置合わせ
 		AdjustWindowPlacement();
 		LayoutTab();
 		::InvalidateRect(this->GetHwnd(), NULL, FALSE);
@@ -1159,7 +1159,7 @@ void CTabWnd::ShowTabWindow(HWND hwnd)
 		return;			 // 切替の最中(busy)は要求を無視する
 	theApp.m_bTabWndChanging = TRUE; //ウィンドウ切替中ON
 	DWORD_PTR dwResult = {0};
-	::SendMessageTimeout(hwnd, MYWM_TAB_WINDOW_NOTIFY, TWNT_WNDPL_ADJUST, (LPARAM)NULL,
+	::SendMessageTimeout(hwnd, MYWM_TAB_WINDOW_NOTIFY, TWNT_WNDPL_ADJUST_COMMAND, (LPARAM)NULL,
 			     SMTO_NORMAL, 10000, &dwResult);
 	TabWnd_ActivateFrameWindow(hwnd);
 	theApp.m_bTabWndChanging = FALSE; // ウィンドウ切替中OFF

--- a/CTabWnd.h
+++ b/CTabWnd.h
@@ -5,14 +5,12 @@
 #define MYWM_TAB_WINDOW_NOTIFY (WM_APP + 213)
 
 //タブウインドウ用メッセージサブコマンド
-enum ETabWndNotifyType
-{
-	TWNT_REFRESH = 0,      //再表示
-	TWNT_ADD = 1,	       //ウインドウ登録
-	TWNT_DEL = 2,	       //ウインドウ削除
-	TWNT_ORDER = 3,	       //ウインドウ順序変更
-	TWNT_WNDPL_ADJUST = 4, //ウィンドウ位置合わせ
-};
+#define	TWNT_REFRESH_COMMAND		0 //再表示
+#define	TWNT_ADD_COMMAND		1 //ウインドウ登録
+#define	TWNT_DEL_COMMAND		2 //ウインドウ削除
+#define	TWNT_ORDER_COMMAND		3 //ウインドウ順序変更
+#define	TWNT_WNDPL_ADJUST_COMMAND	4 //ウィンドウ位置合わせ
+
 inline LRESULT UpDown_SetRange(HWND hwndCtl, int upper, int lower) { return (LRESULT)(ULONG_PTR)::SendMessage(hwndCtl, UDM_SETRANGE, 0L, MAKELPARAM(upper, lower)); }
 inline LRESULT UpDown_GetPos(HWND hwndCtl) { return (LRESULT)(ULONG_PTR)::SendMessage(hwndCtl, UDM_GETPOS, 0L, 0L); }
 inline LRESULT UpDown_SetPos(HWND hwndCtl, DWORD value) { return (LRESULT)(ULONG_PTR)::SendMessage(hwndCtl, UDM_SETPOS, 0L, MAKELONG(value, 0)); }
@@ -31,7 +29,7 @@ static void ActivateFrameWindow(HWND hwnd)
 	::SendMessageTimeout(
 	    hwnd,
 	    MYWM_TAB_WINDOW_NOTIFY,
-	    TWNT_WNDPL_ADJUST,
+	    TWNT_WNDPL_ADJUST_COMMAND,
 	    (LPARAM)NULL,
 	    SMTO_NORMAL,
 	    10000,

--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -1297,7 +1297,7 @@ void CMainFrame::Add_TabWindow(CBrowserFrame* Target)
 				ICoHelper = theApp.LoadIcon(IDI_ICON2);
 				theApp.m_imgFavIcons.Add(ICoHelper);
 
-				TabWindowMsgBSend(TWNT_ORDER, Target->GetSafeHwnd());
+				TabWindowMsgBSend(TWNT_ORDER_COMMAND, Target->GetSafeHwnd());
 			}
 		}
 	}
@@ -1367,12 +1367,12 @@ void CMainFrame::TabWindowMsgBSend(int iCommand, HWND hWnd)
 				if (ptd->IsWindowEnabled())
 				{
 					DWORD_PTR dwResult = {0};
-					if (iCommand == TWNT_REFRESH)
+					if (iCommand == TWNT_REFRESH_COMMAND)
 					{
 						::SendMessageTimeout(ptd->m_hWnd, MYWM_TAB_WINDOW_NOTIFY, iCommand,
 								     (LPARAM)(ptdActive == ptd) ? TRUE : NULL, SMTO_NORMAL, 5000, &dwResult);
 					}
-					else if (iCommand == TWNT_WNDPL_ADJUST)
+					else if (iCommand == TWNT_WNDPL_ADJUST_COMMAND)
 					{
 						if (hWnd == ptd->GetSafeHwnd())
 						{
@@ -1381,7 +1381,7 @@ void CMainFrame::TabWindowMsgBSend(int iCommand, HWND hWnd)
 							break;
 						}
 					}
-					else if (iCommand == TWNT_DEL)
+					else if (iCommand == TWNT_DEL_COMMAND)
 					{
 						if (hWnd == ptd->GetSafeHwnd())
 						{
@@ -1390,7 +1390,7 @@ void CMainFrame::TabWindowMsgBSend(int iCommand, HWND hWnd)
 							break;
 						}
 					}
-					else if (iCommand == TWNT_ORDER)
+					else if (iCommand == TWNT_ORDER_COMMAND)
 					{
 						if (hWnd == ptd->GetSafeHwnd())
 						{

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4419,7 +4419,7 @@ void CSazabi::SetFavicon(CImage* img, CBrowserFrame* pwndFrame)
 		}
 		else
 			m_imgFavIcons.Add(ICoHelper);
-		((CMainFrame*)m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH, NULL);
+		((CMainFrame*)m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH_COMMAND, NULL);
 	}
 }
 void CSazabi::SetDefaultFavicon(CBrowserFrame* pwndFrame)
@@ -4437,7 +4437,7 @@ void CSazabi::SetDefaultFavicon(CBrowserFrame* pwndFrame)
 	}
 	else
 		m_imgFavIcons.Add(ICoHelper);
-	((CMainFrame*)m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH, NULL);
+	((CMainFrame*)m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH_COMMAND, NULL);
 }
 
 void CSazabi::SetWarmFavicon(HWND hwndF)
@@ -4458,7 +4458,7 @@ void CSazabi::SetWarmFavicon(HWND hwndF)
 		}
 		else
 			m_imgFavIcons.Add(ICoHelper);
-		((CMainFrame*)m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH, NULL);
+		((CMainFrame*)m_pMainWnd)->TabWindowMsgBSend(TWNT_REFRESH_COMMAND, NULL);
 	}
 }
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

以下の警告を解消。

```
C:\gitdir\Chronos\CTabWnd.h(8): warning C26812: 列挙型 'ETabWndNotifyType' は対象範囲外です。'enum' (Enum.3) より 'enum class' を優先します。
```

これらはコマンドメッセージのIDとして使われている。
少なくともChronosではメッセージIDはほぼマクロで定義されているため、マクロで定義するように変更。
（enum classにすると、コマンドのメッセージとして渡すときは必ず数値型にしないといけないし、少し微妙な感じがするということもある）

https://github.com/ThinBridge/Chronos/pull/173 と違って単なる変数にしていないのは、上記のようにメッセージはマクロで定義されていることが多いことと、スコープが狭い名前空間で定義されているわけでもないため。

# How to verify the fixed issue:

## The steps to verify:

**警告の解消の確認**

* Code Analysisを実行する。また、Chronosをリビルドする。

**リグレッションテスト**

タブの動作に関するソースコードに変更が入っているので、タブの動作を確認する。

* 複数のタブを開く
* ドラッグアンドドロップでタブの移動をする
* タブの削除をする

## Expected result:

**警告の解消の確認**

以下の警告が表示されないこと

```
C:\gitdir\Chronos\CTabWnd.h(8): warning C26812: 列挙型 'ETabWndNotifyType' は対象範囲外です。'enum' (Enum.3) より 'enum class' を優先します。
```

**リグレッションテスト**

* 各タブが問題なく開くこと
* タブの移動が問題なく行えること
* タブの削除が行われること