### PR TITLE
Update UA for Google Accounts

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1185,7 +1185,8 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		{
 			request->GetHeaderMap(cefHeaders);
 			cefHeaders.erase("User-Agent");
-			cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0"));
+			cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0"));
+			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 Edg/87.0.664.66"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 Edg/87.0.0.0"));


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

Google Accounts blocks to login if the user agent is old.
We can login to Google for now, but it is better to update the user agent to the current latest Firefox user agent.

# How to verify the fixed issue:

## The steps to verify:

* Open developer tools from "システム情報" -> "Show Developer Tools"
* Open the Network tab in the Developer Tools
* Login to Google Account
  * [x] Confirm that we can login to Google Account
* Check a log to connect to `accounts.google.com` in the Developer Tools
  * [x] Confirm that `User Agent` is `Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0
`