### PR TITLE
Use Chrome runtime style

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1988,9 +1988,6 @@ void CChildView::CreateNewBrowserWindow(LPCTSTR lpszUrl, BOOL bActive)
 					CRect rect;
 					pCreateView->GetClientRect(rect);
 					CefWindowInfo info;
-#if CHROME_VERSION_MAJOR >= 125
-					info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
-#endif
 					CefRect windowBounds;
 					windowBounds.Set(rect.right, rect.top, rect.Width(), rect.Height());
 					info.SetAsChild(hWnd, windowBounds);
@@ -2585,9 +2582,6 @@ void CChildView::Navigate(LPCTSTR pszURL)
 		GetClientRect(&rect);
 
 		CefWindowInfo info;
-#if CHROME_VERSION_MAJOR >= 125
-		info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
-#endif
 		CefRect windowBounds;
 		windowBounds.Set(rect.right, rect.top, rect.right - rect.left, rect.bottom - rect.top);
 		info.SetAsChild(GetSafeHwnd(), windowBounds);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/396

# What this PR does / why we need it:

To add support for window sharing in web meeting apps, we must use Chrome runtime style.

Note that we already found some issues when running with Chrome runtime style.

E.g. 

https://github.com/ThinBridge/Chronos/pull/273

https://github.com/ThinBridge/Chronos/pull/196

I think it is better to resolve those issues with another PR.

# How to verify the fixed issue:

* [x] Confirm that Chronos starts correctly.

**We should do all regression tests after already found issues resolved**