### PR TITLE
v14.0.119.0, file dialog: use original file name on warning dialog

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -354,7 +354,7 @@ public:
 				{
 					CString strCaption(theApp.m_strThisAppName);
 					CString strMsg;
-					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)m_strRootPath, (LPCWSTR)strSelPathOriginal);
 					::MessageBoxW(hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}
@@ -660,25 +660,28 @@ public:
 			}
 
 			CString strSelPath(wstrSelPath);
+			CString strSelPathUpper(wstrSelPath);
 			CoTaskMemFree(wstrSelPath);
-			strSelPath.MakeUpper();
-			if (strSelPath.IsEmpty())
+			strSelPathUpper.MakeUpper();
+			if (strSelPathUpper.IsEmpty())
 			{
 				return hresult;
 			}
 
 			CString strRoot(strRootPath);
 			strRoot.MakeUpper();
-			if (strSelPath.Find(strRoot) != 0)
+			if (strSelPathUpper.Find(strRoot) != 0)
 			{
 				CString strMsg;
-				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRoot, (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRootPath, (LPCWSTR)strRootPath, (LPCWSTR)strSelPath);
 				::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 				continue;
 			}
 
-			CString strTSG_Upload = strRoot + L"UPLOAD\\";
-			if (strSelPath.Find(strTSG_Upload) == 0)
+			CStringW strTSG_Upload = strRootPath + L"Upload\\";
+			CStringW strTSG_UploadUpper(strTSG_Upload);
+			strTSG_UploadUpper.MakeUpper();
+			if (strSelPathUpper.Find(strTSG_UploadUpper) == 0)
 			{
 				CString strMsg;
 				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)strSelPath);
@@ -848,15 +851,17 @@ static BOOL WINAPI Hook_GetSaveFileNameW(
 			strRoot.MakeUpper();
 			if (strSelPath.Find(strRoot) != 0)
 			{
-				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRoot, (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+				strMsg.Format(L"%sドライブ以外は指定できません。\n\n保存する場所から%sを指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strPath, (LPCWSTR)strPath, (LPCWSTR)lpofn->lpstrFile);
 				::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 				continue;
 			}
 
-			CStringW strTSG_Upload = strRoot + L"UPLOAD\\";
-			if (strSelPath.Find(strTSG_Upload) == 0)
+			CStringW strTSG_Upload = strPath + L"Upload\\";
+			CStringW strTSG_UploadUpper(strTSG_Upload);
+			strTSG_UploadUpper.MakeUpper();
+			if (strSelPath.Find(strTSG_UploadUpper) == 0)
 			{
-				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)strSelPath);
+				strMsg.Format(L"アップロードフォルダー[%s]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strTSG_Upload, (LPCWSTR)lpofn->lpstrFile);
 				::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 				continue;
 			}
@@ -982,7 +987,7 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 				strRoot.MakeUpper();
 				if (strSelPath.Find(strRoot) != 0)
 				{
-					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRoot, (LPCWSTR)strSelPath);
+					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRootPath, (LPCWSTR)lpofn->lpstrFile);
 					::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/218 for v14.0.119.0

# What this PR does / why we need it:

We now use normalized (uppercase) file path in warning dialogs of file dialogs.

![image](https://github.com/user-attachments/assets/3a74d7a3-2af9-4cc6-972e-598c6a6ce66f)


It is better to use original file path than the normalized (uppercase) file path.

# How to verify the fixed issue:

## The steps to verify:

### Preparation

* Follow the steps below from the ChronosSG project to create an installer from Chronos.zip of the current Artifact of this PR
  * https://github.com/ThinBridge/Chronos-SG/tree/v14.0.119.0-maintenance/Setup/ChronosSetup#%E8%87%AA%E5%8B%95%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E4%BD%9C%E6%88%90%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88
  * Artifact: https://github.com/ThinBridge/Chronos/actions/runs/11886863862/artifacts/2199824295
* Install the created installer
* Create Chronos.exe/alt using ChronosSG_Project from https://github.com/ThinBridge/Chronos-SG/tree/v14.0.119.0-maintenance
* Copy the created Chronos.exe/alt to C:\Chronos

### Test

#### File download

* Download some file to `B:\`
  * [x] Confirm that the file is downloaded correctly.
* Download some file to `B:\Upload`
  * [x] Confirm that the warning dialog like below is displayed.
    * ![image](https://github.com/user-attachments/assets/bfa2bee2-a991-4411-8465-4be3996cb911)
  * [x] Confirm that the paths used in the dialog are original file name.
* Downlaod some file to `C:\temp` (manually input path)
  * [x] Confirm that the warning dialog like below is displayed.
    * ![image](https://github.com/user-attachments/assets/1f511cf0-574a-4784-9f0d-bc407b55b0c2)
  * [x] Confirm that the paths used in the dialog are original file name.

#### File Upload

We can use https://getbootstrap.com/docs/5.0/forms/form-control/#file-input to test to upload file.

* Upload some file from `B:\Upload`
  * [x] Confirm  that the file is uploaded correctly.
* Upload some file from `B:\` (Not in `B:\Upload`)
  * [x] Confirm that the warning dialog like below is displayed.
    * ![image](https://github.com/user-attachments/assets/4521d122-3b66-463a-bee8-c218a5b5aec8)
  * [x] Confirm that the paths used in the dialog are original file name.
