### PR TITLE
Remove unused member variable

### DIFF
--- a/client_handler.h
+++ b/client_handler.h
@@ -314,7 +314,6 @@ protected:
 	// Include the default locking implementation.
 	//IMPLEMENT_LOCKING(ClientHandler);
 private:
-	std::map<std::tuple<CefString, uint32>, bool> m_originAndPermissionsCache;
 	bool IsUsableCommand(int id);
 };
 class AppRenderer : public CefApp, public CefRenderProcessHandler


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/396

# What this PR does / why we need it:

By changes of https://github.com/ThinBridge/Chronos/pull/287, Chronos no longer use `m_originAndPermissionsCache`.
We can remove it.


# How to verify the fixed issue:

* [x] Confirm that a build is passed.