### PR TITLE
Avoid a favicon loading bug

### DIFF
--- a/client_app.cpp
+++ b/client_app.cpp
@@ -45,6 +45,7 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 	//CEF 84まではOKだった。
 	//--enable-print-preview
 	command_line->AppendSwitch(_T("enable-print-preview"));
+	command_line->AppendSwitch(_T("disable-back-forward-cache"));
 
 	//--disable-popup-blocking
 	//CEF 128以降、runtime_styleにCEF_RUNTIME_STYLE_ALLOYを指定すると、デフォルトではポップアップが表示されない。

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -24,6 +24,12 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 {
 	PROC_TIME(OnBeforeCommandLineProcessing)
 
+	//CEF131では、GoBackとGoForwardでキャッシュが有効だとFaviconが更新されない問題がある。
+	//そのため、キャッシュを無効化する。
+#if CHROME_VERSION_MAJOR >= 131
+	command_line->AppendSwitch(_T("disable-back-forward-cache"));
+#endif
+
 	//GetAuthCredentialsが動かなくなったので2019-06-13
 	//command_line->AppendSwitchWithValue(_T("disable-features"), _T("NetworkService"));
 	//2019-07-24 動くようになった。
@@ -45,7 +51,6 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 	//CEF 84まではOKだった。
 	//--enable-print-preview
 	command_line->AppendSwitch(_T("enable-print-preview"));
-	command_line->AppendSwitch(_T("disable-back-forward-cache"));
 
 	//--disable-popup-blocking
 	//CEF 128以降、runtime_styleにCEF_RUNTIME_STYLE_ALLOYを指定すると、デフォルトではポップアップが表示されない。

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -26,6 +26,7 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 
 	//CEF131では、GoBackとGoForwardでキャッシュが有効だとFaviconが更新されない問題がある。
 	//そのため、キャッシュを無効化する。
+	//https://github.com/chromiumembedded/cef/issues/3874
 #if CHROME_VERSION_MAJOR >= 131
 	command_line->AppendSwitch(_T("disable-back-forward-cache"));
 #endif


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/375

# What this PR does / why we need it:

In running with CEF's chrome_runtime mode, the favicon is not updated after `GoBack()` and `GoForward()` if the back forward cache is enabled. So we should disable it.

# How to verify the fixed issue:

* Open https://www.google.com/
* Open https://www.wikipedia.org/
* GoBack and GoFoward several times
  * [x] Confirm that the favicon and the page is reloaded all times.
