### PR TITLE
Specify default download path in the hook function

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -904,18 +904,9 @@ bool ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 		pFileDlg->m_ofn.lpstrTitle = strTitle.GetString();
 		pFileDlg->m_ofn.lpstrInitialDir = strPath;
 
-		WCHAR szSelPath[MAX_PATH + 1] = {0};
 		bRet = pFileDlg->DoModal();
 		if (bRet == IDOK)
 		{
-			memset(szSelPath, 0x00, sizeof(WCHAR) * MAX_PATH);
-			StringCchCopy(szSelPath, MAX_PATH, pFileDlg->GetPathName());
-
-			WCHAR szSelFolderPath[MAX_PATH] = {0};
-			StringCchCopy(szSelFolderPath, MAX_PATH, pFileDlg->GetPathName());
-			PathRemoveFileSpec(szSelFolderPath);
-			theApp.m_strLastSelectFolderPath = szSelFolderPath;
-
 			strPath = pFileDlg->GetPathName();
 			if (!strPath.IsEmpty())
 			{

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -864,13 +864,6 @@ bool ClientHandler::OnBeforeDownload(CefRefPtr<CefBrowser> browser,
 	strPath = strPath.TrimRight('\\');
 	strPath += _T("\\");
 
-	if (!theApp.m_strLastSelectFolderPath.IsEmpty())
-	{
-		if (theApp.IsFolderExists(theApp.m_strLastSelectFolderPath))
-		{
-			strPath = theApp.m_strLastSelectFolderPath;
-		}
-	}
 	HWND hWindow = GetSafeParentWnd(browser);
 	if (SafeWnd(hWindow))
 	{


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/278

# What this PR does / why we need it:

In SG-mode, on executing "Print" -> "Output as PDF", the permission error dialog was displayed.
This is because the system default download path like `C:\Users\{username}\Downloads` was specified and Chronos can not access that path in SG-mode ( Chronos can access under `B:\`).

Also, we didn't use the last selected folder in native-mode. We should use it.

This patch fixes those problem.

# How to verify the fixed issue:

## Native mode

* Download some file
  * [x] Confirm that `C:\Users\{username}\Downloads` is used as the default save folder.
  * [x] Confirm that shortcut in left pain is displayed (settings for SG-mode is not applied).
* Change the download folder to somewhere like `C:\temp` (Call this folder "folder A").
* Save the file.
  * [x] Confirm that the file is downloaded.
* Download another file.
  * [x] Confirm that folder A is used as the default save folder.
* Close the file save dialog.
* Right click a web page.
* Select "Print"
* Select "Output as PDF" in the print preview dialog.
  * [x] Confirm that folder A is used as the default save folder.
* Change the download folder to somewhere like `C:\temp2`.
* Save the file
  * [x] Confirm that the pdf file is saved.

## SG mode

### Preparation

* Follow the steps below from the ChronosSG project to create an installer from Chronos.zip of the current Artifact of this PR
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* Install the created installer
* Create Chronos.exe/alt using ChronosSG_Project from https://github.com/ThinBridge/Chronos-SG/tree/main
* Copy the created Chronos.exe/alt to C:\Chronos

* Download some file.
  * [x] Confirm that `B:\`  or the root path specified with config file is used as the default save folder.
  * [x] Confirm that shortcut in left pain is displayed (settings for SG-mode is not applied).
* Change the download folder to somewhere like `B:\temp` (Call this folder "folder A").
* Save the file.
  * [x] Confirm that the file is downloaded.
* Download another file.
  * [x] Confirm that folder A is used as the default save folder.
* Close the file save dialog.
* Right click a web page.
* Select "Print"
* Select "Output as PDF" in the print preview dialog.
  * [x] Confirm that folder A is used as the default save folder.
* Change the download folder to somewhere like `B:\temp2`.
* Save the file
  * [x] Confirm that the pdf file is saved.


* Download some file
* Specify "C:\test.txt" as download path.
  * Manually input the full path to filename input box.
* Save the file
  * [x] Confirm that the error dialog like below is displayed.
  * ![image](https://github.com/user-attachments/assets/2f282cae-982e-4ec8-981d-d101e9dacfb1)
* Specify "B:\upload" as download path.
  * [x] Confirm that the error dialog like below is displayed.
  * ![image](https://github.com/user-attachments/assets/916b92e2-0da6-4129-9ba2-6e24c795ee95)
