### PR TITLE
Drop support for EnableMediaAccessByApproval

### DIFF
--- a/sbcommon.h
+++ b/sbcommon.h
@@ -949,7 +949,6 @@ public:
 
 		MemoryUsageLimit = 0;
 		WindowCountLimit = 0;
-		EnableMediaAccessByApproval = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
 		EnableMediaAccessPermission = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
 
 		EnableDownloadRestriction = 0;
@@ -1120,7 +1119,6 @@ private:
 	int RunningLimitTime;
 	int MemoryUsageLimit;
 	int WindowCountLimit;
-	int EnableMediaAccessByApproval; // deprecated
 	int EnableMediaAccessPermission;
 
 	//リダイレクト設定
@@ -1625,17 +1623,6 @@ public:
 						WindowCountLimit = 999;
 					continue;
 				}
-				if (strTemp2.CompareNoCase(_T("EnableMediaAccessByApproval")) == 0)
-				{
-					if (strTemp3 == _T("1"))
-					{
-						// EnableMediaAccessByApproval was deprecated.
-						// 1: means manual approval, so it should be migrated to
-						// equivalent EnableMediaAccessPermission = 1 when EnableMediaAccessPermission is not set.
-						EnableMediaAccessByApproval = static_cast<int>(AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL);
-					}
-					continue;
-				}
 				if (strTemp2.CompareNoCase(_T("EnableMediaAccessPermission")) == 0)
 				{
 					int iW = 0;
@@ -1839,13 +1826,6 @@ public:
 					continue;
 				}
 			}
-		}
-		if (!bEnabledMediaAccessPermission)
-		{
-			// If EnableMediaAccessPermission is not set, migrate configuration from
-			// EnableMediaAccessByApproval. Not to depend on described order in ChronosDefault.conf,
-			// delay overriding here.
-			EnableMediaAccessPermission = EnableMediaAccessByApproval;
 		}
 		in.Close();
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/172

# What this PR does / why we need it:

`EnableMediaAccessByApproval` is deprecated. We can use `EnableMediaAccessPermission` instead.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

* Remove `EnableMediaAccessPermission` from ChronosDefault.conf
* Add `EnableMediaAccessByApproval=1` to ChronosDefault.conf
* Start Chronos
* Open a zoom address
  * [x] Confirm that microphone and video are **not** required.