### PR TITLE
[CEF125+] Fix DevTools to popup

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1561,9 +1561,17 @@ void CChildView::ShowDevTools()
 			CefBrowserSettings settings;
 			CefRefPtr<CefClient> client;
 			CefPoint inspect_element_at;
+			// We use Chrome bootstrap + Alloy runtime style since CEF125.
+			// On that case, we should specify DevTools behaviour at 
+			// ClientHandler::OnBeforeDevToolsPopup
+			// https://github.com/chromiumembedded/cef/issues/3685
+			// https://cef-builds.spotifycdn.com/docs/120.1/classCefLifeSpanHandler.html#a42d853d18238d79d2b17d04277bd636a
+			// https://magpcss.org/ceforum/viewtopic.php?f=6&t=19792&p=55334&hilit=Devtools+SetAsPopup#p55334
+#if CHROME_VERSION_MAJOR < 125
 			// Show DevTools window as popup
 			// See https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=17820
 			windowInfo.SetAsPopup(theApp.SafeWnd(this->m_hWnd), "ChronosDevTools");
+#endif
 			m_cefBrowser->GetHost()->ShowDevTools(windowInfo, client, settings, inspect_element_at);
 		}
 	}

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -2115,8 +2115,6 @@ bool ClientHandler::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
 	return TRUE;
 }
 
-
-
 bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				CefRefPtr<CefDragData> dragData,
 				DragOperationsMask mask)

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -254,6 +254,17 @@ bool ClientHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser,
 	return CefLifeSpanHandler::OnBeforePopup(browser, frame, target_url, target_frame_name, target_disposition, user_gesture, popupFeatures, windowInfo, client, settings, extra_info, no_javascript_access);
 }
 
+#if CHROME_VERSION_MAJOR > 125
+void ClientHandler::OnBeforeDevToolsPopup(CefRefPtr<CefBrowser> browser,
+					  CefWindowInfo& windowInfo,
+					  CefRefPtr<CefClient>& client,
+					  CefBrowserSettings& settings,
+					  CefRefPtr<CefDictionaryValue>& extra_info,
+					  bool* use_default_window)
+{
+}
+#endif
+
 void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 					CefRefPtr<CefFrame> frame,
 					CefRefPtr<CefContextMenuParams> params,
@@ -2103,6 +2114,8 @@ bool ClientHandler::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
 	callback->Continue(iRet == IDYES ? true : false, str);
 	return TRUE;
 }
+
+
 
 bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 				CefRefPtr<CefDragData> dragData,

--- a/client_handler.h
+++ b/client_handler.h
@@ -84,6 +84,9 @@ public:
 	virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
 	virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
 	virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& target_url, const CefString& target_frame_name, WindowOpenDisposition target_disposition, bool user_gesture, const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, CefRefPtr<CefDictionaryValue>& extra_info, bool* no_javascript_access) override;
+#if CHROME_VERSION_MAJOR > 125
+	virtual void OnBeforeDevToolsPopup(CefRefPtr<CefBrowser> browser, CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, CefRefPtr<CefDictionaryValue>& extra_info, bool* use_default_window);
+#endif
 
 	// CefContextMenuHandler methods
 	virtual void OnBeforeContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefContextMenuParams> params, CefRefPtr<CefMenuModel> model) override;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#203

# What this PR does / why we need it:

DevTools doesn't popup and is fixed on a current tab window when we use Chrome bootstrap and Alloy runtime style.

FYI: 
https://github.com/chromiumembedded/cef/issues/3685
https://cef-builds.spotifycdn.com/docs/120.1/classCefLifeSpanHandler.html#a42d853d18238d79d2b17d04277bd636a
https://magpcss.org/ceforum/viewtopic.php?f=6&t=19792&p=55334&hilit=Devtools+SetAsPopup#p55334

**Known Issues**

These are known issues.
They will be fixed after this PR.

* DevTools icon is Chromium icon
  * https://github.com/ThinBridge/Chronos/issues/224
* [DevTools][Network]: Open in new tab opens two window
  * https://github.com/ThinBridge/Chronos/issues/223
* [DevTools][Network]: Chronos crashes when trying to save network log (`.har` file)
  * This is an issue of CEF126, is fixed on CEF127.

# How to verify the fixed issue:

* Open DevTools by Help->About->Show Developer Tools.
  * Confirm that DevTools popups.

![image](https://github.com/ThinBridge/Chronos/assets/15982708/0a6ab5ac-dc74-42a7-803a-f4c5fe67fd6e)

