### PR TITLE
Update CEF version to 127.1.4

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=126.2.0+g5c56e98+chromium-126.0.6478.62
+VERSION=127.1.4+ge71a509+chromium-127.0.6533.89
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_126.2.0+g5c56e98+chromium-126.0.6478.62_windows32_minimal
+  set CEFVER=cef_binary_127.1.4+ge71a509+chromium-127.0.6533.89_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/279#issuecomment-2264932904
https://github.com/ThinBridge/Chronos/issues/222

# What this PR does / why we need it:

Chrome bootstrap + Alloy runtime style seems to be somewhat unstable in CEF126.
So update CEF version to 127.1.4 for now.

# How to verify the fixed issue:

## The steps to verify:

1. Actions artifact "Chronos" is 127.1.4.
2. Actions artifact "Chronos-stable"  is 127.1.4.
3. Actions artifact "Chronos-beta"  is still 128.0.1
