### PR TITLE
Fix IsEnablePDFExtension to work

### DIFF
--- a/client_app.cpp
+++ b/client_app.cpp
@@ -69,9 +69,15 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 	//	command_line->AppendSwitch(_T("disable-extensions"));
 	//command_line->AppendSwitchWithValue(_T("proxy-server"),_T("127.0.0.1:8080"));
 
+#if CHROME_VERSION_MAJOR < 126
 	//pdf
+	//CEF126.2.7以降、disable-pdf-extensionオプションが非サポートになった。
+	//そのため、CEF126以降では、ClientHandler::OnAfterCreatedでPreferenceを指定することで同等の処理を行う。
+	//https://github.com/cefsharp/CefSharp/issues/4880
 	if (!theApp.m_AppSettings.IsEnablePDFExtension())
 		command_line->AppendSwitch(_T("disable-pdf-extension"));
+#endif
+
 
 	////flash
 	//2020-12-31 EOL

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -91,6 +91,20 @@ void ClientHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 	REQUIRE_UI_THREAD();
 	PROC_TIME(OnAfterCreated)
 
+#if CHROME_VERSION_MAJOR >= 126
+	//CEF126.2.7以降、disable-pdf-extensionオプションが非サポートになった。
+	//そのため、CEF126以降では、ClientHandler::OnAfterCreatedでPreferenceを指定することで同等の処理を行う。
+	//https://github.com/cefsharp/CefSharp/issues/4880
+	if (!theApp.m_AppSettings.IsEnablePDFExtension())
+	{
+		CefRefPtr<CefRequestContext> requestContext = browser->GetHost()->GetRequestContext();
+		CefString error;
+		CefRefPtr<CefValue> value = CefValue::Create();
+		value->SetBool(true);
+		requestContext->SetPreference("plugins.always_open_pdf_externally", value, error);
+	}
+#endif
+
 	// get browser ID
 	INT nBrowserId = browser->GetIdentifier();
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/303

# What this PR does / why we need it:

The `disable-pdf-extension` command line parameter is no longer supported on CEF 126.2.7+. CEF does the same behavior with specifying the preference `plugins.always_open_pdf_externally` on CEF 126+.

https://github.com/cefsharp/CefSharp/issues/4880

Note that we can't use the preference `plugins.always_open_pdf_externally` on older versions, at least CEF119, because it does not exist.


# How to verify the fixed issue:

## The steps to verify:

1. Check (Enable) "PDF表示を有効にする" in the setting dialog
2. Restart Chronos
3. Open any PDF file on Chronos.
    * [x] Confirm that the PDF file opens in the window.
4. Uncheck (disable) "PDF表示を有効にする" in the setting dialog
5. Restart Chronos
6. Open any PDF file on Chronos.
    * [x] Confirm that a download dialog for the PDF file is opens.