### PR TITLE
Message loop: try to execute remaining works only on not being active

### DIFF
--- a/MessageLoopWorker.h
+++ b/MessageLoopWorker.h
@@ -28,6 +28,7 @@ private:
 	void KillTimer();
 	void OnScheduleWork(int64_t delayMs);
 	void OnTimerTimeout();
+	bool PerformMessageLoopWork();
 	void DoWork();
 	void InitWindow();
 	static LRESULT CALLBACK WindowProcesser(HWND hwnd,


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/204

# What this PR does / why we need it:

Try to execute remaining works only on not being active.

MessageLoopWorker posts a WM_SCHEDULE_CEF_WORK message to execute remaining works if re-entrancy is detected. If WM_SCHEDULE_CEF_WORK messages on re-entrancy are posted while message loop is active, a lot of WM_SCHEDULE_CEF_WORK messages are posted while active. As a result, executing message loop is prevented by those messages. These behavior causes a bug that Chronos hungs after displaying system dialog for printing.

This patch resolve that bug.

# How to verify the fixed issue:

## The steps to verify:

* Display [印刷]->[詳細設定]->[システムダイアログを使用して印刷]
* Select a printer
* Click [印刷]
  * [x] Confirm that printer works immediately and Chronos doesn't freeze.

## Regression tests

* From https://github.com/ThinBridge/Chronos-SG/blob/main/Documents/%E3%83%86%E3%82%B9%E3%83%88%E9%A0%85%E7%9B%AE%E4%B8%80%E8%A6%A7/Sources/1-2_%E7%AE%A1%E7%90%86%E8%80%85%E3%82%AC%E3%82%A4%E3%83%89.md#%E6%93%8D%E4%BD%9C%E9%83%A8
  * Select [ファイル]->[印刷]
  * Wait for preview
    * [x] Confirm that print preview is displayed within 10 seconds 
      * #155
* Show various sites, at least 10 sites.
  * [x] Confirm that all pages are displayed correctly. 


