### PR TITLE
Call vcvars64.bat in setup-cef.bat

### DIFF
--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -19,6 +19,14 @@ IF NOT DEFINED CEFVER (
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 
+setlocal
+
+if exist "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat" (
+  call "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
+) else if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
+  call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+)
+
 @REM -----------------
 @REM Cleanup directory
 @REM -----------------
@@ -62,3 +70,5 @@ cmake -E copy_directory "cef-cache\%CEFVER%\Release" D32
 cmake -E copy_directory "cef-cache\%CEFVER%\Release" R32
 cmake -E copy_directory "cef-cache\%CEFVER%\Resources" D32
 cmake -E copy_directory "cef-cache\%CEFVER%\Resources" R32
+
+endlocal


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

Currently, we should call setup-cef.bat from Visual Studio 2022 Developer Command Prompt.
By calling vcvars64.bat (build tools) in setup-cef.bat, we can avoid to use Visual Studio 2022 Developer Command Prompt and execute setup-cef.bat by file explorer.

# How to verify the fixed issue:

* Double click setup-cef.bat.
  * [x] Confirm that CEF is built.