### PR TITLE
ci: use latest Chronos

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -8,11 +8,11 @@ CEF_BAT=$TOP_DIR/setup-cef.bat
 VERSION=131.2.4+gb7543e4+chromium-131.0.6778.70
 case $1 in
     stable)
-	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)
+	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq '.windows32.versions[] | select(.channel =="stable")' | jq -s --raw-output 'max_by(.chromium_version | split(".") | map(tonumber)) | .cef_version')
 	echo $TARGET_VERSION
 	;;
     beta)
-	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel =="beta").cef_version' | head -n 1)
+	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq '.windows32.versions[] | select(.channel =="beta")' | jq -s --raw-output 'max_by(.chromium_version | split(".") | map(tonumber)) | .cef_version')
 	echo $TARGET_VERSION
 	sed -i'' -e s/windows32_minimal/windows32_beta_minimal/ $CEF_BAT
 	;;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/240

# What this PR does / why we need it:

CI has not used the latest Chronos for `stable` and `beta`.
This patch fixes CI to use the latest Chronos for `stable` and `beta`.

# How to verify the fixed issue:

* [x] Confirm that CI(`Build Chronos`) uses the latest Chronos.