### PR TITLE
Fix dummy UA version for Google Account

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1185,7 +1185,7 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		{
 			request->GetHeaderMap(cefHeaders);
 			cefHeaders.erase("User-Agent");
-			cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0"));
+			cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0"));
 			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 Edg/87.0.664.66"));


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N.A

# What this PR does / why we need it:

Currently Firefox/134.0 sometimes fails to login to Google Account. So use Firefox/131.0 instead of Firefox/134.0.

When having tested https://github.com/ThinBridge/Chronos/pull/267, I could login to Google Account, but now I can't login to Google Account with Firefox/134.0.
I tested other versions and found that Firefox/131.0 is fine.

# How to verify the fixed issue:

* Open developer tools from "システム情報" -> "Show Developer Tools"
* Open the Network tab in the Developer Tools
* Login to Google Account several times
  * [x] Confirm that we can login to Google Account every time
* Check a log to connect to `accounts.google.com` in the Developer Tools
  * [x] Confirm that `User Agent` is `Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0`