### PR TITLE
Support chrome bootstrap alloy style

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -2109,6 +2109,9 @@ void CChildView::CreateNewBrowserWindow(LPCTSTR lpszUrl, BOOL bActive)
 					CRect rect;
 					pCreateView->GetClientRect(rect);
 					CefWindowInfo info;
+#if CHROME_VERSION_MAJOR >= 125
+					info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
+#endif
 					CefRect windowBounds;
 					windowBounds.Set(rect.right, rect.top, rect.Width(), rect.Height());
 					info.SetAsChild(hWnd, windowBounds);
@@ -2702,6 +2705,9 @@ void CChildView::Navigate(LPCTSTR pszURL)
 		GetClientRect(&rect);
 
 		CefWindowInfo info;
+#if CHROME_VERSION_MAJOR >= 125
+		info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
+#endif
 		CefRect windowBounds;
 		windowBounds.Set(rect.right, rect.top, rect.right - rect.left, rect.bottom - rect.top);
 		info.SetAsChild(GetSafeHwnd(), windowBounds);

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4112,6 +4112,9 @@ void CSazabi::InitializeCef()
 	m_bMultiThreadedMessageLoop = FALSE;
 	settings.multi_threaded_message_loop = m_bMultiThreadedMessageLoop;
 	settings.external_message_pump = true;
+#if CHROME_VERSION_MAJOR >= 125
+	settings.chrome_runtime = true;
+#endif
 
 	settings.no_sandbox = true;
 	if (!m_IsSGMode)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_119.4.3+gc76a3b9+chromium-119.0.6045.159_windows32_minimal
+  set CEFVER=cef_binary_126.2.0+g5c56e98+chromium-126.0.6478.62_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/193

# What this PR does / why we need it:

現在使用しているAlloy bootstrapはCEF127でサポート対象外となる予定。
Chrome bootstrapを使うようにする必要がある。
UIの互換性を保ちたければ、Chrome bootstrap + Alloy runtime styleにする必要がある。

このあたりは、CEF125からサポートが追加されている。

https://github.com/chromiumembedded/cef/issues/3685

CEF124以降で、Alloy bootstrapモードでの印刷のプレビューが動作しないといった問題が確認できている。
CEF127でAlloy bootstrapがサポート対象外となることから、Alloyモード特有の問題は修正されないことになっている。
これもAlloyモードでしか発生しない問題なので修正されない。

https://github.com/chromiumembedded/cef/issues/3686

本PRにより、上記の印刷のプレビューが動作しない問題も修正される。

# How to verify the fixed issue:

## The steps to verify:

https://github.com/HashidaTKS/Chronos/actions/runs/9542955348 のChronos-stable.zip（CEF126を使用したChronos）を使用する。

* 10サイトほど、任意の適当なWebページを表示する
  * [x] 問題なく表示されること
* Googleのページを印刷する
  * [x] 印刷プレビューが正しく表示されること
* 適当なページに遷移していき、各ページが正しく表示されること
* リンクを右クリックする
  * [x] コンテキストメニューが正しく表示されること（以前と変わりがないこと）
* 画像を右クリックする
  * [x] コンテキストメニューが正しく表示されること（以前と変わりがないこと）
* テキストを右クリックする
  * [x] コンテキストメニューが正しく表示されること（以前と変わりがないこと）
* 画面上の何もない部分を右クリックする
  * [x] コンテキストメニューが正しく表示されること（以前と変わりがないこと）
* Googleの検索フォームを右クリックする
  * [x] コンテキストメニューが正しく表示されること（以前と変わりがないこと）
* 任意のファイルをダウンロードする
  * [x] ダウンロードの動作が以前と変わりがないこと
*「インスタンスの二重起動を許可する」にチェックが入った状態にする
  * ChronosDefault.confまたはChronos.confで`EnableMultipleInstance=1`とする
* Chronosを二つ起動する
  * [x] 二つ目のChronosのタブで正しく画面が表示されること