### PR TITLE
draft: CEF128+: Avoid crash on OnProtocolExecution

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1910,10 +1910,18 @@ bool ClientHandler::OnSelectClientCertificate(
 
 void ClientHandler::OnProtocolExecution(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool& allow_os_execution)
 {
-	// do default
-	//CefResourceRequestHandler::OnProtocolExecution(browser,frame, request,allow_os_execution);
-	//return;
+	// Using CefBrowser->StopLoad() with allow_os_execution = true causes a crash on CEF128+.
+	// https://github.com/chromiumembedded/cef/issues/3851
+	//
+	// In order to avoid the crash, specifying allow_os_execution = false on CEF128+, but 
+	// this blocks to execute applications installed in OS. E.g. Zoom application for Windows.
+	// 
+	// We should specify allow_os_execution = true after the bug on CEF128+ is fixed.
+#if CHROME_VERSION_MAJOR >= 128
+	allow_os_execution = false;
+#else
 	allow_os_execution = true;
+#endif
 	browser->StopLoad();
 }
 void ClientHandler::OnRenderViewReady(CefRefPtr<CefBrowser> browser)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/305

# What this PR does / why we need it:

This is a Chronos side temporary patch for https://github.com/chromiumembedded/cef/issues/3851.

Using `CefBrowser->StopLoad()` with `allow_os_execution = true` causes a crash on CEF128+. 
In order to avoid the crash, specifying `allow_os_execution = false` on CEF128+, but this blocks to execute applications installed in OS. E.g. Zoom application for Windows.

We should specify `allow_os_execution = true` after the bug on CEF128+ is fixed.

# How to verify the fixed issue:

* Access a Zoom meeting page URL.
  * [x] Confirm that Chronos does not crash.
  * [x] Confirm that a dialog to confirm to open OS application is **not** displayed.
* Click the "Launch meeting" ("ミーティングを起動する")  button
  * [x] Confirm that Chronos does not crash.
  * [x] Confirm that nothing happens
* Click the "Join from your browser" ("ブラウザから参加") link 
  * [x] Confirm that a Zoom meeting room is displayed.
* Access a Teams meeting page URL.
  * [x] Confirm that Chronos does not crash.
* Click the "Join on the Teams app" ("Teams アプリで参加する")  button
  * [x] Confirm that Chronos does not crash.
  * [x] Confirm that nothing happens
* Click the "Continue on this browser" ("このブラウザーで続ける") link 
  * [x] Confirm that a Teams meeting room is displayed.
