### PR TITLE
Make cache directory uniq

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1663,7 +1663,7 @@ int CSazabi::ExitInstance()
 								CloseVOSProcessOther();
 
 							this->UnInitializeCef();
-							this->DeleteCEFCache();
+							this->DeleteCEFCacheAll();
 						}
 					}
 					if (hMutex)
@@ -1675,7 +1675,7 @@ int CSazabi::ExitInstance()
 				else
 				{
 					this->UnInitializeCef();
-					this->DeleteCEFCache();
+					this->DeleteCEFCacheAll();
 				}
 				//ゾンビプロセス化を防ぐ。
 				ExitKillZombieProcess();
@@ -4143,6 +4143,7 @@ void CSazabi::InitializeCef()
 	//
 	if (this->IsSGMode())
 	{
+		m_strCEFCachePathBase.Format(_T("%s\\CEFCache"), (LPCTSTR)m_strExeFolderPath);
 		m_strCEFCachePath.Format(_T("%s\\CEFCache\\%d"), (LPCTSTR)m_strExeFolderPath, pidCurrent);
 	}
 	else
@@ -4154,12 +4155,13 @@ void CSazabi::InitializeCef()
 			strLocalAppPath = m_strExeFolderPath;
 		}
 		strLocalAppPath = strLocalAppPath.TrimRight('\\');
+		m_strCEFCachePathBase.Format(_T("%s\\ChronosCache"), (LPCTSTR)strLocalAppPath);
 		m_strCEFCachePath.Format(_T("%s\\ChronosCache\\%d"), (LPCTSTR)strLocalAppPath, pidCurrent);
 	}
 
 	if (IsFirstInstance())
 	{
-		DeleteCEFCache();
+		DeleteCEFCacheAll();
 	}
 	settings.persist_session_cookies = true;
 	CefString(&settings.root_cache_path) = m_strCEFCachePath;

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4138,8 +4138,8 @@ void CSazabi::InitializeCef()
 
 	// キャッシュフォルダのパスを取得する。
 	//
-	// * C:\Program Files\Chronos\CEFCache (SGモード)
-	// * C:\Users\<user>\AppData\Local\ChronosCache (通常モード)
+	// * C:\Users\<user>\AppData\Local\Thinstall\ChronosSG\%drive_C%\Chronos\CEFCache\{pid} (SGモード)
+	// * C:\Users\<user>\AppData\Local\ChronosCache\{pid} (通常モード)
 	//
 	if (this->IsSGMode())
 	{

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4159,10 +4159,7 @@ void CSazabi::InitializeCef()
 
 	if (IsFirstInstance())
 	{
-		if (this->m_AppSettings.IsEnableDeleteCache())
-		{
-			DeleteCEFCache();
-		}
+		DeleteCEFCache();
 	}
 	settings.persist_session_cookies = true;
 	CefString(&settings.root_cache_path) = m_strCEFCachePath;

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1674,11 +1674,8 @@ int CSazabi::ExitInstance()
 				}
 				else
 				{
-					if (this->m_AppSettings.IsEnableDeleteCache())
-					{
-						this->UnInitializeCef();
-						this->DeleteCEFCache();
-					}
+					this->UnInitializeCef();
+					this->DeleteCEFCache();
 				}
 				//ゾンビプロセス化を防ぐ。
 				ExitKillZombieProcess();

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4137,6 +4137,7 @@ void CSazabi::InitializeCef()
 	CefString strCefAcceptLanguageList;
 	strCefAcceptLanguageList = strLAcceptLanguageList;
 	CefString(&settings.accept_language_list) = strCefAcceptLanguageList;
+	DWORD pidCurrent = GetCurrentProcessId();
 
 	// キャッシュフォルダのパスを取得する。
 	//
@@ -4145,8 +4146,7 @@ void CSazabi::InitializeCef()
 	//
 	if (this->IsSGMode())
 	{
-		m_strCEFCachePath = m_strExeFolderPath;
-		m_strCEFCachePath += _T("CEFCache");
+		m_strCEFCachePath.Format(_T("%s\\CEFCache\\%d"), (LPCTSTR)m_strExeFolderPath, pidCurrent);
 	}
 	else
 	{
@@ -4154,11 +4154,10 @@ void CSazabi::InitializeCef()
 		strLocalAppPath = SBUtil::GetLocalAppDataPath();
 		if (strLocalAppPath.IsEmpty())
 		{
-			m_strCEFCachePath = m_strExeFolderPath;
+			strLocalAppPath = m_strExeFolderPath;
 		}
 		strLocalAppPath = strLocalAppPath.TrimRight('\\');
-		m_strCEFCachePath = strLocalAppPath;
-		m_strCEFCachePath += _T("\\ChronosCache");
+		m_strCEFCachePath.Format(_T("%s\\ChronosCache\\%d"), (LPCTSTR)strLocalAppPath, pidCurrent);
 	}
 
 	if (IsFirstInstance())

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -114,6 +114,7 @@ public:
 	CString m_strDBL_EXE_FolderPath;
 	CString m_strSettingFileFullPath;
 
+	CString m_strCEFCachePathBase;
 	CString m_strCEFCachePath;
 	CString m_strFaviconCachePath;
 
@@ -947,6 +948,14 @@ public:
 		{
 			DeleteDirectory(m_strCEFCachePath, _T("*.*"));
 			::RemoveDirectory(m_strCEFCachePath);
+		}
+	}
+	void DeleteCEFCacheAll()
+	{
+		// CEFCacheを削除する。
+		if (!m_strCEFCachePathBase.IsEmpty())
+		{
+			DeleteDirectory(m_strCEFCachePathBase, _T("*.*"));
 		}
 	}
 	//Windows10 1903環境で問題発生。対策コード2019-10-15

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -946,6 +946,7 @@ public:
 		if (!m_strCEFCachePath.IsEmpty())
 		{
 			DeleteDirectory(m_strCEFCachePath, _T("*.*"));
+			::RemoveDirectory(m_strCEFCachePath);
 		}
 	}
 	//Windows10 1903環境で問題発生。対策コード2019-10-15

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -147,6 +147,7 @@ void ClientApp::OnScheduleMessagePumpWork(int64_t delayMs)
 	messageLoopWorker->PostScheduleMessage(delayMs);
 }
 
+#if CHROME_VERSION_MAJOR >= 120
 // CEF120以降で、複数のCEFのインスタンスが重複した`CefSettings.root_cache_path`を設定していた場合に呼び出されるハンドラー。 
 // https://cef-builds.spotifycdn.com/docs/121.0/classCefBrowserProcessHandler.html#a052a91639483467c0b546d57a05c2f06
 // このハンドラーでfalseを返すか、未実装の場合、Chromeスタイルの新しいウィンドウが起動する。それを避けるため、ここでは
@@ -158,6 +159,7 @@ bool ClientApp::OnAlreadyRunningAppRelaunch(CefRefPtr<CefCommandLine> command_li
 {
 	return true;
 }
+#endif
 
 void DownloadFaviconCB::OnDownloadImageFinished(const CefString& image_url,
 						int http_status_code,

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -147,6 +147,18 @@ void ClientApp::OnScheduleMessagePumpWork(int64_t delayMs)
 	messageLoopWorker->PostScheduleMessage(delayMs);
 }
 
+// CEF120以降で、複数のCEFのインスタンスが重複した`CefSettings.root_cache_path`を設定していた場合に呼び出されるハンドラー。 
+// https://cef-builds.spotifycdn.com/docs/121.0/classCefBrowserProcessHandler.html#a052a91639483467c0b546d57a05c2f06
+// このハンドラーでfalseを返すか、未実装の場合、Chromeスタイルの新しいウィンドウが起動する。それを避けるため、ここでは
+// trueを返している。
+// 
+// インスタンスごとに固有の`CefSettings.root_cache_path value`を使用するようになっているため、このハンドラーが呼ばれる
+// ことはないので、念のための処理である。
+bool ClientApp::OnAlreadyRunningAppRelaunch(CefRefPtr<CefCommandLine> command_line, const CefString& current_directory)
+{
+	return true;
+}
+
 void DownloadFaviconCB::OnDownloadImageFinished(const CefString& image_url,
 						int http_status_code,
 						CefRefPtr<CefImage> image)

--- a/client_app.h
+++ b/client_app.h
@@ -22,7 +22,9 @@ public:
 	virtual void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line);
 	virtual void OnContextInitialized() override;
 	virtual void OnScheduleMessagePumpWork(int64_t delayMs) override;
+#if CHROME_VERSION_MAJOR >= 120
 	virtual bool OnAlreadyRunningAppRelaunch(CefRefPtr<CefCommandLine> command_line, const CefString& current_directory) override;
+#endif
 
 private:
 	IMPLEMENT_REFCOUNTING(ClientApp);

--- a/client_app.h
+++ b/client_app.h
@@ -22,6 +22,7 @@ public:
 	virtual void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line);
 	virtual void OnContextInitialized() override;
 	virtual void OnScheduleMessagePumpWork(int64_t delayMs) override;
+	virtual bool OnAlreadyRunningAppRelaunch(CefRefPtr<CefCommandLine> command_line, const CefString& current_directory) override;
 
 private:
 	IMPLEMENT_REFCOUNTING(ClientApp);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/197

# What this PR does / why we need it:

https://magpcss.org/ceforum/viewtopic.php?f=6&t=19677&p=54689&hilit=OnAlreadyRunningAppRelaunch#p54689

CEF120以降では、複数のCEFのインスタンスが起動する際、`CefSettings.root_cache_path`が重複していると動作しないため、インタンス単位で`CefSettings.root_cache_path`が重複しないように変更。
本修正ではプロセスIDを使用しキャッシュパスが以下のようになるよう変更している。

* `C:\Users\<user>\AppData\Local\Thinstall\ChronosSG\%drive_C%\Chronos\CEFCache\{pid}` (SGモード)
* `C:\Users\<user>\AppData\Local\ChronosCache\{pid}` (通常モード)

また、プロセスIDを使うようになった都合上、キャッシュフォルダを次回以降の起動で再利用できないので、`IsEnableDeleteCache`（ブラウザーキャッシュ（インターネット一時ファイル）を起動/終了時に削除する）の設定に関わらずキャッシュフォルダを毎回削除するように修正。
なお、従来からSGモードでは`IsEnableDeleteCache`の設定に関わらずキャッシュフォルダは削除されていたので、ユーザーへの実影響はないはずである。

また、`CefSettings.root_cache_path`が重複した場合のハンドラーである`OnAlreadyRunningAppRelaunch`も実装。
`CefSettings.root_cache_path`が重複した場合、デフォルトではChromeスタイルの新しいウィンドウが起動するが、そうではなく、Chronos独自の処理をそのまま続けるようこのハンドラーで設定した。

https://cef-builds.spotifycdn.com/docs/121.0/classCefBrowserProcessHandler.html#a052a91639483467c0b546d57a05c2f06

ただし、修正後は`CefSettings.root_cache_path`は重複しないため、`OnAlreadyRunningAppRelaunch`も呼ばれないはずである（呼ばれたとしたらバグ）。そのため、これは念のための対処である。

# How to verify the fixed issue:

以下ChronosのネイティブアプリとSGモードの両方でテストする。

準備: 

* CEF125+を使用してChronosをビルドするか、 https://github.com/HashidaTKS/Chronos/actions/runs/9476585990 のChronos-stableのChronosを使用する。

テスト:

* 「インスタンスの二重起動を許可する」にチェックが入った状態にする
    * ChronosDefault.confまたはChronos.confで`EnableMultipleInstance=1`とする
* Chronosを二つ起動する
    * [x] 二つ目のChronosのタブで正しく画面が表示されること
* キャッシュフォルダを開く
  * `C:\Users\<user>\AppData\Local\Thinstall\ChronosSG\%drive_C%\Chronos\CEFCache\{pid}` (SGモード)
  * `C:\Users\<user>\AppData\Local\ChronosCache\{pid}` (通常モード)
  * pid部分に対応するChronosのプロセスが存在すること
      * タスクマネージャーなどからChronosのプロセスIDを確認する
  * [x] フォルダが存在し、内部にキャッシュファイルが存在すること
      * 何らかのファイルがあればOK
* [ヘルプ]->[ブラウザーキャッシュを削除する]をクリック
* [ブラウザーキャッシュを削除しますか？]ダイアログで[はい(Y)]を選択
    * [x] キャッシュフォルダが削除され、改めて別のpidで再作成されること
      * ※Debugログの出力が有効な状態だとキャッシュフォルダが残り、その中に`CEFDebug.log`のみが存在する。
            これは、キャッシュフォルダに`CEFDebug.log`が作成され、キャッシュフォルダを削除しようとするタイミングでまだこのファイルをCEFが開いており、このファイルが削除できないためである。
* すべてのChronosを終了する
    * [x] すべてのキャッシュフォルダが削除されること
      * ※Debugログの出力が有効な状態だとキャッシュフォルダが残り、その中に`CEFDebug.log`のみが存在する。
            これは、キャッシュフォルダに`CEFDebug.log`が作成され、キャッシュフォルダを削除しようとするタイミングでまだこのファイルをCEFが開いており、このファイルが削除できないためである。
* キャッシュフォルダ配下に手動で以下のような適当なフォルダを作成する
  * `C:\Users\<user>\AppData\Local\Thinstall\ChronosSG\%drive_C%\Chronos\CEFCache\test` (SGモード)
  * `C:\Users\<user>\AppData\Local\ChronosCache\test` (通常モード)
* Chronosを起動する
  * [x] 手動で作成したキャッシュフォルダ配下の適当なフォルダがすべて削除されること...OK