### PR TITLE
Resolve warning

### DIFF
--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -535,7 +535,7 @@ BOOL CMainFrame::ParseCommandLineAndNewWnd(CString strCommandLine)
 	DWORD dwFlags = 0;
 	CChildView* pCreateView = NULL;
 
-	for(int i = 0; i < size; i++)
+	for(size_t i = 0; i < size; i++)
 	{
 		CString str = strArrayCommandLine.GetAt(i);
 		if (str.Find(_T("-")) == 0 || str.Find(_T("/")) == 0)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

There is a warning for comparing signed and unsigned on build.

```
     2>D:\a\Chronos\Chronos\MainFrm.cpp(538,19): error C4018: '<': signed/unsigned mismatch [D:\a\Chronos\Chronos\Sazabi.vcxproj]
```

https://github.com/ThinBridge/Chronos/actions/runs/14300955388/job/40075214195#step:8:39

# How to verify the fixed issue:

* [x] Confirm that there is no warning on build.