### PR TITLE
file download dialog: use IFileSaveDialog (ChronosFileSaveDialog) on SG mode

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1449,17 +1449,7 @@ void CChildView::OnPrintPDF()
 		CStringW strRootDrive(theApp.m_AppSettings.GetRootPath());
 		CStringW strMsg;
 
-		CFileDialog* pFileDlg = NULL;
-		if (theApp.IsSGMode())
-		{
-			//SGModeの場合は、Classicダイアログを使用
-			pFileDlg = new CFileDialog(FALSE, _T("pdf"), strFileName, OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_NONETWORKBUTTON | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST, szFilter, this, 0, FALSE);
-		}
-		else
-		{
-			pFileDlg = new CFileDialog(FALSE, _T("pdf"), strFileName, OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_NONETWORKBUTTON | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST, szFilter, this);
-		}
-
+		CFileDialog* pFileDlg = pFileDlg = new CFileDialog(FALSE, _T("pdf"), strFileName, OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_NONETWORKBUTTON | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST, szFilter, this);
 		pFileDlg->m_ofn.lpstrTitle = strTitle.GetString();
 		pFileDlg->m_ofn.lpstrInitialDir = strPath;
 

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -841,18 +841,7 @@ void ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 		CStringW strMsg;
 		INT_PTR bRet = FALSE;
 
-		CFileDialog* pFileDlg = NULL;
-		if (theApp.IsSGMode())
-		{
-			//SGModeの場合は、Classicダイアログを使用
-			pFileDlg = new CFileDialog(FALSE,
-						   NULL, strFileName, OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_NONETWORKBUTTON | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST, szFilter, pCWnd, 0, FALSE);
-		}
-		else
-		{
-			pFileDlg = new CFileDialog(FALSE,
-						   NULL, strFileName, OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_NONETWORKBUTTON | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST, szFilter, pCWnd);
-		}
+		CFileDialog* pFileDlg = new CFileDialog(FALSE, NULL, strFileName, OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_NONETWORKBUTTON | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST, szFilter, pCWnd);
 		pFileDlg->m_ofn.lpstrTitle = strTitle.GetString();
 		pFileDlg->m_ofn.lpstrInitialDir = strPath;
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/294

# What this PR does / why we need it:

Use IFileSaveDialog (ChronosFileSaveDialog) on SG mode

We can hide the recent folder by use IFileSaveDialog (ChronosFileSaveDialog, a common item dialog) instead of GetSaveFileNameW (Hook_GetSaveFileNameW, a common file dialog).


**old dialog (common file dialog)**
![old_dialog](https://github.com/user-attachments/assets/5fbd5875-d66e-4a27-b479-616c74a93c62)

**new dialog (common item dialog)**
![new_dialog](https://github.com/user-attachments/assets/e83ae4e5-f2a5-4a38-b7cf-969071b40dc9)


# How to verify the fixed issue:

## 準備

* ChronosSGプロジェクトの以下の手順に従い、このPRのcurrentのArtifactのChronos.zipからインストーラーを作成する
  * https://github.com/ThinBridge/Chronos-SG/tree/v14.0.119.0-maintenance/Setup/ChronosSetup#%E8%87%AA%E5%8B%95%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E4%BD%9C%E6%88%90%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88
  * Artifact: https://github.com/ThinBridge/Chronos/actions/runs/11791606501/artifacts/2174614137
* 作成したインストーラーをインストールする
* https://github.com/ThinBridge/Chronos-SG/tree/v14.0.119.0-maintenance のChronosSG_Projectを使用してChronos.exe/altを作成する
* 作成したChronos.exe/altをC:\Chronosにコピーする

## テスト

* Chronos.exeを起動する
* 設定を初期状態とする
* 任意の画像ファイルをダウンロードする
* [x] 新しいファイルダウンロードダイアログが開くこと
* [x] ダイアログのタイトルが「ダウンロードファイルを保存」であること
* [x] 中央のフォルダー表示には`B:\`のみが表示されていること（Recentが表示されてないこと）
* [x] 左ペインに何も表示されないこと
* [x] 上部のセレクトボックスにB:\しか表示されないこと
* B:\ドライブ直下で適当な名前でファイルを保存する
* [x] ファイルが保存できること
* ファイルマネージャーを開く
* [x] 保存したファイルが存在すること
* 再度適当なファイルをダウンロードする
* ファイルダウンロードダイアログの表示を待つ
* 上部のセレクトボックスに「C:\」を指定する
* [x] 「リソースC:¥にはアクセスできません」という警告ダイアログが表示され、`C:\`を表示できないこと
* ダウンロードダイアログで、手動で`C:\temp\dummy.txt`という名前を入力し、保存しようとする
* [x] 「B:\ドライブ以外は指定できません」という警告メッセージが表示され、保存できないこと
* [x] 警告メッセージ表示後、再度ファイルダウンロードダイアログが表示されること
* B::\Uploadフォルダー（アップロードフォルダーと同じフォルダ）に保存しようとする
* [x] 「アップロードフォルダー（B:\Upload）には保存できません」という警告メッセージが表示され、保存できないこと
* ファイルダウンロードダイアログを閉じる
* ページを右クリックし、「印刷(PDF出力)」を選択する
* [x] 新しいファイルダウンロードダイアログが開くこと
* [x] ダイアログのタイトルが「名前を付けてPDF ドキュメントを保存」であること
* Chronosを再起動する
* 設定->機能制限設定->ファイルのダウンロードを禁止する を有効にする
* 任意の画像ファイルをダウンロードする
* [x] 「ファイルダウンロードはシステム管理者により制限されています」という警告ダイアログとともに、ダウンロードが禁止されること
* ページを右クリックし、「印刷(PDF出力)」を選択する
* [x] 「ファイルダウンロードはシステム管理者により制限されています」という警告ダイアログとともに、ダウンロードが禁止されること
