### PR TITLE
ChFiler: Hide open file and open folder if EnableAutoTransfer = true

### DIFF
--- a/DlgDL.cpp
+++ b/DlgDL.cpp
@@ -52,7 +52,45 @@ void CDlgDL::OnBnClickedOk()
 {
 	//	CDialogEx::OnOK();
 }
-
+void CDlgDL::SetCompST(BOOL bComp, LPCTSTR strFileFullPath)
+{
+	m_bDLComp = bComp;
+	if (m_bDLComp)
+	{
+		m_strFileFullPath = strFileFullPath;
+		TCHAR szFolder[MAX_PATH] = {0};
+		StringCchCopy(szFolder, MAX_PATH, strFileFullPath);
+		PathRemoveFileSpec(szFolder);
+		m_strFileFolderPath = szFolder;
+		m_FileName.SetWindowText(strFileFullPath);
+		m_Prog.SetPos(100);
+		m_Tf.SetWindowText(_T(""));
+		if (!theApp.m_AppSettings.IsEnableAutoTransfer())
+		{
+			GetDlgItem(IDC_BUTTON_FO)->EnableWindow(TRUE);
+			GetDlgItem(IDC_BUTTON_FO)->ShowWindow(SW_SHOW);
+			GetDlgItem(IDC_BUTTON_DIRO)->EnableWindow(TRUE);
+			GetDlgItem(IDC_BUTTON_DIRO)->ShowWindow(SW_SHOW);
+		}
+		CString closeButtonLabel;
+		closeButtonLabel.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_CLOSE);
+		GetDlgItem(IDC_BUTTON1)->SetWindowText(closeButtonLabel);
+		CString windowTitle;
+		windowTitle.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_TITLE);
+		this->SetWindowText(windowTitle);
+		m_Msg.SetWindowText(windowTitle);
+		if (!this->IsWindowVisible())
+		{
+			this->ShowWindow(SW_SHOW);
+		}
+		::SetWindowPos(this->m_hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+		if (!m_iTimerID)
+		{
+			m_iTimerID = (INT_PTR)this;
+			this->SetTimer(m_iTimerID, 30 * 1000, 0);
+		}
+	}
+}
 void CDlgDL::OnTimer(UINT_PTR nIDEvent)
 {
 	if (m_iTimerID == nIDEvent)

--- a/DlgDL.h
+++ b/DlgDL.h
@@ -26,43 +26,8 @@ protected:
 	DECLARE_MESSAGE_MAP()
 public:
 	UINT m_nBrowserId;
-	void SetCompST(BOOL bComp, LPCTSTR strFileFullPath)
-	{
-		m_bDLComp = bComp;
-		if (m_bDLComp)
-		{
-			m_strFileFullPath = strFileFullPath;
-			TCHAR szFolder[MAX_PATH] = {0};
-			StringCchCopy(szFolder, MAX_PATH, strFileFullPath);
-			PathRemoveFileSpec(szFolder);
-			m_strFileFolderPath = szFolder;
-			m_FileName.SetWindowText(strFileFullPath);
-			m_Prog.SetPos(100);
-			m_Tf.SetWindowText(_T(""));
-			GetDlgItem(IDC_BUTTON_FO)->EnableWindow(TRUE);
-			GetDlgItem(IDC_BUTTON_FO)->ShowWindow(SW_SHOW);
-			GetDlgItem(IDC_BUTTON_DIRO)->EnableWindow(TRUE);
-			GetDlgItem(IDC_BUTTON_DIRO)->ShowWindow(SW_SHOW);
-			CString closeButtonLabel;
-			closeButtonLabel.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_CLOSE);
-			GetDlgItem(IDC_BUTTON1)->SetWindowText(closeButtonLabel);
-			CString windowTitle;
-			windowTitle.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_TITLE);
-			this->SetWindowText(windowTitle);
-			m_Msg.SetWindowText(windowTitle);
-			if (!this->IsWindowVisible())
-			{
-				this->ShowWindow(SW_SHOW);
-			}
-			::SetWindowPos(this->m_hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-			if (!m_iTimerID)
-			{
-				m_iTimerID = (INT_PTR)this;
-				this->SetTimer(m_iTimerID, 30 * 1000, 0);
-			}
-		}
-	}
 	BOOL GetCompST() { return m_bDLComp; }
+	void SetCompST(BOOL bComp, LPCTSTR strFileFullPath);
 	afx_msg void OnBnClickedOk();
 	afx_msg void OnBnClickedCancel();
 	afx_msg void OnTimer(UINT_PTR nIDEvent);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/44

# What this PR does / why we need it:

Hide open file and open folder buttons of the finish download dialog if EnableAutoTransfer = true.
This is affect only for SG-mode (working on ThinApp).

# How to verify the fixed issue:

*  最新版のインストーラー（v14.0.119.1のものでよい）からC:\ChronosにChronosN.exeをインストールしておく
* https://github.com/ThinBridge/Chronos-SG の`SourceFiles\build_modules.bat`を実行し、各モジュールをビルド&`Projects\ChronosSG_Project`に配置する（自動）。
* https://github.com/ThinBridge/Chronos-SG の`Projects\ChronosSG_Project\build.bat`を実行し、`Chronos.exe`/`Chronos.exe.alt`を作成し、`C:\Chronos`フォルダーに配置する。
* C:\Chronos\Chronos.confを作成し、以下の記載を行う。
  * `EnableAutoTransfer=1`
* Chronosを起動する
* 適当なファイルをダウンロードする
  * ダウンロード完了ダイアログの「ファイルを開く」「フォルダーを開く」ボタンが表示されないこと ...OK
* Chronosを終了する
* C:\Chronos\Chronos.confを作成し、以下の記載を行う。
  * `EnableAutoTransfer=0`
* Chronosを起動する
* 適当なファイルをダウンロードする
  * ダウンロード完了ダイアログの「ファイルを開く」「フォルダーを開く」ボタンが表示されること ...OK