### PR TITLE
ChFiler: Transfer files just after download if EnableAutoTransfer

### DIFF
--- a/DlgDL.cpp
+++ b/DlgDL.cpp
@@ -52,7 +52,45 @@ void CDlgDL::OnBnClickedOk()
 {
 	//	CDialogEx::OnOK();
 }
-
+void CDlgDL::SetCompST(BOOL bComp, LPCTSTR strFileFullPath)
+{
+	m_bDLComp = bComp;
+	if (m_bDLComp)
+	{
+		m_strFileFullPath = strFileFullPath;
+		TCHAR szFolder[MAX_PATH] = {0};
+		StringCchCopy(szFolder, MAX_PATH, strFileFullPath);
+		PathRemoveFileSpec(szFolder);
+		m_strFileFolderPath = szFolder;
+		m_FileName.SetWindowText(strFileFullPath);
+		m_Prog.SetPos(100);
+		m_Tf.SetWindowText(_T(""));
+		if (!theApp.m_AppSettings.IsEnableAutoTransfer())
+		{
+			GetDlgItem(IDC_BUTTON_FO)->EnableWindow(TRUE);
+			GetDlgItem(IDC_BUTTON_FO)->ShowWindow(SW_SHOW);
+			GetDlgItem(IDC_BUTTON_DIRO)->EnableWindow(TRUE);
+			GetDlgItem(IDC_BUTTON_DIRO)->ShowWindow(SW_SHOW);
+		}
+		CString closeButtonLabel;
+		closeButtonLabel.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_CLOSE);
+		GetDlgItem(IDC_BUTTON1)->SetWindowText(closeButtonLabel);
+		CString windowTitle;
+		windowTitle.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_TITLE);
+		this->SetWindowText(windowTitle);
+		m_Msg.SetWindowText(windowTitle);
+		if (!this->IsWindowVisible())
+		{
+			this->ShowWindow(SW_SHOW);
+		}
+		::SetWindowPos(this->m_hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+		if (!m_iTimerID)
+		{
+			m_iTimerID = (INT_PTR)this;
+			this->SetTimer(m_iTimerID, 30 * 1000, 0);
+		}
+	}
+}
 void CDlgDL::OnTimer(UINT_PTR nIDEvent)
 {
 	if (m_iTimerID == nIDEvent)

--- a/DlgDL.h
+++ b/DlgDL.h
@@ -26,43 +26,8 @@ protected:
 	DECLARE_MESSAGE_MAP()
 public:
 	UINT m_nBrowserId;
-	void SetCompST(BOOL bComp, LPCTSTR strFileFullPath)
-	{
-		m_bDLComp = bComp;
-		if (m_bDLComp)
-		{
-			m_strFileFullPath = strFileFullPath;
-			TCHAR szFolder[MAX_PATH] = {0};
-			StringCchCopy(szFolder, MAX_PATH, strFileFullPath);
-			PathRemoveFileSpec(szFolder);
-			m_strFileFolderPath = szFolder;
-			m_FileName.SetWindowText(strFileFullPath);
-			m_Prog.SetPos(100);
-			m_Tf.SetWindowText(_T(""));
-			GetDlgItem(IDC_BUTTON_FO)->EnableWindow(TRUE);
-			GetDlgItem(IDC_BUTTON_FO)->ShowWindow(SW_SHOW);
-			GetDlgItem(IDC_BUTTON_DIRO)->EnableWindow(TRUE);
-			GetDlgItem(IDC_BUTTON_DIRO)->ShowWindow(SW_SHOW);
-			CString closeButtonLabel;
-			closeButtonLabel.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_CLOSE);
-			GetDlgItem(IDC_BUTTON1)->SetWindowText(closeButtonLabel);
-			CString windowTitle;
-			windowTitle.LoadString(ID_DOWNLOAD_COMPLETE_DIALOG_TITLE);
-			this->SetWindowText(windowTitle);
-			m_Msg.SetWindowText(windowTitle);
-			if (!this->IsWindowVisible())
-			{
-				this->ShowWindow(SW_SHOW);
-			}
-			::SetWindowPos(this->m_hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-			if (!m_iTimerID)
-			{
-				m_iTimerID = (INT_PTR)this;
-				this->SetTimer(m_iTimerID, 30 * 1000, 0);
-			}
-		}
-	}
 	BOOL GetCompST() { return m_bDLComp; }
+	void SetCompST(BOOL bComp, LPCTSTR strFileFullPath);
 	afx_msg void OnBnClickedOk();
 	afx_msg void OnBnClickedCancel();
 	afx_msg void OnTimer(UINT_PTR nIDEvent);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/44

# What this PR does / why we need it:

ダウンロード完了ダイアログが自動で閉じた場合にもファイルが自動転送されるように修正。
「ファイルを開く」「フォルダーを開く」が非表示になったため、ダウンロード完了ダイアログが閉じたタイミングではなく、ダウンロード完了後ただちに転送すればよくなっているため、その方針で修正。
つまり、ダウンロード完了ダイアログが表示されるタイミングで自動送信されるようになったため、どのように閉じられたかに関係なく送信されるようになっている。

SGモード（ThinApp上で動いている場合）にのみ影響。

# How to verify the fixed issue:

*  最新版のインストーラー（v14.0.119.1のものでよい）からC:\ChronosにChronosN.exeをインストールしておく
* https://github.com/ThinBridge/Chronos-SG の`SourceFiles\build_modules.bat`を実行し、各モジュールをビルド&`Projects\ChronosSG_Project`に配置する（自動）。
* https://github.com/ThinBridge/Chronos-SG の`Projects\ChronosSG_Project\build.bat`を実行し、`Chronos.exe`/`Chronos.exe.alt`を作成し、`C:\Chronos`フォルダーに配置する。
* C:\Chronos\Chronos.confを作成し、以下の記載を行う。
  * `EnableAutoTransfer=1`
* Chronosを起動する
* 適当なファイルをダウンロードする
  * ダウンロード完了ダイアログが開いたタイミングでファイルの自動転送が行われること
    * ※転送処理そのものの正当性は確認済みなので、転送中ダイアログが出ればOKとする
* Chronosを終了する
* C:\Chronos\Chronos.confを作成し、以下の記載を行う。
  * `EnableAutoTransfer=0`
* Chronosを起動する
* 適当なファイルをダウンロードする
  * ダウンロード完了ダイアログが開いたタイミングや閉じたタイミングで自動転送が実行されないこと ...OK
    * ※転送中ダイアログが出なければOKとする
