### PR TITLE
build.yaml: regard warning on build as error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup CEF
         run: .\setup-cef.bat
       - name: Compile Chronos
-        run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG
+        run: msbuild /m /p:Platform=Win32 /p:Configuration=R64_CSG /p:RunCodeAnalysis=true /p:CodeAnalysisRuleSet=Sazabi.ruleset /warnaserror
       - name: Prepare upload
         run: move R32 Chronos
       - name: Prepare Chronos.exe to launch easily


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/182

# What this PR does / why we need it:

It is better to detect warnings on CI, so having added `/p:RunCodeAnalysis=true /p:CodeAnalysisRuleSet=Sazabi.ruleset /warnaserror` to the build parameters.
Now CI regards warnings as error and fails if there are warnings.

# How to verify the fixed issue:

* [x] Confirm that the CI succeeds if there is no warning: https://github.com/ThinBridge/Chronos/actions/runs/14258420312/job/39965149855
* [x] Confirm that the CI fails if there are warnings: https://github.com/ThinBridge/Chronos/actions/runs/14258586975/job/39965585915?pr=277
  * Intentionally having added a new warning: https://github.com/ThinBridge/Chronos/pull/277/commits/705e460ffef1e2a26843b4585c1bbdb038eaf718