### PR TITLE
Improve rebar setting

### DIFF
--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -873,6 +873,7 @@ BEGIN_MESSAGE_MAP(CDlgSetDSP, CPropertyPage)
 	ON_WM_DESTROY()
 	ON_MESSAGE(ID_SETTING_OK, Set_OK)
 	ON_BN_CLICKED(IDC_BUTTON1, &CDlgSetDSP::OnBnClickedButton1)
+	ON_BN_CLICKED(IDC_CHECK_DISABLE_REBAR, &CDlgSetDSP::OnBnClickedCheckDisableRebar)
 END_MESSAGE_MAP()
 
 BOOL CDlgSetDSP::OnInitDialog()
@@ -905,9 +906,15 @@ BOOL CDlgSetDSP::OnInitDialog()
 
 	//Rebar
 	if (theApp.m_AppSettingsDlgCurrent.IsRebar())
+	{
 		((CButton*)GetDlgItem(IDC_CHECK_DISABLE_REBAR))->SetCheck(1);
+		GetDlgItem(IDC_CHECK_LOGO)->EnableWindow(TRUE);
+	}
 	else
+	{
 		((CButton*)GetDlgItem(IDC_CHECK_DISABLE_REBAR))->SetCheck(0);
+		GetDlgItem(IDC_CHECK_LOGO)->EnableWindow(FALSE);
+	}
 
 	//ステータスバー
 	if (theApp.m_AppSettingsDlgCurrent.IsStatusbar())
@@ -2847,4 +2854,10 @@ void CDlgSetCustomScript::OnBnClickedButton1()
 void CDlgSetCustomScript::OnBnClickedShowDevTools()
 {
 	theApp.ShowDevTools();
+}
+
+void CDlgSetDSP::OnBnClickedCheckDisableRebar()
+{
+	BOOL checked = ((CButton*)GetDlgItem(IDC_CHECK_DISABLE_REBAR))->GetCheck();
+	GetDlgItem(IDC_CHECK_LOGO)->EnableWindow(checked);
 }

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -399,6 +399,7 @@ protected:
 	DECLARE_MESSAGE_MAP()
 public:
 	afx_msg void OnBnClickedButton1();
+	afx_msg void OnBnClickedCheckDisableRebar();
 };
 
 class CDlgSetGen : public CPropertyPage

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -274,7 +274,7 @@ BEGIN
     CONTROL         "GPUレンダリングを有効にする",IDC_CHECK_GPU,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,25,161,10
     CONTROL         "Rebar(メニュー、ツールバー、アドレスバー)を表示する",IDC_CHECK_DISABLE_REBAR,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,55,238,10
-    CONTROL         "Rebarにロゴを表示する",IDC_CHECK_LOGO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,70,161,10
+    CONTROL         "Rebarにロゴを表示する",IDC_CHECK_LOGO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,70,161,10
     CONTROL         "ステータスバーを表示する",IDC_CHECK_DISABLE_STATUSBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,85,153,10
     GROUPBOX        "ポップアップウィンドウ",IDC_STATIC,8,133,265,45
     LTEXT           "幅マージン",IDC_STATIC,15,145,45,8
@@ -1632,7 +1632,7 @@ BEGIN
     CONTROL         "Enable GPU rendering",IDC_CHECK_GPU,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,25,161,10
     CONTROL         "Show Rebar (menubar, toolbar and address bar)",IDC_CHECK_DISABLE_REBAR,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,55,238,10
-    CONTROL         "Show logo on the Rebar",IDC_CHECK_LOGO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,70,161,10
+    CONTROL         "Show logo on the Rebar",IDC_CHECK_LOGO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,70,161,10
     CONTROL         "Show status bar",IDC_CHECK_DISABLE_STATUSBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,85,153,10
     GROUPBOX        "Popup windows",IDC_STATIC,8,133,265,45
     LTEXT           "Horizontal margin",IDC_STATIC,15,145,45,8


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/11

# What this PR does / why we need it:

`Show logo on the Rebar` works only when `Show Rebar` is enabled.
So we should indent the `Show logo on the Rebar` checkbox, and enable it only when the `Show Rebar` checkbox is checked.


When the `Show Rebar` checkbox is checked:
![enabled](https://github.com/ThinBridge/Chronos/assets/15982708/f5134125-792a-4afd-8c10-36a687fffa95)

When  the `Show Rebar` checkbox is unchecked: 
![disabled](https://github.com/ThinBridge/Chronos/assets/15982708/c00261a5-c1dc-42d9-876b-ea29104af507)


# How to verify the fixed issue:

## The steps to verify:

1. Open appearance setting dialog.
2. Click the `Show Rebar` checkbox multiple times.
3. Close and re-open appearance setting dialog with the enabled "Show Rebar" checkbox.
4. Close and re-open appearance setting dialog with the disabled "Show Rebar" checkbox.

## Expected result:

1. The `Show logo on the Rebar` checkbox is indented.
2. The `Show logo on the Rebar` checkbox is enabled if the "Show Rebar" checkbox is checked, disabled if unchecked.
3. The `Show logo on the Rebar` checkbox is enabled when re-opening.
4. The `Show logo on the Rebar` checkbox is disabled when re-opening.


