### PR TITLE
Suppress warning C26495

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -23,6 +23,7 @@ CChildView::CChildView()
 	m_bFirstCallDontClose = FALSE;
 	m_nBrowserID = 0;
 	m_bDevToolsWnd = FALSE;
+	m_bFindNext = FALSE;
 }
 
 CChildView::~CChildView()

--- a/CTabWnd.cpp
+++ b/CTabWnd.cpp
@@ -475,6 +475,9 @@ CTabWnd::CTabWnd()
 	m_TAB_WINDOW_HEIGHT = TAB_WINDOW_HEIGHT;
 	m_MAX_TABITEM_WIDTH = MAX_TABITEM_WIDTH;
 	m_MIN_TABITEM_WIDTH = MIN_TABITEM_WIDTH;
+	m_nTabHover = 0;
+	m_hDefaultCursor = NULL;
+	m_ptSrcCursor = {0};
 	return;
 }
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#42

# What this PR does / why we need it:

Suppress warning like below.

```
重大度レベル	コード	説明	プロジェクト	ファイル	行	抑制状態	詳細
警告	C26495	変数 'CTabWnd::m_ptSrcCursor' が初期化されていません。メンバー変数は必ず初期化してください (type.6)。	Sazabi	C:\gitdir\Chronos\CTabWnd.cpp	459		
```

# How to verify the fixed issue:

## The warning is suppressed

* Execute Code Analysis.
  * The warning C26495 is not displayed. ...OK

## Regression test

* Start Chronos and check that moving tabs works correctly. ...OK