### PR TITLE
Check Chronos version mismatch

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1436,33 +1436,6 @@ void CSazabi::OpenChTaskMgr()
 		pi.hProcess = 0;
 	}
 }
-void CSazabi::CheckChronosVersionMismatch()
-{
-	if (!this->IsSGMode())
-	{
-		return;
-	}
-
-	CString chronosExePath = m_strExeFolderPath + _T("Chronos.exe");
-	CString chronosNExePath = m_strExeFolderPath + _T("ChronosN.exe");
-	std::tuple<WORD, WORD, WORD, WORD> chronosVersion = GetFileVersion(chronosExePath);
-	std::tuple<WORD, WORD, WORD, WORD> chronosNVersion = GetFileVersion(chronosNExePath);
-	if (chronosVersion != chronosNVersion)
-	{
-		CString alertMsg;
-		alertMsg.LoadString(IDS_EXE_VERSION_MISMATCH);
-		alertMsg.Format(alertMsg,
-						std::get<0>(chronosVersion),
-						std::get<1>(chronosVersion),
-						std::get<2>(chronosVersion),
-						std::get<3>(chronosVersion),
-						std::get<0>(chronosNVersion),
-						std::get<1>(chronosNVersion),
-						std::get<2>(chronosNVersion),
-						std::get<3>(chronosNVersion));
-		::MessageBox(NULL, alertMsg, m_strThisAppName, MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
-	}
-}
 void CSazabi::InitLogWrite()
 {
 	PROC_TIME(InitLogWrite)
@@ -3697,6 +3670,34 @@ std::tuple<WORD, WORD, WORD, WORD> CSazabi::GetFileVersion(CString filePath)
 	}
 
 	return std::make_tuple(0, 0, 0, 0);
+}
+
+void CSazabi::CheckChronosVersionMismatch()
+{
+	if (!this->IsSGMode())
+	{
+		return;
+	}
+
+	CString chronosExePath = m_strExeFolderPath + _T("Chronos.exe");
+	CString chronosNExePath = m_strExeFolderPath + _T("ChronosN.exe");
+	std::tuple<WORD, WORD, WORD, WORD> chronosVersion = GetFileVersion(chronosExePath);
+	std::tuple<WORD, WORD, WORD, WORD> chronosNVersion = GetFileVersion(chronosNExePath);
+	if (chronosVersion != chronosNVersion)
+	{
+		CString alertMsg;
+		alertMsg.LoadString(IDS_EXE_VERSION_MISMATCH);
+		alertMsg.Format(alertMsg,
+				std::get<0>(chronosVersion),
+				std::get<1>(chronosVersion),
+				std::get<2>(chronosVersion),
+				std::get<3>(chronosVersion),
+				std::get<0>(chronosNVersion),
+				std::get<1>(chronosNVersion),
+				std::get<2>(chronosNVersion),
+				std::get<3>(chronosNVersion));
+		::MessageBox(NULL, alertMsg, m_strThisAppName, MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+	}
 }
 
 CString CSazabi::GetVOSVersionFromNT0_DLLStr()

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3641,19 +3641,13 @@ CString CSazabi::GetChromiumVersionStr()
 
 std::tuple<WORD, WORD, WORD, WORD> CSazabi::GetFileVersion(CString filePath)
 {
+	std::tuple<WORD, WORD, WORD, WORD> result = std::make_tuple(0, 0, 0, 0);
 	if (!::PathFileExists(filePath))
 	{
-		return std::make_tuple(0, 0, 0, 0);
+		return result;
 	}
-
 	DWORD handle = 0;
 	DWORD versionSize = ::GetFileVersionInfoSize((LPCWSTR)filePath, &handle);
-
-	if (versionSize == 0)
-	{
-		return std::make_tuple(0, 0, 0, 0);
-	}
-
 	PBYTE pData = new BYTE[versionSize];
 	memset(pData, 0x00, versionSize);
 	if (::GetFileVersionInfo((LPCWSTR)filePath, NULL, versionSize, pData))
@@ -3662,15 +3656,14 @@ std::tuple<WORD, WORD, WORD, WORD> CSazabi::GetFileVersion(CString filePath)
 		UINT len = 0;
 		if (VerQueryValue(pData, _T("\\"), (PVOID*)&fileInfo, &len))
 		{
-			delete[] pData;
-			return std::make_tuple(HIWORD(fileInfo->dwFileVersionMS),
-								   LOWORD(fileInfo->dwFileVersionMS),
-								   HIWORD(fileInfo->dwFileVersionLS),
-								   LOWORD(fileInfo->dwFileVersionLS));
+			result = std::make_tuple(HIWORD(fileInfo->dwFileVersionMS),
+								     LOWORD(fileInfo->dwFileVersionMS),
+								     HIWORD(fileInfo->dwFileVersionLS),
+								     LOWORD(fileInfo->dwFileVersionLS));
 		}
 	}
 	delete[] pData;
-	return std::make_tuple(0, 0, 0, 0);
+	return result;
 }
 
 void CSazabi::CheckChronosVersionMismatch()

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3662,13 +3662,14 @@ std::tuple<WORD, WORD, WORD, WORD> CSazabi::GetFileVersion(CString filePath)
 		UINT len = 0;
 		if (VerQueryValue(pData, _T("\\"), (PVOID*)&fileInfo, &len))
 		{
+			delete[] pData;
 			return std::make_tuple(HIWORD(fileInfo->dwFileVersionMS),
 								   LOWORD(fileInfo->dwFileVersionMS),
 								   HIWORD(fileInfo->dwFileVersionLS),
 								   LOWORD(fileInfo->dwFileVersionLS));
 		}
 	}
-
+	delete[] pData;
 	return std::make_tuple(0, 0, 0, 0);
 }
 

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -271,6 +271,8 @@ public:
 	CString IsProcessExistsName(DWORD dPID);
 	CString GetCefVersionStr();
 	CString GetChromiumVersionStr();
+	std::tuple<WORD, WORD, WORD, WORD> GetFileVersion(CString filePath);
+	void CheckChronosVersionMismatch();
 	//Setting Dlg///////////////////////////////////
 	void ShowSettingDlg(CWnd* pParentWnd);
 	CString m_strCurrentURL4DlgSetting;

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -1375,6 +1375,8 @@ BEGIN
     ID_CERTIFICATION_SUBJECT "発行先: "
     ID_CERTIFICATION_SERIAL_NUMBER "シリアル番号: "
     ID_CERTIFICATION_VALID_PERIOD "有効期間: "
+    IDS_EXE_VERSION_MISMATCH 
+                            "Chronos.exeとChronosN.exeのバージョンが異なります。\n\nChronos.exe: %d.%d.%d.%d\nChronosN.exe: %d.%d.%d.%d\n\nChronos.exeを再作成してください。"
 END
 
 #endif    // 日本語 (日本) resources
@@ -2760,6 +2762,8 @@ BEGIN
     ID_CERTIFICATION_SUBJECT "Subject: "
     ID_CERTIFICATION_SERIAL_NUMBER "Serial number: "
     ID_CERTIFICATION_VALID_PERIOD "Valid period: "
+    IDS_EXE_VERSION_MISMATCH 
+                            "The versions of Chronos.exe and ChronosN.exe are different.\n\nChronos.exe: %d.%d.%d.%d\nChronosN.exe: %d.%d.%d.%d\n\nPlease recreate Chronos.exe."
 END
 
 #endif    // 英語 (ニュートラル) resources

--- a/resource.h
+++ b/resource.h
@@ -298,6 +298,7 @@
 #define ID_CERTIFICATION_SUBJECT        436
 #define ID_CERTIFICATION_SERIAL_NUMBER  437
 #define ID_CERTIFICATION_VALID_PERIOD   438
+#define IDS_EXE_VERSION_MISMATCH        439
 #define IDC_EDIT1                       1000
 #define IDC_EDIT_PW                     1001
 #define IDC_EDIT2                       1002


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/147

# What this PR does / why we need it:

Chronos displays a warning dialog like below if the versions of Chronos.exe and ChronosN.exe is different.

![image](https://github.com/user-attachments/assets/6194deff-f1ac-4894-9ec7-dda8ee92b5e2)

This warning dialog displays only when SG-mode.

# How to verify the fixed issue:

## Native move

* [x] Confirm that the native Chronos does not display the warning dialog.

## SG mode (ThinApp mode)

* ChronosSGリポジトリから、旧バージョン（`14.1.119.0`以下）のインストーラーを入手する。
* 旧バージョンのインストーラを実行しインストールする。
* https://github.com/ThinBridge/Chronos-SG/tree/main のChronosSG_Projectを使用して`Chronos.exe/alt`を作成する
  * ※プロジェクトフォルダのバージョンは旧バージョンでなくても良い。
       `build.bat`を実行した際の`C:\Chronos\ChronosN.exe`のバージョンが`Chronos.exe`のバージョンとなるため。
* 作成したChronos.exe/altを`C:\Chronos`にコピーする
* ChronosSGプロジェクトの以下の手順に従い、このPRのcurrentのArtifactのChronos.zipからインストーラーを作成する
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーをインストールする
* `C:\Chronos\Chronos.exe`を起動する
* [x] `Chronos.exe`と`ChronosN.exe`のバージョンが異なる旨の警告ダイアログが表示されること
* [x] Chronosが起動すること
* `Chronos.exe/alt`を作成する
* 作成した`Chronos.exe/alt`を`C:\Chronos`にコピーする
* `C:\Chronos\Chronos.exe`を起動する
* [x] `Chronos.exe`と`ChronosN.exe`のバージョンが異なる旨の警告ダイアログが表示されないこと
* [x] Chronosが起動すること