### PR TITLE
Make root_cache_path equal to cache_path

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4176,12 +4176,10 @@ void CSazabi::InitializeCef()
 		CefString(&settings.cache_path) = m_strCEFCachePath;
 	}
 
+#if CHROME_VERSION_MAJOR < 115
 	CString strUserDataPath;
 	strUserDataPath = m_strCEFCachePath;
 	strUserDataPath += _T("\\UserData");
-#if CHROME_VERSION_MAJOR >= 115
-	CefString(&settings.root_cache_path) = strUserDataPath;
-#else
 	CefString(&settings.user_data_path) = strUserDataPath;
 #endif
 #if CHROME_VERSION_MAJOR <= 127


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

`CefSettings.cache_path` must be an absolute path that is either equal to or a child directory of `CefSettings.root_cache_path`. However, on the contrary, currently `root_cache_path` is a child directory of `cache_path`, it is not correct.

https://github.com/chromiumembedded/cef/blob/master/include/internal/cef_types.h#L288 https://github.com/chromiumembedded/cef/blob/master/include/internal/cef_types.h#L316

# How to verify the fixed issue:

* Open `C:\Users\<user>\AppData\Local\ChronosCache\{pid}`
* [x] Confirm that cache data exist
* [x] Confirm that UserData folder does not exist

