### PR TITLE
ChFiler: Add support for auto transfer when SG mode

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -3084,7 +3084,7 @@ void CBrowserFrame::OpenThinFiler()
 	//起動している。
 	if (hWndCap)
 	{
-		SBUtil::SetAbsoluteForegroundWindow(hWndCap, FALSE);
+		theApp.OpenChFiler(CHFILER_INIT_MODE::OPEN, NULL);
 	}
 	else
 	{

--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -3092,7 +3092,7 @@ void CBrowserFrame::OpenThinFiler()
 		CString startingMsg;
 		startingMsg.LoadString(IDS_STRING_STARTING_FILEMGR);
 		SetMessage_MsgDlg(startingMsg);
-		theApp.OpenChFiler(NULL);
+		theApp.OpenChFiler(CHFILER_INIT_MODE::OPEN, NULL);
 		Release_MsgDlg();
 	}
 }

--- a/DlgDL.cpp
+++ b/DlgDL.cpp
@@ -76,10 +76,10 @@ void CDlgDL::OnBnClickedCancel()
 			this->KillTimer(m_iTimerID);
 			m_iTimerID = 0;
 		}
-		if (::PathFileExists(m_strFileFolderPath))
+		if (theApp.m_AppSettings.IsEnableAutoTransfer() &&
+		    ::PathFileExists(m_strFileFullPath))
 		{
-			theApp.OpenChFiler(m_strFileFolderPath);
-			CDialog::OnOK();
+			theApp.OpenChFiler(CHFILER_INIT_MODE::TRANSFER, m_strFileFullPath);
 		}
 		CDialogEx::OnCancel();
 		return;
@@ -130,7 +130,11 @@ void CDlgDL::OnBnClickedButton1()
 			this->KillTimer(m_iTimerID);
 			m_iTimerID = 0;
 		}
-
+		if (theApp.m_AppSettings.IsEnableAutoTransfer() &&
+		    ::PathFileExists(m_strFileFullPath))
+		{
+			theApp.OpenChFiler(CHFILER_INIT_MODE::TRANSFER, m_strFileFullPath);
+		}
 		return;
 	}
 	CString confirmMsg;
@@ -286,7 +290,7 @@ void CDlgDL::OnBnClickedButtonFo()
 	{
 		if (::PathFileExists(m_strFileFullPath))
 		{
-			theApp.OpenChFiler(m_strFileFullPath);
+			theApp.OpenChFiler(CHFILER_INIT_MODE::OPEN, m_strFileFullPath);
 			CDialog::OnOK();
 		}
 	}
@@ -321,7 +325,7 @@ void CDlgDL::OnBnClickedButtonDiro()
 		}
 		else if (::PathFileExists(m_strFileFolderPath))
 		{
-			theApp.OpenChFiler(m_strFileFolderPath);
+			theApp.OpenChFiler(CHFILER_INIT_MODE::OPEN, m_strFileFolderPath);
 			CDialog::OnOK();
 		}
 	}

--- a/DlgDL.cpp
+++ b/DlgDL.cpp
@@ -76,6 +76,11 @@ void CDlgDL::OnBnClickedCancel()
 			this->KillTimer(m_iTimerID);
 			m_iTimerID = 0;
 		}
+		if (::PathFileExists(m_strFileFolderPath))
+		{
+			theApp.OpenChFiler(m_strFileFolderPath);
+			CDialog::OnOK();
+		}
 		CDialogEx::OnCancel();
 		return;
 	}

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1312,7 +1312,7 @@ void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 					}
 					else
 					{
-						nAtom = ::GlobalAddAtom(strParam);
+						nAtom = ::GlobalAddAtom(strOpenPath);
 						LRESULT lr = SendMessageTimeout(hWndCap, WM_USER + 58, (WPARAM)nAtom, static_cast<LPARAM>(initMode), SMTO_BLOCK, 3 * 1000, NULL);
 					}
 					return;

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1195,26 +1195,14 @@ void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 	{
 		if (!theApp.IsSGMode()) return;
 
-		CString strExecCommand;
-		CString strCommand;
-		CString strParam;
-		CString strOpenPath;
-		if (lpOpenPath)
+		if (initMode == CHFILER_INIT_MODE::EXIT_CHECK)
 		{
-			strOpenPath = lpOpenPath;
+			CString strExecCommand;
+			CString strCommand;
+			LPCTSTR strParam = _T("/ExitChk");
 			strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
-			strExecCommand.Format(_T("\"%sChFiler.exe\" \"%s\""), (LPCTSTR)m_strExeFolderPath, (LPCTSTR)strOpenPath);
-			strParam.Format(_T("\"%s\""), (LPCTSTR)strOpenPath);
-		}
-		else
-		{
-			strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
-			strExecCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
-			strParam = _T("");
-		}
+			strExecCommand.Format(_T("\"%sChFiler.exe\" %s"), (LPCTSTR)m_strExeFolderPath, strParam);
 
-		if (strOpenPath == _T("/ExitChk"))
-		{
 			STARTUPINFO si = {0};
 			PROCESS_INFORMATION pi = {0};
 			si.cb = sizeof(si);
@@ -1284,6 +1272,24 @@ void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 		}
 		else
 		{
+			CString strExecCommand;
+			CString strCommand;
+			CString strParam;
+			CString strOpenPath;
+			if (lpOpenPath)
+			{
+				strOpenPath = lpOpenPath;
+				strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
+				LPCTSTR mode = initMode == CHFILER_INIT_MODE::OPEN ? _T("") : _T("/Transfer");
+				strParam.Format(_T("%s \"%s\""), mode, (LPCTSTR)strOpenPath);
+				strExecCommand.Format(_T("\"%sChFiler.exe\" %s"), (LPCTSTR)m_strExeFolderPath, (LPCTSTR)strParam);
+			}
+			else
+			{
+				strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
+				strExecCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
+				strParam = _T("");
+			}
 			CString strFrmWnd;
 			strFrmWnd = _T("CFiler:");
 			strFrmWnd += m_FrmWndClassName;
@@ -1302,12 +1308,12 @@ void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 					ATOM nAtom = {0};
 					if (strParam.IsEmpty())
 					{
-						LRESULT lr = SendMessageTimeout(hWndCap, WM_USER + 58, (WPARAM)0, 0, SMTO_BLOCK, 3 * 1000, NULL);
+						LRESULT lr = SendMessageTimeout(hWndCap, WM_USER + 58, (WPARAM)0, static_cast<LPARAM>(CHFILER_INIT_MODE::OPEN), SMTO_BLOCK, 3 * 1000, NULL);
 					}
 					else
 					{
 						nAtom = ::GlobalAddAtom(strParam);
-						LRESULT lr = SendMessageTimeout(hWndCap, WM_USER + 58, (WPARAM)nAtom, 0, SMTO_BLOCK, 3 * 1000, NULL);
+						LRESULT lr = SendMessageTimeout(hWndCap, WM_USER + 58, (WPARAM)nAtom, static_cast<LPARAM>(initMode), SMTO_BLOCK, 3 * 1000, NULL);
 					}
 					return;
 				}
@@ -1994,7 +2000,7 @@ void CSazabi::CloseVOSProcessOther()
 	RegCloseKey(hKey);
 	if (!bThinFilerExecFlg)
 	{
-		OpenChFiler(CHFILER_INIT_MODE::EXIT_CHECK);
+		OpenChFiler(CHFILER_INIT_MODE::EXIT_CHECK, NULL);
 	}
 }
 

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1188,7 +1188,7 @@ void CSazabi::ExitKillZombieProcess()
 		}
 	}
 }
-void CSazabi::OpenChFiler(LPCTSTR lpOpenPath)
+void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 {
 	PROC_TIME(OpenChFiler)
 	try
@@ -1994,7 +1994,7 @@ void CSazabi::CloseVOSProcessOther()
 	RegCloseKey(hKey);
 	if (!bThinFilerExecFlg)
 	{
-		OpenChFiler(_T("/ExitChk"));
+		OpenChFiler(CHFILER_INIT_MODE::EXIT_CHECK);
 	}
 }
 

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -45,6 +45,13 @@
 #define CEF_WOD_IGNORE_ACTION		WOD_IGNORE_ACTION
 #endif
 
+enum class CHFILER_INIT_MODE
+{
+	OPEN,
+	TRANSFER,
+	EXIT_CHECK
+};
+
 class CChildView;
 class CScriptHost;
 class CBrowserFrame;
@@ -333,7 +340,7 @@ public:
 	BOOL DeleteDirectoryTempFolder(LPCTSTR lpPathName);
 
 	void ExitKillZombieProcess();
-	void OpenChFiler(LPCTSTR lpOpenPath);
+	void OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath = NULL);
 	void OpenChTaskMgr();
 
 	//{{AFX_VIRTUAL(CSazabi)

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -980,6 +980,7 @@ public:
 		EnableUploadSync = 0;
 		EnableUploadSyncMirror = 0;
 		UploadSyncInterval = 0;
+		EnableAutoTransfer = 0;
 		DisableOpendOpAlert = 0;
 		DisableExitOpAlert = 0;
 		ConfirmAutoRefresh = 0;
@@ -1064,6 +1065,7 @@ public:
 		Data.EnableUploadSync = EnableUploadSync;
 		Data.EnableUploadSyncMirror = EnableUploadSyncMirror;
 		Data.UploadSyncInterval = UploadSyncInterval;
+		Data.EnableAutoTransfer = EnableAutoTransfer;
 		Data.DisableOpendOpAlert = DisableOpendOpAlert;
 		Data.DisableExitOpAlert = DisableExitOpAlert;
 		Data.ConfirmAutoRefresh = ConfirmAutoRefresh;
@@ -1172,6 +1174,7 @@ private:
 	int EnableUploadSync;
 	int EnableUploadSyncMirror;
 	int UploadSyncInterval;
+	int EnableAutoTransfer;
 	CString UploadBasePath;
 	//ChTaskMGR---------------------------------
 	int LABEL_TYPE;
@@ -1273,6 +1276,7 @@ public:
 		EnableUploadSync = 0;
 		EnableUploadSyncMirror = 0;
 		UploadSyncInterval = 5000;
+		EnableAutoTransfer = 0;
 		DisableOpendOpAlert = 0;
 		DisableExitOpAlert = 2;
 		ConfirmAutoRefresh = 2;
@@ -1797,6 +1801,15 @@ public:
 					UploadSyncInterval = iW;
 					continue;
 				}
+				if (strTemp2.CompareNoCase(_T("EnableAutoTransfer")) == 0)
+				{
+					int iW = 0;
+					iW = _ttoi(strTemp3);
+					if (iW < 0)
+						iW = 0;
+					UploadSyncInterval = iW;
+					continue;
+				}
 
 				//ChTaskMGR---------------------------------
 				if (strTemp2.CompareNoCase(_T("LABEL_TYPE")) == 0)
@@ -2016,6 +2029,7 @@ public:
 		strRet += EXTVAL(EnableUploadSync);
 		strRet += EXTVAL(EnableUploadSyncMirror);
 		strRet += EXTVAL(UploadSyncInterval);
+		strRet += EXTVAL(EnableAutoTransfer);
 		strRet += EXTVAL(EnableOpendOp);
 		strRet += EXTVAL(DisableOpendOpAlert);
 
@@ -2116,6 +2130,7 @@ public:
 	inline BOOL IsEnableUploadSync() { return EnableUploadSync; }
 	inline BOOL IsEnableUploadSyncMirror() { return EnableUploadSyncMirror; }
 	inline int GetUploadSyncInterval() { return UploadSyncInterval; }
+	inline BOOL IsEnableAutoTransfer() { return EnableAutoTransfer; }
 	inline BOOL IsDisableOpendOpAlert() { return DisableOpendOpAlert; }
 	inline BOOL IsDisableExitOpAlert() { return DisableExitOpAlert; }
 	inline int GetConfirmAutoRefresh() { return ConfirmAutoRefresh; }
@@ -2228,6 +2243,7 @@ public:
 	inline void SetEnableUploadSync(DWORD dVal) { EnableUploadSync = dVal; }
 	inline void SetEnableUploadSyncMirror(DWORD dVal) { EnableUploadSyncMirror = dVal; }
 	inline void SetUploadSyncInterval(DWORD dVal) { UploadSyncInterval = dVal; }
+	inline void SetEnableAutoTransfer(DWORD dVal) { EnableAutoTransfer = dVal; }
 	inline void SetDisableOpendOpAlert(DWORD dVal) { DisableOpendOpAlert = dVal; }
 	inline void SetDisableExitOpAlert(DWORD dVal) { DisableExitOpAlert = dVal; }
 	inline void SetConfirmAutoRefresh(DWORD dVal) { ConfirmAutoRefresh = dVal; }

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1803,11 +1803,7 @@ public:
 				}
 				if (strTemp2.CompareNoCase(_T("EnableAutoTransfer")) == 0)
 				{
-					int iW = 0;
-					iW = _ttoi(strTemp3);
-					if (iW < 0)
-						iW = 0;
-					UploadSyncInterval = iW;
+					EnableAutoTransfer = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/44

# What this PR does / why we need it:

Add support for auto transfer when SG mode, means working on ThinApp.

* Add a config parameter `EnableAutoTransfer`
  * Value Type: boolean
    * `0`(`False`)
    * `1`(`True`)
  * Default: `False`

* If `EnableAutoTransfer` is `True`, Chronos automatically opens and transfers a downloaded file.
  * The downloaded file is opened and transferred when closing the donwload dialog.
    ![image](https://github.com/ThinBridge/Chronos/assets/15982708/31d01c12-5a8d-4cf0-b2e8-e8e1b4d5bc80)
* If `EnableAutoTransfer` is `False`, Chronos doesn't automatically open and transfer a downloaded file. 

# How to verify the fixed issue:

This change is for the SG mode, means working on ThinApp, file manager, so we can't test it only in this repository.
Tests for this PR is executed with https://github.com/ThinBridge/Chronos-SG/pull/226