### PR TITLE
Find: use Chrome style "Find" dialog

### DIFF
--- a/BroView.h
+++ b/BroView.h
@@ -49,7 +49,6 @@ protected:
 	afx_msg LRESULT OnAddressChange(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnStatusMessage(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnSearchURL(WPARAM wParam, LPARAM lParam);
-	afx_msg LRESULT OnFindDialogMessage(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnCloseBrowser(WPARAM wParam, LPARAM lParam);
 	//afx_msg LRESULT OnNewBrowser(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnNewWindow(WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/7
#285

# What this PR does / why we need it:

If we change the runtime_style from  `CEF_RUNTIME_STYLE_ALLOY` to  `CEF_RUNTIME_STYLE_CHROME`, 
`m_cefBrowser->GetHost()->Find` does not work.
Also we can use the Chrome style Find dialog with the runtime_style `CEF_RUNTIME_STYLE_CHROME`.

By the above reasons, we should use the Chrome style Find dialog after the runtime_style is modified 
to `CEF_RUNTIME_STYLE_CHROME`.

Note that this implementation does not work with the runtime_style `CEF_RUNTIME_STYLE_ALLOY` .

Before:

![image](https://github.com/user-attachments/assets/40f45227-046c-4ab3-b732-02152ef63a7f)


After:

![image](https://github.com/user-attachments/assets/f76bb811-c9b0-4b55-9c1e-d46e680bb529)


# How to verify the fixed issue:

## The steps to verify:

* Comment out https://github.com/ThinBridge/Chronos/blob/master/BroView.cpp#L1992 and https://github.com/ThinBridge/Chronos/blob/master/BroView.cpp#L2589
  * `info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;` -> `//info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;`
* Re-build Chronos
* Start Chronos
* Open the setting dialog
* Open the Appearance setting
* Check (Enable) the ShowTabs checkbox
* Close the setting dialog with OK
* Restart Chronos
* Open the Find dialog `Ctrl + F`
  * [x] Confirm that the Chrome style find dialog is opened.
* Input some words to the find dialog input
  * [x] Confirm that the words in the displaying page are hilighted
* Open the setting dialog
* Open the Appearance setting
* Uncheck (disable) the ShowTabs checkbox
* Close the setting dialog with OK
* Restart Chronos
* Open the Find dialog `Ctrl + F`
  * [x] Confirm that the Chrome style find dialog is opened.
* Input some words to the find dialog input
  * [x] Confirm that the words in the displaying page are hilighted
