### PR TITLE
Do not use dummy UA for Google Account

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1178,20 +1178,22 @@ cef_return_value_t ClientHandler::OnBeforeResourceLoad(
 		//2021-01-07Googleにログインできない。。。
 		//調査結果、FirefoxにすればOK, Edge/87.0.0.0をつけてもOK
 		//デフォルトのUAをEdgeに変更する対応にする。
+		// 
 		//2021-11-30 ↑の対策がNGになっていることに気がついた。UAにEdgeをつけてもNG
 		//↓のコード復活
 		//accounts.google.comへのアクセス時は、FirefoxのUAにしてしまう。
-		if (strHost == _T("accounts.google.com"))
-		{
-			request->GetHeaderMap(cefHeaders);
-			cefHeaders.erase("User-Agent");
-			cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0"));
-			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0"));
-			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0"));
-			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 Edg/87.0.664.66"));
-			//cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36 Edg/87.0.0.0"));
-			request->SetHeaderMap(cefHeaders);
-		}
+		//
+		//2025/01/22 CEF131では、UAを変更しなくてもGoogleにログインできる。
+		//むしろ、UAを変更するとログインに失敗する。以下のUAの変更は不要。
+		//将来またUAを変更する必要がある場合の為に削除ではくてコメントアウトとしておく。
+		//
+		//if (strHost == _T("accounts.google.com"))
+		//{
+		//	request->GetHeaderMap(cefHeaders);
+		//	cefHeaders.erase("User-Agent");
+		//	cefHeaders.insert(std::make_pair("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0"));
+		//	request->SetHeaderMap(cefHeaders);
+		//}
 
 		if (!theApp.m_AppSettings.IsEnableURLFilter())
 			return RV_CONTINUE;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

On CEF131, we can login to Google Account with original UA.
So do not use dummy UA for Google Account.

# How to verify the fixed issue:

* Open developer tools from "システム情報" -> "Show Developer Tools"
* Open the Network tab in the Developer Tools
* Login to Google Account several times
  * [x] Confirm that we can login to Google Account every time
* Check a log to connect to accounts.google.com in the Developer Tools
  * [x] Confirm that User Agent is `Mozilla/5.0 (Windows NT 10.0;) AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/131.0.6778.70 Safari/537.36 Chronos/SystemGuard`