### PR TITLE
Specify allow_os_execution true

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1913,14 +1913,13 @@ bool ClientHandler::OnSelectClientCertificate(
 
 void ClientHandler::OnProtocolExecution(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool& allow_os_execution)
 {
-	// Using CefBrowser->StopLoad() with allow_os_execution = true causes a crash on CEF128+.
+	// Using CefBrowser->StopLoad() with allow_os_execution = true causes a crash on CEF128 - 134.
 	// https://github.com/chromiumembedded/cef/issues/3851
 	//
 	// In order to avoid the crash, specifying allow_os_execution = false on CEF128+, but 
 	// this blocks to execute applications installed in OS. E.g. Zoom application for Windows.
-	// 
-	// We should specify allow_os_execution = true after the bug on CEF128+ is fixed.
-#if CHROME_VERSION_MAJOR >= 128
+
+#if CHROME_VERSION_MAJOR >= 128 && CHROME_VERSION_MAJOR < 135
 	allow_os_execution = false;
 #else
 	allow_os_execution = true;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/305

# What this PR does / why we need it:

The crash bag is fixed on CEF135.

https://github.com/chromiumembedded/cef/issues/3851

We can specify `allow_os_execution=true`.

# How to verify the fixed issue:

* Build Chronos with CEF135 ( or, rebuild after https://github.com/ThinBridge/Chronos/pull/275 is merged )
* Access to a Teams meeting room
  * [x] Confirm that the following dialog is displayed
    ![image](https://github.com/user-attachments/assets/1e6feb1d-515b-4eef-93b6-e6fe21cd3b41)
  * [x] Confirm that the Chronos does not crash
* Access to a Zoom meeting room
  * [x] Confirm that the following dialog is displayed
    ![image](https://github.com/user-attachments/assets/464f8c4d-be8b-4c8b-93e3-6121105797c5)
  * [x] Confirm that the Chronos does not crash
