### PR TITLE
Revert "Specify allow_os_execution true on CEF 135+"

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1913,13 +1913,14 @@ bool ClientHandler::OnSelectClientCertificate(
 
 void ClientHandler::OnProtocolExecution(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool& allow_os_execution)
 {
-	// Using CefBrowser->StopLoad() with allow_os_execution = true causes a crash on CEF128 - 134.
+	// Using CefBrowser->StopLoad() with allow_os_execution = true causes a crash on CEF128+.
 	// https://github.com/chromiumembedded/cef/issues/3851
 	//
 	// In order to avoid the crash, specifying allow_os_execution = false on CEF128+, but 
 	// this blocks to execute applications installed in OS. E.g. Zoom application for Windows.
-
-#if CHROME_VERSION_MAJOR >= 128 && CHROME_VERSION_MAJOR < 135
+	// 
+	// We should specify allow_os_execution = true after the bug on CEF128+ is fixed.
+#if CHROME_VERSION_MAJOR >= 128
 	allow_os_execution = false;
 #else
 	allow_os_execution = true;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/305

# What this PR does / why we need it:

This reverts commit a0e7a645cfa9db21956ec59f9807a5da04fe7878.

Currently Chronos always asks for parmission to run a program, but it is not good to be asked for permission for something that is not allowed to run in the CSG environment.

We should introduce a setting parameter to specify allowed programs.
As preparation for that, reverting a0e7a645cfa9db21956ec59f9807a5da04fe7878. 

# How to verify the fixed issue:

* [x] Confirm that Zoom meeting room does not ask to run the Zoom desktop application.