### PR TITLE
Avoid extra view focus

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -316,24 +316,12 @@ BOOL CBrowserFrame::PreTranslateMessage(MSG* pMsg)
 									this->m_wndView.bSetCefBrowserFocus();
 							}
 
-							if (m_nBrowserState & CEF_BIT_IS_LOADING)
+							theApp.m_wndpActiveTabLine->MoveWnd(rc);
+							BOOL bProgress = (m_nBrowserState & CEF_BIT_IS_LOADING) ? TRUE : FALSE;
+							if (theApp.m_wndpActiveTabLine->m_bProgress != bProgress)
 							{
-								rc.top -= 2;
-								theApp.m_wndpActiveTabLine->MoveWnd(rc);
-								if (!theApp.m_wndpActiveTabLine->m_bProgress)
-								{
-									theApp.m_wndpActiveTabLine->m_bProgress = TRUE;
-									theApp.m_wndpActiveTabLine->InvalidateRect(NULL);
-								}
-							}
-							else
-							{
-								theApp.m_wndpActiveTabLine->MoveWnd(rc);
-								if (theApp.m_wndpActiveTabLine->m_bProgress)
-								{
-									theApp.m_wndpActiveTabLine->m_bProgress = FALSE;
-									theApp.m_wndpActiveTabLine->InvalidateRect(NULL);
-								}
+								theApp.m_wndpActiveTabLine->m_bProgress = bProgress;
+								theApp.m_wndpActiveTabLine->InvalidateRect(NULL);
 							}
 						}
 					}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/17

# What this PR does / why we need it:

Previously, when the browser state was "loading", we modified the tab rectangle as `rc.top -= 2`. That caused the unintended view focus by having satisfied the condition `theApp.m_wndpActiveTabLine->m_Rc != rc` at the next time message pump.

When status is loading:

![Image](https://github.com/user-attachments/assets/2d9a09b5-cd87-4876-a6ef-749b1fcc9c61)

When status is loaded:

![Image](https://github.com/user-attachments/assets/7e2a48e9-87ea-4a99-9d5f-cd5ee3786525)

Comparing those two pictures, the former is somehow larger than the later.
As a result, `theApp.m_wndpActiveTabLine->m_Rc != rc` is satisfied.

This patch removes the modification of the tab rectangle size and suppress unintended focus changes.

# How to verify the fixed issue:

* Open https://www.msn.com/ja-jp
  * [x] Confirm that the tab rectangle size when loading is same as after loading.
* Reload the page with clicking the reload button
* Click the address bar just after reloading
* Continue to input some texts to the address bar until ending loading
  * [x] Confirm that the focus is fixed in the address bar and not moved to inside of the view
* Repeat reloading page and input texts to the address bar several times
  * [x] Confirm that the focus is never moved to inside of the view