### PR TITLE
Use StringCchCopy instead of lstrcpy family

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1483,9 +1483,9 @@ void CChildView::OnPrintPDF()
 		if (bRet == IDOK)
 		{
 			memset(szSelPath, 0x00, sizeof(WCHAR) * MAX_PATH);
-			lstrcpynW(szSelPath, pFileDlg->GetPathName(), MAX_PATH);
-			WCHAR szSelFolderPath[MAX_PATH + 1] = {0};
-			lstrcpynW(szSelFolderPath, pFileDlg->GetPathName(), MAX_PATH);
+			StringCchCopy(szSelPath, MAX_PATH, pFileDlg->GetPathName());
+			WCHAR szSelFolderPath[MAX_PATH] = {0};
+			StringCchCopy(szSelFolderPath, MAX_PATH, pFileDlg->GetPathName());
 			PathRemoveFileSpec(szSelFolderPath);
 			theApp.m_strLastSelectFolderPath = szSelFolderPath;
 			strPath = pFileDlg->GetPathName();

--- a/CTabWnd.cpp
+++ b/CTabWnd.cpp
@@ -822,7 +822,7 @@ LRESULT CTabWnd::OnNotify(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			{
 				CString strRet;
 				strRet = this->m_pwndMainFrame->Get_TabWindowInfo_Title((HWND)tcitem.lParam);
-				lstrcpyn(m_szTextTip, strRet, _countof(m_szTextTip) - 1);
+				StringCchCopy(m_szTextTip, _countof(m_szTextTip), strRet);
 
 				((NMTTDISPINFO*)pnmh)->lpszText = m_szTextTip;
 				((NMTTDISPINFO*)pnmh)->hinst = NULL;
@@ -1072,7 +1072,7 @@ void CTabWnd::Refresh(BOOL bEnsureVisible /* = TRUE*/, BOOL bRebuild /* = FALSE*
 			strTempTitle.Replace(_T("&"), _T("&&"));
 			//文字のカット
 			SBUtil::GetDivChar(strTempTitle, 24, strTempTitle, FALSE);
-			lstrcpyn(szName, strTempTitle, _countof(szName) - 1);
+			StringCchCopy(szName, _countof(szName), strTempTitle);
 
 			tcitem.pszText = szName;
 			tcitem.iImage = j;

--- a/DlgDL.h
+++ b/DlgDL.h
@@ -32,8 +32,8 @@ public:
 		if (m_bDLComp)
 		{
 			m_strFileFullPath = strFileFullPath;
-			TCHAR szFolder[MAX_PATH * 2 + 1] = {0};
-			lstrcpyn(szFolder, strFileFullPath, MAX_PATH * 2);
+			TCHAR szFolder[MAX_PATH] = {0};
+			StringCchCopy(szFolder, MAX_PATH, strFileFullPath);
 			PathRemoveFileSpec(szFolder);
 			m_strFileFolderPath = szFolder;
 			m_FileName.SetWindowText(strFileFullPath);

--- a/DlgDebugWnd.cpp
+++ b/DlgDebugWnd.cpp
@@ -493,7 +493,7 @@ void CDlgDebugWnd::OnGetdispinfoList1(NMHDR* pNMHDR, LRESULT* pResult)
 			case LIST_INDEX:
 			{
 				this->DWToString(pData->iIndex, m_strTemp);
-				lstrcpy(item->pszText, m_strTemp);
+				StringCchCopy(item->pszText, m_strTemp.GetLength() + 1, m_strTemp);
 				break;
 			}
 			case LIST_DATE_TIME:

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -400,7 +400,7 @@ BOOL CSazabi::InitFunc_SGMode()
 		TCHAR szTargetPath[4096] = {0};
 		CString strDrive;
 		TCHAR szPath[MAX_PATH] = {0};
-		lstrcpyn(szPath, m_AppSettings.GetRootPath(), MAX_PATH);
+		StringCchCopy(szPath, MAX_PATH, m_AppSettings.GetRootPath());
 		if (PathStripToRoot(szPath))
 			strDrive = szPath;
 		if (strDrive.IsEmpty())
@@ -795,7 +795,7 @@ BOOL CSazabi::InitMultipleInstance()
 	strFrmWndClass.Replace(_T("."), _T(""));
 	strFrmWndClass.Replace(_T("--"), _T("-"));
 	strFrmWndClass.Replace(_T(" "), _T("_"));
-	lstrcpyn(m_FrmWndClassName, strFrmWndClass, 512);
+	StringCchCopy(m_FrmWndClassName, 512, strFrmWndClass);
 
 	SetAppID(m_FrmWndClassName);
 
@@ -1354,7 +1354,7 @@ void CSazabi::OpenChTaskMgr()
 	CString strFndWndChk;
 	strFndWndChk = _T("ChTaskMGR:");
 	strFndWndChk += m_FrmWndClassName;
-	lstrcpyn(FrmWndClassName, strFndWndChk, 255);
+	StringCchCopy(FrmWndClassName, _countof(FrmWndClassName), strFndWndChk);
 
 	HWND hWndCap = ::FindWindow(FrmWndClassName, NULL); //APのハンドル取得
 	//起動している。
@@ -2445,7 +2445,7 @@ void CSazabi::OpenDefaultBrowser(const CString& strURL, DWORD iType, const CStri
 			strFrmWndClass.Replace(_T("."), _T(""));
 			strFrmWndClass.Replace(_T("--"), _T("-"));
 			strFrmWndClass.Replace(_T(" "), _T("_"));
-			lstrcpyn(FrmWndClassName, strFrmWndClass, 255);
+			StringCchCopy(FrmWndClassName, _countof(FrmWndClassName), strFrmWndClass);
 
 			HWND hWndCap = FindWindow(FrmWndClassName, NULL); //APのハンドル取得
 			//起動している。

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -633,7 +633,7 @@ public:
 
 		CString strParam(lpPath);
 		TCHAR szPath[MAX_PATH] = {0};
-		lstrcpyn(szPath, strParam, MAX_PATH);
+		StringCchCopy(szPath, MAX_PATH, strParam);
 
 		if (PathStripToRoot(szPath))
 			strRet = szPath;

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -861,10 +861,10 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 		if (bRet == IDOK)
 		{
 			memset(szSelPath, 0x00, sizeof(WCHAR) * MAX_PATH);
-			lstrcpynW(szSelPath, pFileDlg->GetPathName(), MAX_PATH);
+			StringCchCopy(szSelPath, MAX_PATH, pFileDlg->GetPathName());
 
-			WCHAR szSelFolderPath[MAX_PATH + 1] = {0};
-			lstrcpynW(szSelFolderPath, pFileDlg->GetPathName(), MAX_PATH);
+			WCHAR szSelFolderPath[MAX_PATH] = {0};
+			StringCchCopy(szSelFolderPath, MAX_PATH, pFileDlg->GetPathName());
 			PathRemoveFileSpec(szSelFolderPath);
 			theApp.m_strLastSelectFolderPath = szSelFolderPath;
 
@@ -939,7 +939,7 @@ void ClientHandler::OnDownloadUpdated(CefRefPtr<CefBrowser> browser, CefRefPtr<C
 		CefString cefFulPath = download_item->GetFullPath();
 		LPCWSTR fullPath = (LPCWSTR)cefFulPath.c_str();
 		if (fullPath)
-			lstrcpyn(values.szFullPath, fullPath, 512);
+			StringCchCopy(values.szFullPath, 512, fullPath);
 	}
 	HWND hWindow = GetSafeParentWnd(browser);
 	UINT nBrowserId = browser->GetIdentifier();

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -5,6 +5,7 @@
 #include "locale.h"
 #include <sddl.h>
 #include <VersionHelpers.h>
+#include <strsafe.h>
 #include "include/cef_version.h"
 
 #include "mmsystem.h"
@@ -1892,7 +1893,7 @@ public:
 			iSize += 1; //+1=null
 			pVal = new TCHAR[iSize];
 			memset(pVal, 0x00, sizeof(TCHAR) * iSize);
-			lstrcpyn(pVal, strVal, iSize);
+			StringCchCopy(pVal, iSize, strVal);
 			RegSetValueEx(hKey, lpRegSub, 0, REG_SZ, (LPBYTE)pVal, sizeof(TCHAR) * iSize);
 			RegCloseKey(hKey);
 			delete[] pVal;
@@ -2906,10 +2907,9 @@ public:
 				delete[] m_pstrData_UTF8;
 				m_pstrData_UTF8 = NULL;
 			}
-			long size = src.GetLength() * 2 + 2;
-			wchar_t* lpWideString = new wchar_t[size];
-			memset(lpWideString, 0x00, size);
-			lstrcpyn(lpWideString, src, size);
+			long size = src.GetLength() + 1;
+			wchar_t* lpWideString = new wchar_t[size]{0};
+			StringCchCopy(lpWideString, size, src);
 			long size2 = src.GetLength() * 3 + 2;
 			m_pstrData_UTF8 = new char[size2];
 			memset(m_pstrData_UTF8, 0x00, size2);
@@ -4036,8 +4036,8 @@ public:
 					pDLDlg->m_Msg.SetWindowText(strMsg);
 					pDLDlg->m_Tf.SetWindowText(strTf);
 					pDLDlg->m_strFileFullPath = strFileName;
-					TCHAR szFolder[MAX_PATH * 2 + 1] = {0};
-					lstrcpyn(szFolder, strFileName, MAX_PATH * 2);
+					TCHAR szFolder[MAX_PATH] = {0};
+					StringCchCopy(szFolder, MAX_PATH, strFileName);
 					PathRemoveFileSpec(szFolder);
 					pDLDlg->m_strFileFolderPath = szFolder;
 					m_taskbarList3.SetProgress((ULONGLONG)nProgress, (ULONGLONG)100, TBPF_NORMAL);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#179

# What this PR does / why we need it:

Use `StringCchCopy` instead of the `lstrcpy` family.

This change affects all of the system, especially the following process is affected.

* File download
* Audit log
* TRACE Log Monitor Window

# How to verify the fixed issue:

* Chronosを起動し、各ウィンドウが正しく表示されること ...OK
* 新しいタブを作成し新しいタブが問題なく表示されること  ...OK
* 以下の監査ログのテスト手順を実施し、問題なく監査ログが送信されること ...OK
  * https://github.com/ThinBridge/Chronos-SG/blob/main/Documents/%E3%83%86%E3%82%B9%E3%83%88%E9%A0%85%E7%9B%AE%E4%B8%80%E8%A6%A7/Sources/1-3_%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E8%A8%AD%E5%AE%9A.md#%E3%83%AD%E3%82%B0%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BCurl
* 適当なファイルをダウンロードし、保存する
  * ファイルパスの表示等が問題なく表示され、ダウンロードできること ...OK
* ログ出力設定で「ログをファイルへ出力する」を有効にし、TRACE Log Monitor Windows を開く
  * 表示される表の内容の末尾が欠けていたり、表示されないものがないこと ...OK
