### PR TITLE
ExtFilter: modify a value for displaying all

### DIFF
--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1266,7 +1266,7 @@ public:
 		//ChFiler---------------------------------
 		RootPath = _T("B:\\");
 		UploadBasePath = _T("O:\\");
-		ExtFilter = _T("*.*");
+		ExtFilter = _T(".*");
 		EnableOpendOp = 1;
 		EnableTransferLog = 0;
 		EnableUploadSync = 0;


### PR DESCRIPTION
This is a work in progress, not tested yet.

# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/19

# What this PR does / why we need it:

We should specify only extensions (and separater ".") for ExtFilter. On the other hand the value for displaying all (default) is "\*.\*", having a filename. So this patch modifies "\*.\*" to ".\*" in order to contains only an extension.

# How to verify the fixed issue:

This change is for the ThinApp mode file manager, so we can't test it in this repository.
A test for this PR is executed with https://github.com/ThinBridge/Chronos-SG/pull/174.