### PR TITLE
Round up the default value of MemoryUsageLimit to 2048

### DIFF
--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1226,7 +1226,7 @@ public:
 
 		EnableRunningTime = FALSE;
 		RunningLimitTime = 1440;
-		MemoryUsageLimit = 2040;
+		MemoryUsageLimit = 2048;
 		WindowCountLimit = 60;
 		EnableMediaAccessPermission = static_cast<int>(AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS);
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

> Describe issue number. If issue doesn't exist, fill N/A.

https://github.com/ThinBridge/Chronos-SG/issues/345

# What this PR does / why we need it:

> Explain the detail of the problem.

The current default value of MemoryUsageLimit, 2040, looks fractional.
Adjust it by rounding up to 2048.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Start Chronos
2. Open Preferences -> Restriction
3. See the value of "Maximum allocated RAM (MB)"

## Expected result:

> Describe the obvious situation to verify.

It should be 2048.