### PR TITLE
Remove EnableDeleteCache

### DIFF
--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -1531,16 +1531,6 @@ BOOL CDlgSetCAP::OnInitDialog()
 		((CButton*)GetDlgItem(IDC_EnableUploadRestriction))->SetCheck(0);
 	}
 
-	//EnableEnableDeleteCache
-	if (theApp.m_AppSettingsDlgCurrent.IsEnableDeleteCache())
-	{
-		((CButton*)GetDlgItem(IDC_EnableDeleteCache))->SetCheck(1);
-	}
-	else
-	{
-		((CButton*)GetDlgItem(IDC_EnableDeleteCache))->SetCheck(0);
-	}
-
 	//running
 	if (theApp.m_AppSettingsDlgCurrent.IsEnableRunningTime())
 	{
@@ -1591,12 +1581,6 @@ LRESULT CDlgSetCAP::Set_OK(WPARAM wParam, LPARAM lParam)
 		theApp.m_AppSettingsDlgCurrent.SetEnableUploadRestriction(1);
 	else
 		theApp.m_AppSettingsDlgCurrent.SetEnableUploadRestriction(0);
-
-	//EnableDeleteCache
-	if (((CButton*)GetDlgItem(IDC_EnableDeleteCache))->GetCheck() == 1)
-		theApp.m_AppSettingsDlgCurrent.SetEnableDeleteCache(1);
-	else
-		theApp.m_AppSettingsDlgCurrent.SetEnableDeleteCache(0);
 
 	//running
 	if (((CButton*)GetDlgItem(IDC_Enable_ProcessRunTime))->GetCheck() == 1)

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -492,8 +492,6 @@ FONT 9, "MS UI Gothic", 0, 0, 0x1
 BEGIN
     CONTROL         "ファイルのダウンロードを禁止する",IDC_EnableDownloadRestriction,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,12,177,10
     CONTROL         "ファイルのアップロードを禁止する",IDC_EnableUploadRestriction,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,28,177,10
-    CONTROL         "ブラウザーキャッシュ(インターネット一時ファイル)を起動/終了時に削除する",IDC_EnableDeleteCache,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,44,277,10
     GROUPBOX        "リソース制限",IDC_STATIC,5,60,355,111
     CONTROL         "起動時間を制限する",IDC_Enable_ProcessRunTime,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,76,90,10
     EDITTEXT        IDC_EDIT_LIMIT_TIME,18,91,52,14,ES_AUTOHSCROLL | ES_NUMBER
@@ -1854,8 +1852,6 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,12,177,10
     CONTROL         "Forbid to upload files",IDC_EnableUploadRestriction,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,28,177,10
-    CONTROL         "Clear browser caches (internet temporary files) on every startup and shutdown",IDC_EnableDeleteCache,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,44,277,10
     GROUPBOX        "Resource restrictions",IDC_STATIC,5,60,355,111
     CONTROL         "Restrict running time",IDC_Enable_ProcessRunTime,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,76,90,10
     EDITTEXT        IDC_EDIT_LIMIT_TIME,18,91,52,14,ES_AUTOHSCROLL | ES_NUMBER

--- a/resource.h
+++ b/resource.h
@@ -403,7 +403,6 @@
 #define IDC_EnableUploadRestriction     1341
 #define IDC_Enable_ProcessRunTime       1342
 #define IDC_EnableDownloadRestriction   1343
-#define IDC_EnableDeleteCache           1344
 #define IDC_EDIT_LIMIT_TIME             1345
 #define IDC_VOS_CLOSE_PROCESS           1346
 #define IDC_SHOW_DEV_TOOLS              1347

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -954,7 +954,6 @@ public:
 
 		EnableDownloadRestriction = 0;
 		EnableUploadRestriction = 0;
-		EnableDeleteCache = 0;
 		EnableRunningTime = 0;
 		RunningLimitTime = 0;
 		EnableURLRedirect = 0;
@@ -1039,7 +1038,6 @@ public:
 
 		Data.EnableDownloadRestriction = EnableDownloadRestriction;
 		Data.EnableUploadRestriction = EnableUploadRestriction;
-		Data.EnableDeleteCache = EnableDeleteCache;
 		Data.EnableRunningTime = EnableRunningTime;
 		Data.RunningLimitTime = RunningLimitTime;
 		Data.EnableURLRedirect = EnableURLRedirect;
@@ -1118,7 +1116,6 @@ private:
 	//制限設定
 	int EnableDownloadRestriction;
 	int EnableUploadRestriction;
-	int EnableDeleteCache;
 	int EnableRunningTime;
 	int RunningLimitTime;
 	int MemoryUsageLimit;
@@ -1226,7 +1223,6 @@ public:
 		//制限設定
 		EnableDownloadRestriction = FALSE;
 		EnableUploadRestriction = FALSE;
-		EnableDeleteCache = FALSE;
 
 		EnableRunningTime = FALSE;
 		RunningLimitTime = 1440;
@@ -1673,12 +1669,6 @@ public:
 					continue;
 				}
 
-				if (strTemp2.CompareNoCase(_T("EnableDeleteCache")) == 0)
-				{
-					EnableDeleteCache = (strTemp3 == _T("1")) ? TRUE : FALSE;
-					continue;
-				}
-
 				if (strTemp2.CompareNoCase(_T("EnableRunningTime")) == 0)
 				{
 					EnableRunningTime = (strTemp3 == _T("1")) ? TRUE : FALSE;
@@ -1975,7 +1965,6 @@ public:
 		strRet += _T("# Restriction\n");
 		strRet += EXTVAL(EnableDownloadRestriction);
 		strRet += EXTVAL(EnableUploadRestriction);
-		strRet += EXTVAL(EnableDeleteCache);
 		strRet += EXTVAL(EnableRunningTime);
 		strRet += EXTVAL(RunningLimitTime);
 		strRet += EXTVAL(MemoryUsageLimit);
@@ -2092,7 +2081,6 @@ public:
 
 	inline BOOL IsEnableDownloadRestriction() { return EnableDownloadRestriction; }
 	inline BOOL IsEnableUploadRestriction() { return EnableUploadRestriction; }
-	inline BOOL IsEnableDeleteCache() { return EnableDeleteCache; }
 	inline BOOL IsEnableRunningTime() { return EnableRunningTime; }
 	inline int GetRunningLimitTime() { return RunningLimitTime; }
 
@@ -2184,7 +2172,6 @@ public:
 
 	inline void SetEnableDownloadRestriction(DWORD dVal) { EnableDownloadRestriction = dVal ? 1 : 0; }
 	inline void SetEnableUploadRestriction(DWORD dVal) { EnableUploadRestriction = dVal ? 1 : 0; }
-	inline void SetEnableDeleteCache(DWORD dVal) { EnableDeleteCache = dVal ? 1 : 0; }
 	inline void SetEnableRunningTime(DWORD dVal) { EnableRunningTime = dVal ? 1 : 0; }
 	inline void SetRunningLimitTime(DWORD dVal) { RunningLimitTime = dVal; }
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

Related: #199

# What this PR does / why we need it:

In SG mode (ThinApp mode), a data folder is always removed on shutting down, so `EnableDeleteCache = false` doesn't work as expected, which is a specification (limitation) of ThinApp.
Also, since CEF120, we should specify unique cache folder for each instances, that make re-using cache folder difficult.

Because of the reason above,  we should remove `EnableDeleteCache`.

# How to verify the fixed issue:

## The steps to verify:

* Open "機能制限設定" of setting dialog
  * [x] Confirm that an option "ブラウザーキャッシュ(インターネット一時ファイル)を起動/終了時に削除する" is not exist.
  * ![image](https://github.com/ThinBridge/Chronos/assets/15982708/45a4b2e3-5854-488b-a4ec-2e8f31f40479)
* Close Chronos
  * [x] Confirm that a cache folder is remove.
  * a ceche folder is `%LOCALAPPDATA%\ChronosCache\UserData` for native Chronos