### PR TITLE
Disable first party sets

### DIFF
--- a/client_app.cpp
+++ b/client_app.cpp
@@ -28,6 +28,14 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 	//command_line->AppendSwitchWithValue(_T("disable-features"), _T("NetworkService"));
 	//2019-07-24 動くようになった。
 	//Chromium Embedded Framework Version 75.1.4+g4210896+chromium-75.0.3770.100
+	
+	//CEF119: FirstPartySetsが有効だとYouTubeの検索窓にカーソルを合わせるとクラッシュする問題への対処。
+	//https://github.com/chromiumembedded/cef/issues/3643
+	//Chromeが3rd party cookiesをサポート外としたのは2024/1からだが、CEF119は2023/11のリリース。
+	//そのため、CEF119ではまだthird party cookiesをサポートしているので、first party setsを無効化して問題ない。
+	//https://cloud.google.com/looker/docs/best-practices/chrome-third-party-cookie-deprecation?hl=en
+	//TODO: CEF122以降でこの問題は解消しているため、CEF122以降になったらこの記載は削除する。
+	command_line->AppendSwitchWithValue(_T("disable-features"), _T("FirstPartySets"));
 
 	//2020-09-16
 	//https://bitbucket.org/chromiumembedded/cef/issues/2989/m85-print-preview-fails-to-load-pdf-file


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/248

# What this PR does / why we need it:

CEF119 has a bug that CEF crashes when a mouse cursor enters to a search box of YouTube when [first party sets](https://privacysandbox.com/open-web/#the-privacy-sandbox-timeline/) is enabled. 

https://github.com/chromiumembedded/cef/issues/3643

We disable first party sets as temporary measure.

The bug is fixed since CEF122, so we can enable first party sets if we adopt to use CEF122+.

By following https://privacysandbox.com/open-web/#the-privacy-sandbox-timeline/ and https://cloud.google.com/looker/docs/best-practices/chrome-third-party-cookie-deprecation?hl=en, third party cookies are unsupported since 1/2024 and CEF119 is released on 2023, so CEF119 supports third party cookies.
As a result, it seems that we can simply disable first party sets on CEF119.

# How to verify the fixed issue:

## The steps to verify:

### Confirm bug fixe

* Start Chronos
* Access to  [www.youtube.com](http://www.youtube.com/) 
* Move a mouse cursor to a search box above the page
  * Confirm that Chronos doesn't crash ...OK

### Regression test

* Open some pages
  * Confirm that the pages are displayed fine ...OK