### PR TITLE
Draft: Context menu: Remove needless separators

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -41,6 +41,9 @@
 #pragma warning(push, 0)
 #pragma warning(disable : 26812)
 
+// https://magpcss.org/ceforum/apidocs3/projects/(default)/CefMenuModel.html#GetCommandIdAt(int)
+#define CH_MENU_INVALID_OR_SEPARATOR (-1)
+
 ClientHandler::ClientHandler()
 {
 	m_bDownLoadStartFlg = FALSE;
@@ -383,6 +386,27 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 	contextMenuPrintLabel.LoadString(ID_CONTEXT_MENU_PRINT);
 	CefString cefContextMenuPrintLabel(contextMenuPrintLabel);
 	model->AddItem(MENU_ID_PRINT, cefContextMenuPrintLabel);
+
+	
+	// メニュー項目調整後、Separatorが連続することがあるので、連続している場合は削除する。
+	size_t count = model->GetCount();
+	int beforeCommandId = CH_MENU_INVALID_OR_SEPARATOR;
+	int commandId;
+	for (size_t i = count - 1; i > 0; i--)
+	{
+		commandId = model->GetCommandIdAt(i);
+		if (commandId == CH_MENU_INVALID_OR_SEPARATOR && beforeCommandId == CH_MENU_INVALID_OR_SEPARATOR)
+		{
+			model->RemoveAt(i);
+		}
+		beforeCommandId = commandId;
+	}
+	// 先頭がSeparatorだった場合、まだ残存している。
+	commandId = model->GetCommandIdAt(0);
+	if (commandId == CH_MENU_INVALID_OR_SEPARATOR)
+	{
+		model->RemoveAt(0);
+	}
 
 	// call parent
 	CefContextMenuHandler::OnBeforeContextMenu(browser, frame, params, model);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

There are needless separators in context menu in some cases.
The needless separators mean:

* A separator at the top or bottom of context menu.

![image](https://github.com/ThinBridge/Chronos/assets/15982708/4d1d5c28-e1d7-4cee-aac4-16ba57543a8c)

* Continuous separators (now don't exitst).

This patch remove them.

# How to verify the fixed issue:

## The steps to verify:

1. Start Chronos
2. Right click images, links, pages.
    * Confirm that there are no needless separators in context menu. 
    * Confirm that necessary separators don't removed.

![image](https://github.com/ThinBridge/Chronos/assets/15982708/1dd92c77-c50a-4749-9340-93d79253c7d6)

![image](https://github.com/ThinBridge/Chronos/assets/15982708/a395afc9-fee5-4d94-a2e0-15bdaf4b1bda)

![image](https://github.com/ThinBridge/Chronos/assets/15982708/f4fedb9d-e15a-458a-a9b9-e15685abd741)


