### PR TITLE
Enable FirstPartySets for CEF122+

### DIFF
--- a/client_app.cpp
+++ b/client_app.cpp
@@ -29,13 +29,15 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 	//2019-07-24 動くようになった。
 	//Chromium Embedded Framework Version 75.1.4+g4210896+chromium-75.0.3770.100
 	
+#if CHROME_VERSION_MAJOR < 122
 	//CEF119: FirstPartySetsが有効だとYouTubeの検索窓にカーソルを合わせるとクラッシュする問題への対処。
 	//https://github.com/chromiumembedded/cef/issues/3643
 	//Chromeが3rd party cookiesをサポート外としたのは2024/1からだが、CEF119は2023/11のリリース。
 	//そのため、CEF119ではまだthird party cookiesをサポートしているので、first party setsを無効化して問題ない。
 	//https://cloud.google.com/looker/docs/best-practices/chrome-third-party-cookie-deprecation?hl=en
-	//TODO: CEF122以降でこの問題は解消しているため、CEF122以降になったらこの記載は削除する。
+	//TODO: CEF122以降でこの問題は解消している
 	command_line->AppendSwitchWithValue(_T("disable-features"), _T("FirstPartySets"));
+#endif
 
 	//2020-09-16
 	//https://bitbucket.org/chromiumembedded/cef/issues/2989/m85-print-preview-fails-to-load-pdf-file

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -35,7 +35,7 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 	//Chromeが3rd party cookiesをサポート外としたのは2024/1からだが、CEF119は2023/11のリリース。
 	//そのため、CEF119ではまだthird party cookiesをサポートしているので、first party setsを無効化して問題ない。
 	//https://cloud.google.com/looker/docs/best-practices/chrome-third-party-cookie-deprecation?hl=en
-	//TODO: CEF122以降でこの問題は解消している
+	//CEF122以降でこの問題は解消している
 	command_line->AppendSwitchWithValue(_T("disable-features"), _T("FirstPartySets"));
 #endif
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/248

Related: #195

# What this PR does / why we need it:

A bug that Chronos crashes when moving a mouse cursor into a search box on YouTube if we enable FirstPartySets is fixed since CEF122.
We can enable FirstPartySets since CEF122.  

# How to verify the fixed issue:

## The steps to verify::

* Download [Chronos.zip](https://github.com/ThinBridge/Chronos/actions/runs/9541961042) (Chronos with CEF119)
* Start Chronos.exe in Chronos.zip
* Access to [www.youtube.com](http://www.youtube.com/)
* Move a mouse cursor to a search box above the page
  * [x] Confirm that Chronos doesn't crash ...OK
* Download [Chronos-stable.zip](https://github.com/ThinBridge/Chronos/actions/runs/9541961042) (Chronos with CEF126)
* Start Chronos.exe in Chronos-stable.zip
* Access to [www.youtube.com](http://www.youtube.com/)
* Move a mouse cursor to a search box above the page
  * [x] Confirm that Chronos doesn't crash ...OK