### PR TITLE
Update CEF version to 131.2.4+gb7543e4+chromium-131.0.6778.70

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=127.1.4+ge71a509+chromium-127.0.6533.89
+VERSION=131.2.4+gb7543e4+chromium-131.0.6778.70
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -173,6 +173,21 @@ bool ClientHandler::OnOpenURLFromTab(CefRefPtr<CefBrowser> browser,
 	return false;
 }
 
+#if CHROME_VERSION_MAJOR > 130
+bool ClientHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser,
+				  CefRefPtr<CefFrame> frame,
+				  int popup_id,
+				  const CefString& target_url,
+				  const CefString& target_frame_name,
+				  WindowOpenDisposition target_disposition,
+				  bool user_gesture,
+				  const CefPopupFeatures& popupFeatures,
+				  CefWindowInfo& windowInfo,
+				  CefRefPtr<CefClient>& client,
+				  CefBrowserSettings& settings,
+				  CefRefPtr<CefDictionaryValue>& extra_info,
+				  bool* no_javascript_access)
+#else
 bool ClientHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser,
 				  CefRefPtr<CefFrame> frame,
 				  const CefString& target_url,
@@ -185,6 +200,7 @@ bool ClientHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser,
 				  CefBrowserSettings& settings,
 				  CefRefPtr<CefDictionaryValue>& extra_info,
 				  bool* no_javascript_access)
+#endif
 {
 	PROC_TIME(OnBeforePopup)
 
@@ -251,7 +267,11 @@ bool ClientHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser,
 		if (lRet == 0)
 			return false;
 	}
+#if CHROME_VERSION_MAJOR > 130
+	return CefLifeSpanHandler::OnBeforePopup(browser, frame, popup_id, target_url, target_frame_name, target_disposition, user_gesture, popupFeatures, windowInfo, client, settings, extra_info, no_javascript_access);
+#else
 	return CefLifeSpanHandler::OnBeforePopup(browser, frame, target_url, target_frame_name, target_disposition, user_gesture, popupFeatures, windowInfo, client, settings, extra_info, no_javascript_access);
+#endif
 }
 
 #if CHROME_VERSION_MAJOR > 125

--- a/client_handler.h
+++ b/client_handler.h
@@ -83,7 +83,12 @@ public:
 	virtual bool DoClose(CefRefPtr<CefBrowser> browser) override;
 	virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
 	virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
+#if CHROME_VERSION_MAJOR > 130
+	virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int popup_id, const CefString& target_url, const CefString& target_frame_name, WindowOpenDisposition target_disposition, bool user_gesture, const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, CefRefPtr<CefDictionaryValue>& extra_info, bool* no_javascript_access) override;
+#else
 	virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& target_url, const CefString& target_frame_name, WindowOpenDisposition target_disposition, bool user_gesture, const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, CefRefPtr<CefDictionaryValue>& extra_info, bool* no_javascript_access) override;
+#endif
+
 #if CHROME_VERSION_MAJOR > 125
 	virtual void OnBeforeDevToolsPopup(CefRefPtr<CefBrowser> browser, CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, CefRefPtr<CefDictionaryValue>& extra_info, bool* use_default_window);
 #endif

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_127.1.4+ge71a509+chromium-127.0.6533.89_windows32_minimal
+  set CEFVER=cef_binary_131.2.4+gb7543e4+chromium-131.0.6778.70_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We should use the latest stable CEF.
This is a preparation for the regression test for CEF131.

# How to verify the fixed issue:

* [x] Confirm that the build is success.
* [x] Confirm that Chronos.exe can be executed.

The regression test for CEF131 will be executed after this PR, so I didn't check detail behaviours of Chronos.