### PR TITLE
Initialize APIHookC before executing InitializeCef

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -485,15 +485,15 @@ BOOL CSazabi::InitInstance()
 	// 保存 (ChronosDefault.conf)
 	this->m_AppSettings.SaveDataToFileEx(this->m_strSettingFileFullPath);
 
-	// SZB
-	InitializeCef();
-
 	// API Hook初期化
 	if (!m_pAPIHook)
 	{
 		m_pAPIHook = new APIHookC;
 		m_pAPIHook->DoHookComDlgAPI();
 	}
+
+	// SZB
+	InitializeCef();
 
 	// SystemGuard用の処理
 	if (this->IsSGMode())


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/245

I think this is not enough for fixing https://github.com/ThinBridge/Chronos-SG/issues/245.
I will create more change(s) (PR(s)) for https://github.com/ThinBridge/Chronos-SG/issues/245 after this patch.

# What this PR does / why we need it:

InitializeCef(CefInitialize) starts some new threads and processes. On the other hand, APIHookC initialization (DoHookComDlgAPI) tries to temporarily freeze those threads and processes. As a result, the implementation before this patch freezes threads and processes just after starting them.

Sometimes that behavior causes hung of Chronos because of failing to freeze those threads and processes. Also, this behavior itself is wasteful.

# How to verify the fixed issue:
## The steps to verify:

* ChronosSGプロジェクトの以下の手順に従い、このPRのcurrentのArtifactのChronos.zipからインストーラーを作成する
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーをインストールする
* `C:\Chronos\Chronos.exe`を起動する
  * [x] Chronosが起動すること
* 任意のファイルをダウンロードする 
  * [x] ファイルダウンロードダイアログが、APIHookCにより上書きされたものであること
    * B:\ドライブしか選択できない
    * B:\Uploadにダウンロードしようとするとエラーダイアログが出る
    * 左ペインにデスクトップへのリンクなどが表示されない
