### PR TITLE
[Trace Log Monitor Window] use appropriate buffer size

### DIFF
--- a/DlgDebugWnd.cpp
+++ b/DlgDebugWnd.cpp
@@ -493,7 +493,7 @@ void CDlgDebugWnd::OnGetdispinfoList1(NMHDR* pNMHDR, LRESULT* pResult)
 			case LIST_INDEX:
 			{
 				this->DWToString(pData->iIndex, m_strTemp);
-				StringCchCopy(item->pszText, m_strTemp.GetLength() + 1, m_strTemp);
+				StringCchCopy(item->pszText, item->cchTextMax, m_strTemp);
 				break;
 			}
 			case LIST_DATE_TIME:


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

`item->cchTextMax` is an actual length of `item->pszText`.
So we should use it.

# How to verify the fixed issue:

* Open "Trace Log Monitor Window" from setting dialog
* Open some web pages in order to output logs to "Trace Log Monitor Window"
  * [x] Confirm that index numbers in list view of "Trace Log Monitor Window" are displayed correctly.

![image](https://github.com/ThinBridge/Chronos/assets/15982708/6fee0faa-1015-48ef-abb7-17939b7db63f)
