### PR TITLE
Set m_strURL in OnBeforeBrowse

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -2146,6 +2146,7 @@ LRESULT CChildView::OnBeforeBrowse(WPARAM wParam, LPARAM lParam)
 	if (wParam)
 	{
 		CString strURL((LPCTSTR)wParam);
+		m_strURL = strURL;
 		if (!strURL.IsEmpty())
 		{
 			BOOL bTopPage = FALSE;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/106

# What this PR does / why we need it:

Chronos output wrong audit logs when failing to load page.
A logged URL is not the URL failed to load, but the URL succeeded to load last time.

The reason why this occurs is that Chronos sets m_strURL only in [OnAddressChange](https://github.com/ThinBridge/Chronos/blob/master/BroView.cpp#L2480), but OnAddressChange is not called when failing to load page.

We should also set m_strURL in OnBeforeBrowse.

Note that there are some cases that only OnAddressChange is called and OnBeforeBrowse is not called. So we can not remove the process to set m_strURL from OnAddressChange.

E.g. Chronos calls only OnAddressChange changing only hash fragment like below:

1. Open https://github.com/ThinBridge/Chronos/blob/master/README.md at a tab
2. After that, open https://github.com/ThinBridge/Chronos/blob/master/README.md#chronos at the same tab


# How to verify the fixed issue:

* Start [httpsserver.ps1](https://github.com/ThinBridge/Chronos-SG/blob/main/Documents/Tools/httpserver.ps1) (web server for test) with Powershell
* Start Chronos
* Open "設定" -> "ログ出力設定"
* Check "監査ログ出力を有効にする"
* Specify "http://localhost:8000" to "ログサーバーURL"
* Check "閲覧履歴を記録する"
* Click "OK" button
* Open https://www.google.co.jp/
  * [x] Confirm that the web page is displayed correctly
* Confirm Powershell prompt
  * [x] Confirm that the audit log like below is output, especially confirm url is correct
    ```
    GET: /?operation=browsing&pcname=TH-NOTE-PC&userid=TH-NOTE-PC%5Chashi&name=www.google.co.jp&url=https%3A%2F%2Fwww.google.co.jp%2F&time=2024-12-13%2016%3A00%3A14
    Cache-Control: no-cache
    Connection: Keep-Alive
    Pragma: no-cache
    Host: localhost:8000
    User-Agent: CSGAgent
    ```
* Open http://example.jp in the same tab
* Confirm Powershell prompt
  * [x] Confirm that the audit log like below is output, especially confirm url is correct
    ```
    GET: /?operation=browsing&pcname=TH-NOTE-PC&userid=TH-NOTE-PC%5Chashi&name=%E3%82%A8%E3%83%A9%E3%83%BC%3A%20%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%81%95%E3%82%8C%E3%81%9F%20URL%20%E3%81%AF%E5%8F%96%E5%BE%97%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%9B%E3%82%93%E3%81%A7%E3%81%97%E3%81%9F&url=http%3A%2F%2Fexample.jp%2F&time=2024-12-13%2016%3A10%3A54
    Cache-Control: no-cache
    Connection: Keep-Alive
    Pragma: no-cache
    Host: localhost:8000
    User-Agent: CSGAgent
    ```