### PR TITLE
Do not focus menubar

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -704,7 +704,6 @@ void CBrowserFrame::CreateRebars()
 		{
 			CMFCPopupMenu::SetForceMenuFocus(FALSE);
 			EnableDocking(CBRS_ALIGN_TOP);
-			m_pwndMenuBar->EnableDocking(CBRS_TOP);
 			DockPane(m_pwndMenuBar);
 			//------------------------------------
 			// Remove menubar gripper and borders:

--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -698,18 +698,24 @@ void CBrowserFrame::CreateRebars()
 				//---------------------------------
 				m_pwndMenuBar->SetSizes(CSize(36, 30), CSize(23, 23));
 				m_pwndMenuBar->SetMenuSizes(CSize(22, 22), CSize(16, 16));
-
-				//------------------------------------
-				// Remove menubar gripper and borders:
-				//------------------------------------
-				m_pwndMenuBar->SetPaneStyle(m_pwndMenuBar->GetPaneStyle() &
-							    ~(CBRS_GRIPPER | CBRS_BORDER_TOP | CBRS_BORDER_BOTTOM | CBRS_BORDER_LEFT | CBRS_BORDER_RIGHT));
 			}
 		}
 		if (theApp.m_AppSettings.IsRebar())
-			;
+		{
+			CMFCPopupMenu::SetForceMenuFocus(FALSE);
+			EnableDocking(CBRS_ALIGN_TOP);
+			m_pwndMenuBar->EnableDocking(CBRS_TOP);
+			DockPane(m_pwndMenuBar);
+			//------------------------------------
+			// Remove menubar gripper and borders:
+			//------------------------------------
+			m_pwndMenuBar->SetPaneStyle(m_pwndMenuBar->GetPaneStyle() &
+						    ~(CBRS_GRIPPER | CBRS_BORDER_TOP | CBRS_BORDER_BOTTOM | CBRS_BORDER_LEFT | CBRS_BORDER_RIGHT));
+		}
 		else
+		{
 			m_pwndMenuBar->ShowPane(FALSE, 0, FALSE);
+		}
 	}
 	PROC_TIME_E(CreateRebars_MENUBAR)
 
@@ -873,15 +879,6 @@ void CBrowserFrame::CreateRebars()
 			}
 			m_pwndReBarCreateFlg = TRUE;
 			PROC_TIME_E(CreateRebars_REBAR_Create)
-
-			PROC_TIME_S(CreateRebars_REBAR_AddBar_MENU)
-			if (m_pwndMenuBar)
-			{
-				m_pwndMenuBar->ShowPane(TRUE, 0, FALSE);
-				m_pwndReBar->AddBar(m_pwndMenuBar, NULL, NULL,
-						    RBBS_NOGRIPPER | RBBS_BREAK);
-			}
-			PROC_TIME_E(CreateRebars_REBAR_AddBar_MENU)
 
 			PROC_TIME_S(CreateRebars_REBAR_AddBar_ToolBar)
 			if (m_pwndToolBar)

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1531,7 +1531,11 @@ void CChildView::OnCut()
 {
 	HWND hwnd = NULL;
 	hwnd = ::GetFocus();
-	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
+	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_wndEditSearch) && (hwnd == FRM->m_wndEditSearch->m_hWnd))
+	{
+		FRM->m_wndEditSearch->Cut();
+	}
+	else if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
 	{
 		FRM->m_pwndAddress->m_Edit.Cut();
 	}
@@ -1546,7 +1550,11 @@ void CChildView::OnCopy()
 	HWND hwnd = NULL;
 	hwnd = ::GetFocus();
 
-	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
+	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_wndEditSearch) && (hwnd == FRM->m_wndEditSearch->m_hWnd))
+	{
+		FRM->m_wndEditSearch->Copy();
+	}
+	else if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
 	{
 		FRM->m_pwndAddress->m_Edit.Copy();
 	}
@@ -1562,7 +1570,11 @@ void CChildView::OnPaste()
 	HWND hwnd = NULL;
 	hwnd = ::GetFocus();
 
-	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
+	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_wndEditSearch) && (hwnd == FRM->m_wndEditSearch->m_hWnd))
+	{
+		FRM->m_wndEditSearch->Paste();
+	}
+	else if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
 	{
 		FRM->m_pwndAddress->m_Edit.Paste();
 	}
@@ -1577,7 +1589,14 @@ void CChildView::OnSelAll()
 	HWND hwnd = NULL;
 	hwnd = ::GetFocus();
 
-	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
+	 
+	if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_wndEditSearch) && (hwnd == FRM->m_wndEditSearch->m_hWnd))
+	{
+		CString str;
+		FRM->m_wndEditSearch->GetWindowText(str);
+		FRM->m_wndEditSearch->SetSel(0, str.GetLength());
+	}
+	else if (theApp.IsWnd(FRM) && theApp.IsWnd(FRM->m_pwndAddress) && (hwnd == FRM->m_pwndAddress->m_hWnd || hwnd == FRM->m_pwndAddress->m_Edit.m_hWnd))
 	{
 		CString str;
 		FRM->m_pwndAddress->m_Edit.GetWindowText(str);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

For https://github.com/ThinBridge/Chronos-SG/issues/299

# What this PR does / why we need it:

The menu bar's Edit -> Cut, Copy, Paste and Select All do commands to a focused item, and if there is no focused item, they do commands to the view windows.
On the other hand, the menu bar gets a mouse focus when clicking it.

![image](https://github.com/user-attachments/assets/24d84658-2264-4734-8264-abed0921bac9)


As a result,  the menu bar's Edit -> Cut, Copy, Paste and Select All don't work for the address edit box and the search edit box in the rebar because they are unfocused when clicking the menu bar.

# How to verify the fixed issue:

## The steps to verify:

* Specify enable rebar from in the setting dialog
* Specify enable tab in the setting dialog
* Restart Chronos
  * [x] Confirm that the menu bar and rebar are displayed same as the previous version.
* Click the search edit box
* Click the menu bar
  * [x] Confirm that the mouse focus is still on the search edit box
* Execute "Edit -> Select All" of the menu bar.
  * [x] Confirm that "Select All" is executed to the search edit box.
* Execute "Edit -> Cut" of the menu bar.
  * [x] Confirm that is "Cut" executed to the search edit box.
* Execute "Edit -> Paste" of the menu bar.
  * [x] Confirm that is "Paste" executed to the search edit box.
* Execute "Edit -> Copy" of the menu bar.
  * [x] Confirm that is "Copy" executed to the search edit box.
* Click the address edit box
* Click the menu bar
  * [x] Confirm that the mouse focus is still on the address edit box
* Execute "Edit -> Select All" of the menu bar.
  * [x] Confirm that "Select All" is executed to the address edit box.
* Execute "Edit -> Cut" of the menu bar.
  * [x] Confirm that is "Cut" executed to the address edit box.
* Execute "Edit -> Paste" of the menu bar.
  * [x] Confirm that is "Paste" executed to the address edit box.
* Execute "Edit -> Copy" of the menu bar.
  * [x] Confirm that is "Copy" executed to the address edit box.
* Click any input in the view
* Click the menu bar
  * [x] Confirm that the mouse focus is still on the input.
* Execute "Edit -> Select All" of the menu bar.
  * [x] Confirm that "Select All" is executed to the input.
* Execute "Edit -> Cut" of the menu bar.
  * [x] Confirm that is "Cut" executed to the input.
* Execute "Edit -> Paste" of the menu bar.
  * [x] Confirm that is "Paste" executed to the input.
* Execute "Edit -> Copy" of the menu bar.
  * [x] Confirm that is "Copy" executed to the input.
* Double click the menu bar
  * [x] Confirm that the menu bar is not floated
* Specify disable tab in the setting dialog
* Restart Chronos
  * [x] Confirm that the menu bar and rebar are displayed same as the previous version.
* Specify disable rebar from in the setting dialog
* Restart Chronos
  * [x] Confirm that the menu bar and rebar are not displayed.
* Specify enable tab in the setting dialog
* Restart Chronos
  * [x] Confirm that the menu bar and rebar are not displayed.

