### PR TITLE
Use an original filename for audit log on uploading

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -338,6 +338,7 @@ public:
 			}
 
 			CString strSelPath(wstrSelPath);
+			CString strSelPathOriginal(wstrSelPath);
 			CoTaskMemFree(wstrSelPath);
 			strSelPath.MakeUpper();
 			if (strSelPath.IsEmpty())
@@ -362,8 +363,8 @@ public:
 			if (theApp.m_AppSettings.IsEnableLogging() && theApp.m_AppSettings.IsEnableUploadLogging())
 			{
 				WCHAR* ptrFile = NULL;
-				ptrFile = PathFindFileNameW(strSelPath);
-				CString strFileName(ptrFile ? ptrFile : strSelPath);
+				ptrFile = PathFindFileNameW(strSelPathOriginal);
+				CString strFileName(ptrFile ? ptrFile : strSelPathOriginal);
 				theApp.SendLoggingMsg(LOG_UPLOAD, strFileName, hwndOwner);
 			}
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/216

# What this PR does / why we need it:

When uploading file with file open dialog, we output an uppercase filename since Chronos v13.0.112.0. 

https://github.com/ThinBridge/Chronos/pull/36
commit hash: https://github.com/ThinBridge/Chronos/commit/7c3c5a377af79d7fc74491ec19fa187f1201c930

However, for audit log, we should output an original filename.

# How to verify the fixed issue:

## The steps to verify:

Chronos-SGリポジトリが参照できることを前提とする。

1. Powershellのコンソールを起動し、`Chronos-SG/Documents/Tools/httpserver.ps1`を実行し簡易HTTPサーバーを起動する。(Set-ExecutionPolicy -ExecutionPolicy RemoteSignedを管理者権限のPowershellで有効化済み)
2. `Chronos-SG/Tools/uploadserver.ps1`を開き、スクリプトで使用されているURLのポート番号を8000から8001に変更する。
3. 1とは別のコンソールで `Chronos-SG/Tools/uploadserver.ps1`を実行し簡易ファイルアップロードサイトを起動する。
4. Chronosを起動する
5. [設定] -> [ログ出力設定]を開く
6. [監査ログ出力を有効にする]にチェックを入れる
7. [ログサーバーURL]に`http://127.0.0.1:8000`を指定する
8. [アップロード操作を記録する]にチェックを入れる
9. OKを押して設定ダイアログを閉じる
10. Chronosのアドレスバーに`http://127.0.0.1:8001`を指定する
11. ファイルアップロードのサイトが開かれるので、[ファイルを選択]ボタンを押す
12. 適当なファイルを選択してアップロードする
13. 1のコンソールを確認する
    * [x] `GET: /?operation=upload&pcname=TH-NOTE-PC&userid=TH-NOTE-PC%5Chashi&name=Google.pdf&url=http%3A%2F%2F127.0.0.1%3A8001%2F&time=2024-07-05%2018%3A59%3A34`のように、ファイル名である`name`の値が大文字になっておらず、オリジナルのファイル名と同じであること。
