### PR TITLE
draft: Add support for limitting upload file length

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -364,6 +364,23 @@ public:
 				}
 			}
 
+			int maxFileLength = theApp.m_AppSettings.GetMaxUploadFileLength();
+			if (maxFileLength > 0)
+			{
+				WCHAR* ptrFile = NULL;
+				ptrFile = PathFindFileNameW((LPCWSTR)strSelPathOriginal);
+				CString fileName(ptrFile);
+				int fileLength = fileName.GetLength();
+				if (fileLength > maxFileLength)
+				{
+					CString strCaption(theApp.m_strThisAppName);
+					CString strMsg;
+					strMsg.Format(L"ファイル名が長すぎるためアップロードできません。\n\n選択したファイルの名前: %d文字\n指定可能なファイル名の最大値: %d文字", fileLength, maxFileLength);
+					::MessageBoxW(hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
+					continue;
+				}
+			}
+
 			if (theApp.m_AppSettings.IsEnableLogging() && theApp.m_AppSettings.IsEnableUploadLogging())
 			{
 				WCHAR* ptrFile = NULL;
@@ -992,6 +1009,21 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 				if (strSelPath.Find(strRoot) != 0)
 				{
 					strMsg.Format(L"アップロードフォルダー[%s]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[%s]", (LPCWSTR)strRootPath, (LPCWSTR)lpofn->lpstrFile);
+					::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
+					continue;
+				}
+			}
+
+			int maxFileLength = theApp.m_AppSettings.GetMaxUploadFileLength();
+			if (maxFileLength > 0)
+			{
+				WCHAR* ptrFile = NULL;
+				ptrFile = PathFindFileNameW(lpofn->lpstrFile);
+				CString fileName(ptrFile);
+				int fileLength = fileName.GetLength();
+				if (fileLength > maxFileLength)
+				{
+					strMsg.Format(L"ファイル名が長すぎるためアップロードできません。\n\n選択したファイルの名前: %d文字\n指定可能なファイル名の最大値: %d文字", fileLength, maxFileLength);
 					::MessageBoxW(lpofn->hwndOwner, strMsg, strCaption, MB_OK | MB_ICONWARNING);
 					continue;
 				}

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -951,6 +951,7 @@ public:
 		WindowCountLimit = 0;
 		EnableMediaAccessByApproval = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
 		EnableMediaAccessPermission = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
+		MaxUploadFileLength = 0;
 
 		EnableDownloadRestriction = 0;
 		EnableUploadRestriction = 0;
@@ -1035,6 +1036,7 @@ public:
 		Data.MemoryUsageLimit = MemoryUsageLimit;
 		Data.WindowCountLimit = WindowCountLimit;
 		Data.EnableMediaAccessPermission = EnableMediaAccessPermission;
+		Data.MaxUploadFileLength = MaxUploadFileLength;
 
 		Data.EnableDownloadRestriction = EnableDownloadRestriction;
 		Data.EnableUploadRestriction = EnableUploadRestriction;
@@ -1122,6 +1124,7 @@ private:
 	int WindowCountLimit;
 	int EnableMediaAccessByApproval; // deprecated
 	int EnableMediaAccessPermission;
+	int MaxUploadFileLength;
 
 	//リダイレクト設定
 	int EnableURLRedirect;
@@ -1229,6 +1232,7 @@ public:
 		MemoryUsageLimit = 2040;
 		WindowCountLimit = 60;
 		EnableMediaAccessPermission = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
+		MaxUploadFileLength = 0;
 
 		/////////////////////////////////////////////////////////////////////////////////////////////////
 		//リダイレクト設定
@@ -1657,6 +1661,17 @@ public:
 					continue;
 				}
 
+				if (strTemp2.CompareNoCase(_T("MaxUploadFileLength")) == 0)
+				{
+					int iW = 0;
+					iW = _ttoi(strTemp3);
+					if (0 <= iW && iW <= MAX_PATH - 1)
+						MaxUploadFileLength = iW;
+					else
+						MaxUploadFileLength = 0;
+					continue;
+				}
+
 				if (strTemp2.CompareNoCase(_T("EnableDownloadRestriction")) == 0)
 				{
 					EnableDownloadRestriction = (strTemp3 == _T("1")) ? TRUE : FALSE;
@@ -2020,6 +2035,7 @@ public:
 
 		strRet += _T("# non GUI parameters\n");
 		strRet += EXTVAL(EnableMediaAccessPermission);
+		strRet += EXTVAL(MaxUploadFileLength);
 		strRet += EXTVAL(UploadBasePath);
 		strRet += EXTVAL(ExitMessage);
 		strRet += EXTVAL(unZipMessage);
@@ -2078,6 +2094,7 @@ public:
 	inline int GetMemoryUsageLimit() { return MemoryUsageLimit; }
 	inline int GetWindowCountLimit() { return WindowCountLimit; }
 	inline int GetMediaAccessPermission() { return EnableMediaAccessPermission; }
+	inline int GetMaxUploadFileLength() { return MaxUploadFileLength; }
 
 	inline BOOL IsEnableDownloadRestriction() { return EnableDownloadRestriction; }
 	inline BOOL IsEnableUploadRestriction() { return EnableUploadRestriction; }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#261

# What this PR does / why we need it:

Add a `MaxUploadFileLength` parameter to the settings.
Chronos blocks uploading of files whose name length exceeds `MaxUploadFileLength`.


# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1.
2.

## Expected result:

> Describe the obvious situation to verify.
