### PR TITLE
Update CEF version to 131.4.1

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=131.2.4+gb7543e4+chromium-131.0.6778.70
+VERSION=131.4.1+g437feba+chromium-131.0.6778.265
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_131.2.4+gb7543e4+chromium-131.0.6778.70_windows32_minimal
+  set CEFVER=cef_binary_131.4.1+g437feba+chromium-131.0.6778.265_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Following the CEF build instructions for self-building, the CEF version we can build for major version 131 is 131.4.1 for now, so we should use that version.

FYI: Self-build CEF is located [here](https://github.com/ThinBridge/Self-Build-CEF/releases/tag/131.4.1)

# How to verify the fixed issue:

* [x] Confirm that CEF version is 131.4.1

![image](https://github.com/user-attachments/assets/0991639c-edf9-4985-9fc2-1c3489537323)
