### PR TITLE
Do not use deprecated apis

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -119,7 +119,7 @@ public:
 		}
 
 		CComPtr<IShellItem> psi;
-		hresult = ::SHCreateShellItem(NULL, NULL, pidl, &psi);
+		hresult = ::SHCreateItemFromIDList(pidl, IID_PPV_ARGS(&psi));
 		if (SUCCEEDED(hresult))
 		{
 			this->SetFolder(psi);
@@ -372,7 +372,7 @@ public:
 				theApp.SendLoggingMsg(LOG_UPLOAD, strFileName, hwndOwner);
 			}
 
-			PathRemoveFileSpec(strSelPath.GetBuffer());
+			PathCchRemoveFileSpec(strSelPath.GetBuffer(), strSelPath.GetLength() + 1);
 			strSelPath.ReleaseBuffer();
 			theApp.m_strLastSelectUploadFolderPath = strSelPath;
 
@@ -475,7 +475,7 @@ public:
 		}
 
 		CComPtr<IShellItem> psi;
-		hresult = ::SHCreateShellItem(NULL, NULL, pidl, &psi);
+		hresult = ::SHCreateItemFromIDList(pidl, IID_PPV_ARGS(&psi));
 		if (SUCCEEDED(hresult))
 		{
 			this->SetFolder(psi);
@@ -734,7 +734,7 @@ public:
 				}
 			}
 
-			PathRemoveFileSpec(strSelPath.GetBuffer());
+			PathCchRemoveFileSpec(strSelPath.GetBuffer(), strSelPath.GetLength() + 1);
 			strSelPath.ReleaseBuffer();
 			theApp.m_strLastSelectFolderPath = strSelPath;
 			return hresult;
@@ -1042,7 +1042,7 @@ static BOOL WINAPI Hook_GetOpenFileNameW(
 				}
 			}
 
-			PathRemoveFileSpec(strSelPath.GetBuffer());
+			PathCchRemoveFileSpec(strSelPath.GetBuffer(), strSelPath.GetLength() + 1);
 			strSelPath.ReleaseBuffer();
 			theApp.m_strLastSelectUploadFolderPath = strSelPath;
 

--- a/DlgDL.cpp
+++ b/DlgDL.cpp
@@ -60,7 +60,7 @@ void CDlgDL::SetCompST(BOOL bComp, LPCTSTR strFileFullPath)
 		m_strFileFullPath = strFileFullPath;
 		TCHAR szFolder[MAX_PATH] = {0};
 		StringCchCopy(szFolder, MAX_PATH, strFileFullPath);
-		PathRemoveFileSpec(szFolder);
+		PathCchRemoveFileSpec(szFolder, MAX_PATH);
 		m_strFileFolderPath = szFolder;
 		m_FileName.SetWindowText(strFileFullPath);
 		m_Prog.SetPos(100);

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1761,8 +1761,8 @@ CString CSazabi::GetThinAppEntryPointFolderPath()
 	TCHAR szTargetPath[512] = {0};
 	if (GetEnvironmentVariable(_T("TS_ORIGIN"), szTargetPath, 512))
 	{
-		PathRemoveFileSpec(szTargetPath);
-		PathAddBackslash(szTargetPath);
+		PathCchRemoveFileSpec(szTargetPath, 512);
+		PathCchAddBackslash(szTargetPath, 512);
 		strPath = szTargetPath;
 	}
 	return strPath;

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -9,7 +9,9 @@
 #include "include/cef_version.h"
 
 #include "mmsystem.h"
+#include <pathcch.h>
 #pragma comment(lib, "winmm.lib")
+#pragma comment(lib, "Pathcch.lib")
 class CProcessingTimeMon
 {
 public:
@@ -4017,7 +4019,7 @@ public:
 					pDLDlg->m_strFileFullPath = strFileName;
 					TCHAR szFolder[MAX_PATH] = {0};
 					StringCchCopy(szFolder, MAX_PATH, strFileName);
-					PathRemoveFileSpec(szFolder);
+					PathCchRemoveFileSpec(szFolder, MAX_PATH);
 					pDLDlg->m_strFileFolderPath = szFolder;
 					m_taskbarList3.SetProgress((ULONGLONG)nProgress, (ULONGLONG)100, TBPF_NORMAL);
 					return;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/pull/250#discussion_r1881306538
https://github.com/ThinBridge/Chronos/pull/250#discussion_r1881306538

# What this PR does / why we need it:

Do not use deprecated APIs.

https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shcreateshellitem

> Note  It is recommended that you use [SHCreateItemWithParent](https://learn.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-shcreateitemwithparent) or [SHCreateItemFromIDList](https://learn.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-shcreateitemfromidlist) instead of this function.

https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathremovefilespecw

> Note  This function is deprecated. We recommend the use of the [PathCchRemoveFileSpec](https://learn.microsoft.com/en-us/windows/desktop/api/pathcch/nf-pathcch-pathcchremovefilespec) function in its place.

https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathaddbackslashw

> Note  Misuse of this function can lead to a buffer overrun. We recommend the use of the safer [PathCchAddBackslash](https://learn.microsoft.com/en-us/windows/desktop/api/pathcch/nf-pathcch-pathcchaddbackslash) or [PathCchAddBackslashEx](https://learn.microsoft.com/en-us/windows/desktop/api/pathcch/nf-pathcch-pathcchaddbackslashex) function in its place.

# How to verify the fixed issue:

## Overview

The all changes affect to the file upload dialog, the file download dialog and the file download finish dialog.
We should confirm they work fine.

## Preparation

* Follow the steps below from the ChronosSG project to create an installer from Chronos.zip of the current Artifact of this PR
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* Install the created installer
* Create Chronos.exe/alt using ChronosSG_Project from https://github.com/ThinBridge/Chronos-SG/tree/main
* Copy the created Chronos.exe/alt to C:\Chronos

## Test

* Create `C:\Chronos\Chronos.conf`
* Add the following line to `Chronos.conf`
  * `EnableUploadSyncMirror=0`
* Start Chronos.exe
* Open the file manager
* Create `B:\test` from the file manager.
* Create `B:\Upload\test` from the file manager.
* Close the file manager
* Download some file
  * [x] Confirm that the default folder is `B:\` in the file save dialog.
* Save file to the `B:\test` folder
  * [x] Confirm that we can save the file to `B:\test`
  * [x] Confirm that the "finish file download" dialog is displayed
  * [x] Confirm that the file is saved (downloaded) to `B:\test`
* Download another file
  * [x] Confirm that the default folder is `B:\test` in the file save dialog.
* Save file to the `B:\` folder
  * [x] Confirm that we can save the file to `B:\`
  * [x] Confirm that the "finish file download" dialog is displayed
  * [x] Confirm that the file is saved (downloaded) to `B:\`
* Open the file manager
* Copy the downloaded file(s) to `B:\Upload` with the file manager.
* Copy the downloaded file(s) to `B:\Upload\test` with the file manager.
* Close the file manager
* Try to upload from https://getbootstrap.com/docs/5.0/forms/form-control/#file-input
  * [x] Confirm that the default folder is `B:\Upload` in the file open dialog.
* Select(Upload) the file in `B:\Upload\test`
  * [x] Confirm that the selected file is specified to the file input.
* Re-try to upload from https://getbootstrap.com/docs/5.0/forms/form-control/#file-input
  * [x] Confirm that the default folder is `B:\Upload\test` in the file open dialog.
* Select(Upload) the file in `B:\Upload`
  * [x] Confirm that the selected file is specified to the file input.

