### PR TITLE
Improve critical section

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -8,6 +8,8 @@
 static char THIS_FILE[] = __FILE__;
 #endif
 
+#define CHRONOS_GLOCAL_MUTEX_NAME _T("Chronos_Gobal_Mutex")
+
 BEGIN_MESSAGE_MAP(CSazabi, CWinApp)
 	//{{AFX_MSG_MAP(CSazabi)
 	//}}AFX_MSG_MAP
@@ -432,17 +434,56 @@ BOOL CSazabi::InitInstance()
 {
 	PROC_TIME(InitInstance)
 	CString logmsg;
-
+	HANDLE hMutex = {0};
+	DWORD dwWaitResult = WAIT_FAILED;
+	hMutex = ::CreateMutex(NULL, FALSE, CHRONOS_GLOCAL_MUTEX_NAME);
+	if (hMutex)
+	{
+		dwWaitResult = WaitForSingleObject(hMutex, 30 * 1000);
+	}
 	if (!InitFunc_Base())
+	{
+		if (hMutex)
+		{
+			if (dwWaitResult == WAIT_OBJECT_0)
+			{
+				ReleaseMutex(hMutex);
+			}
+			::CloseHandle(hMutex);
+			hMutex = NULL;
+		}
 		return FALSE;
+	}
 
 	m_strThisAppName = gstrThisAppNameR;
 
 	if (!InitFunc_Events())
+	{
+		if (hMutex)
+		{
+			if (dwWaitResult == WAIT_OBJECT_0)
+			{
+				ReleaseMutex(hMutex);
+			}
+			::CloseHandle(hMutex);
+			hMutex = NULL;
+		}
 		return FALSE;
+	}
 
 	if (!InitFunc_Paths())
+	{
+		if (hMutex)
+		{
+			if (dwWaitResult == WAIT_OBJECT_0)
+			{
+				ReleaseMutex(hMutex);
+			}
+			::CloseHandle(hMutex);
+			hMutex = NULL;
+		}
 		return FALSE;
+	}
 
 	this->GetOSVersion();
 	this->SetThisAppVersionString();
@@ -466,18 +507,51 @@ BOOL CSazabi::InitInstance()
 
 	// 設定ファイル初期読み込み
 	if (!InitFunc_Settings())
+	{
+		if (hMutex)
+		{
+			if (dwWaitResult == WAIT_OBJECT_0)
+			{
+				ReleaseMutex(hMutex);
+			}
+			::CloseHandle(hMutex);
+			hMutex = NULL;
+		}
 		return FALSE;
+	}
 
 	// コマンドラインオプションを解析する
 	this->InitParseCommandLine();
 
 	// VOS以外（物理環境で直接このEXEが起動された場合は、VOS環境で再実行）
 	if (!InitFunc_ExecOnVOS())
+	{
+		if (hMutex)
+		{
+			if (dwWaitResult == WAIT_OBJECT_0)
+			{
+				ReleaseMutex(hMutex);
+			}
+			::CloseHandle(hMutex);
+			hMutex = NULL;
+		}
 		return TRUE;
+	}
 
 	// 2重起動をチェックする。EXEのパスが違う場合は、起動を許可する。
 	if (InitMultipleInstance())
+	{
+		if (hMutex)
+		{
+			if (dwWaitResult == WAIT_OBJECT_0)
+			{
+				ReleaseMutex(hMutex);
+			}
+			::CloseHandle(hMutex);
+			hMutex = NULL;
+		}
 		return TRUE;
+	}
 
 	// Chronos.exeのバージョンとChronosN.exeのバージョンが異なる場合、警告する
 	CheckChronosVersionMismatch();
@@ -509,6 +583,16 @@ BOOL CSazabi::InitInstance()
 	{
 		if (IsFirstInstance())
 			this->InitLogWrite();
+	}
+
+	if (!hMutex)
+	{
+		WriteDebugTraceDateTime(_T("Failed to CreateMutex"), DEBUG_LOG_TYPE_GE);
+	}
+	if (hMutex && dwWaitResult != WAIT_OBJECT_0)
+	{
+		logmsg.Format(_T("Failed to aquire mutex: %lx"), dwWaitResult);
+		WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 
 	// 各種confファイルの読込
@@ -588,6 +672,15 @@ BOOL CSazabi::InitInstance()
 	::GetWindowThreadProcessId(pFrame->m_hWnd, &m_dwProcessId);
 	m_hProcess.Attach(::OpenProcess(PROCESS_ALL_ACCESS, FALSE, m_dwProcessId));
 	InitProcessSetting();
+	if (hMutex)
+	{
+		if (dwWaitResult == WAIT_OBJECT_0)
+		{
+			ReleaseMutex(hMutex);
+		}
+		::CloseHandle(hMutex);
+		hMutex = NULL;
+	}
 	return TRUE;
 }
 
@@ -1585,6 +1678,24 @@ void CSazabi::UnInitializeObjects()
 }
 int CSazabi::ExitInstance()
 {
+	PROC_TIME(ExitInstance)
+	HANDLE hMutex = {0};
+	DWORD dwWaitResult = WAIT_FAILED;
+	hMutex = ::CreateMutex(NULL, FALSE, CHRONOS_GLOCAL_MUTEX_NAME);
+	if (hMutex)
+	{
+		dwWaitResult = WaitForSingleObject(hMutex, 30 * 1000);
+		if (dwWaitResult != WAIT_OBJECT_0)
+		{
+			CString logmsg;
+			logmsg.Format(_T("Failed to aquire mutex: %lx"), dwWaitResult);
+			WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
+		}
+	}
+	else
+	{
+		WriteDebugTraceDateTime(_T("Failed to CreateMutex"), DEBUG_LOG_TYPE_GE);
+	}
 	PROC_TIME_S(ExitInstance_p1)
 
 	WriteDebugTraceDateTime(_T("----------------------------------------------------------------------------------------------------"), DEBUG_LOG_TYPE_GE);
@@ -1621,7 +1732,6 @@ int CSazabi::ExitInstance()
 			this->UnInitializeCef();
 			this->DeleteCEFCache();
 			ExecNewInstance(_T(""));
-			::Sleep(1 * 5000);
 			m_bEnforceDeleteCache = FALSE;
 		}
 		else
@@ -1635,8 +1745,7 @@ int CSazabi::ExitInstance()
 				{
 					//CloseAllで複数のプロセスでこの部分を通ってしまうのでBlockする。
 					SetLastError(NO_ERROR);
-					HANDLE hMutex = {0};
-					hMutex = ::CreateMutex(NULL, FALSE, _T("tfgszb_close"));
+
 					if (::GetLastError() != ERROR_ALREADY_EXISTS)
 					{
 						CString confirmMsg;
@@ -1658,7 +1767,6 @@ int CSazabi::ExitInstance()
 						if (iRt == IDCANCEL || iRt == IDNO || iRt == IDTIMEOUT)
 						{
 							ExecNewInstance(_T(""));
-							::Sleep(1 * 1000);
 						}
 						else
 						{
@@ -1668,11 +1776,6 @@ int CSazabi::ExitInstance()
 							this->UnInitializeCef();
 							this->DeleteCEFCacheAll();
 						}
-					}
-					if (hMutex)
-					{
-						::CloseHandle(hMutex);
-						hMutex = NULL;
 					}
 				}
 				else
@@ -1698,6 +1801,15 @@ int CSazabi::ExitInstance()
 	AfxOleTerm(FALSE);
 	bRet = CWinApp::ExitInstance();
 	PROC_TIME_E(ExitInstance_p3)
+	if (hMutex)
+	{
+		if (dwWaitResult == WAIT_OBJECT_0)
+		{
+			ReleaseMutex(hMutex);
+		}
+		::CloseHandle(hMutex);
+		hMutex = NULL;
+	}
 	return bRet;
 }
 

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -540,7 +540,7 @@ BOOL CSazabi::InitInstance()
 	}
 	if (hMutex && dwWaitResult != WAIT_OBJECT_0)
 	{
-		logmsg.Format(_T("InitInstance: Failed to aquire mutex: %lx"), dwWaitResult);
+		logmsg.Format(_T("InitInstance: Failed to acquire mutex: %lx"), dwWaitResult);
 		WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 
@@ -1634,7 +1634,7 @@ int CSazabi::ExitInstance()
 	if (hMutex && dwWaitResult != WAIT_OBJECT_0)
 	{
 		CString logmsg;
-		logmsg.Format(_T("ExitInstance: Failed to aquire mutex: %lx"), dwWaitResult);
+		logmsg.Format(_T("ExitInstance: Failed to acquire mutex: %lx"), dwWaitResult);
 		WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 	PROC_TIME_S(ExitInstance_p1)

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -536,11 +536,11 @@ BOOL CSazabi::InitInstance()
 
 	if (!hMutex)
 	{
-		WriteDebugTraceDateTime(_T("Failed to CreateMutex"), DEBUG_LOG_TYPE_GE);
+		WriteDebugTraceDateTime(_T("InitInstance: Failed to CreateMutex"), DEBUG_LOG_TYPE_GE);
 	}
 	if (hMutex && dwWaitResult != WAIT_OBJECT_0)
 	{
-		logmsg.Format(_T("Failed to aquire mutex: %lx"), dwWaitResult);
+		logmsg.Format(_T("InitInstance: Failed to aquire mutex: %lx"), dwWaitResult);
 		WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 
@@ -1629,12 +1629,12 @@ int CSazabi::ExitInstance()
 	CHRONOS_ENTER_CRITICAL_SECTION(hMutex, dwWaitResult, 30 * 1000);
 	if (!hMutex)
 	{
-		WriteDebugTraceDateTime(_T("Failed to CreateMutex"), DEBUG_LOG_TYPE_GE);
+		WriteDebugTraceDateTime(_T("ExitInstance: Failed to CreateMutex"), DEBUG_LOG_TYPE_GE);
 	}
 	if (hMutex && dwWaitResult != WAIT_OBJECT_0)
 	{
 		CString logmsg;
-		logmsg.Format(_T("Failed to aquire mutex: %lx"), dwWaitResult);
+		logmsg.Format(_T("ExitInstance: Failed to aquire mutex: %lx"), dwWaitResult);
 		WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_GE);
 	}
 	PROC_TIME_S(ExitInstance_p1)

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -45,6 +45,27 @@
 #define CEF_WOD_IGNORE_ACTION		WOD_IGNORE_ACTION
 #endif
 
+#define CHRONOS_ENTER_CRITICAL_SECTION(hMutex, dwWaitResult, waitMilliSec) \
+	{                                                                      \
+		hMutex = {0};                                                      \
+		dwWaitResult = WAIT_FAILED;                                        \
+		hMutex = ::CreateMutex(NULL, FALSE, _T("Chronos_Gobal_Mutex"));    \
+		if (hMutex)                                                        \
+		{                                                                  \
+			dwWaitResult = WaitForSingleObject(hMutex, waitMilliSec);      \
+		}                                                                  \
+	}
+#define CHRONOS_LEAVE_CRITICAL_SECTION(hMutex, dwWaitResult) \
+	if (hMutex)                                              \
+	{                                                        \
+		if (dwWaitResult == WAIT_OBJECT_0)                   \
+		{                                                    \
+			ReleaseMutex(hMutex);                            \
+		}                                                    \
+		::CloseHandle(hMutex);                               \
+		hMutex = NULL;                                       \
+	}
+
 enum class CHFILER_INIT_MODE
 {
 	OPEN,


### PR DESCRIPTION
# Which issue(s) this PR fixes:

For https://github.com/ThinBridge/Chronos-SG/issues/245

# What this PR does / why we need it:

Originally we didn't execute `WaitForSingleObject` for `hMutex` in `ExitInstance`, so exclusive control didn't work.
So fixed to execute  `WaitForSingleObject`.

Also there may be problems when `InitInstance` and `ExitInstance` are executed in parallel.

E.g. [`IsExistsAnotherInstance` in `ExitInstance`](https://github.com/ThinBridge/Chronos/blob/master/Sazabi.cpp#L1630) and [`InitMultipleInstance` in `InitInstance`](https://github.com/ThinBridge/Chronos/blob/master/Sazabi.cpp#L479) may affect each other because they use the same window name.

So fixed to acquire mutex in`InitInstance` and execute all of `ExitInstance` in critical section.

# How to verify the fixed issue:

* ChronosSGプロジェクトの以下の手順に従い、このPRのcurrentのArtifactのChronos.zipからインストーラーを作成する
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーをインストールする
* `C:\Chronos\Chronos.conf`を作成し、以下の記載を行う
  * `EnableMultipleInstance=1`
* `C:\Chronos\Chronos.exe`を起動する
  * [x] Chronosが起動すること
* 右上のxマークからChronosを終了する
* 「Chronos SystemGuardを終了してよろしいですか？」のダイアログで「いいえ」を選択する
  * [x] Chronosが再起動すること
  * [x] 終了～再起動までに30秒かからないこと（`hMutex`が解放されていることの確認） 
* 上記の再起動処理を20 ～ 30回ほど繰り返す
  * [x] 毎回Chronosが終了すること
  * [x] 毎回Chronosが再起動すること
* 右上のxマークからChronosを終了する
* 「Chronos SystemGuardを終了してよろしいですか？」のダイアログで「はい」を選択する
  * [x] Chronosが終了すること
  * [x] Chronos.exe/ChronosN.exeのプロセスが残留していないこと（タスクマネージャーの詳細タブから確認）
* `C:\Chronos\Chronos.exe`を起動する
* 「ヘルプ」-> 「ブラウザーキャッシュを削除する」を選択する
  * [x] Chronosが再起動すること
  * [x] 終了～再起動までに30秒かからないこと（`hMutex`が解放されていることの確認） 
* 上記のブラウザーキャッシュの削除処理を20 ～ 30回ほど繰り返す
  * [x] 毎回Chronosが終了すること
  * [x] 毎回Chronosが再起動すること
* 右上のxマークからChronosを終了する
* 「Chronos SystemGuardを終了してよろしいですか？」のダイアログで「はい」を選択する
  * [x] Chronosが終了すること
  * [x] Chronos.exe/ChronosN.exeのプロセスが残留していないこと（タスクマネージャーの詳細タブから確認）