### PR TITLE
Suppress permission prompts if we don't need them

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -2013,14 +2013,14 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 	if (requested_permissions == CEF_MEDIA_PERMISSION_NONE)
 		return false;
 
-    AppSettings::MediaAccessPermission permission = static_cast<AppSettings::MediaAccessPermission>(theApp.m_AppSettings.GetMediaAccessPermission());
+	AppSettings::MediaAccessPermission permission = static_cast<AppSettings::MediaAccessPermission>(theApp.m_AppSettings.GetMediaAccessPermission());
 	switch (permission)
 	{
 	case AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL:
 		// 単にfalseでreturnすることでデフォルト動作をする。
-		// Chrome style runtimeモードでのデフォルト動作は「ユーザーによる承認」であり
+		// Chrome runtime styleモードでのデフォルト動作は「ユーザーによる承認」であり
 		// このパラメータの挙動と一致する。
-		// https://cef-builds.spotifycdn.com/docs/125.0/classCefPermissionHandler.html#a05723b8cdd0a3f410ea52d05e2a41e16
+		// https://cef-builds.spotifycdn.com/docs/135.0/classCefPermissionHandler.html#a05723b8cdd0a3f410ea52d05e2a41e16
 		return false;
 	case AppSettings::MediaAccessPermission::DEFAULT_MEDIA_APPROVAL:
 		if (requested_permissions & CEF_MEDIA_PERMISSION_DESKTOP_AUDIO_CAPTURE ||
@@ -2035,6 +2035,33 @@ bool ClientHandler::OnRequestMediaAccessPermission(
 		return true;
 	default:
 		callback->Continue(CEF_MEDIA_PERMISSION_NONE);
+		return true;
+	}
+}
+
+bool ClientHandler::OnShowPermissionPrompt(CefRefPtr<CefBrowser> browser,
+					   uint64_t prompt_id,
+					   const CefString& requesting_origin,
+					   uint32_t requested_permissions,
+					   CefRefPtr<CefPermissionPromptCallback> callback)
+{
+	if (requested_permissions == CEF_MEDIA_PERMISSION_NONE)
+		return false;
+
+	AppSettings::MediaAccessPermission permission = static_cast<AppSettings::MediaAccessPermission>(theApp.m_AppSettings.GetMediaAccessPermission());
+	switch (permission)
+	{
+	case AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL:
+		// 単にfalseでreturnすることでデフォルト動作をする。
+		// Chrome runtime styleモードでのデフォルト動作は「ユーザーによる承認」であり
+		// このパラメータの挙動と一致する。
+		// https://cef-builds.spotifycdn.com/docs/135.0/classCefPermissionHandler.html#a749ce2a4fc34250d8fea3c64e687f58a
+		return false;
+	case AppSettings::MediaAccessPermission::DEFAULT_MEDIA_APPROVAL:
+		callback->Continue(CEF_PERMISSION_RESULT_ACCEPT);
+		return true;
+	default:
+		callback->Continue(CEF_PERMISSION_RESULT_DENY);
 		return true;
 	}
 }

--- a/client_handler.h
+++ b/client_handler.h
@@ -192,6 +192,11 @@ public:
 						    const CefString& requesting_origin,
 						    uint32 requested_permissions,
 						    CefRefPtr<CefMediaAccessCallback> callback) override;
+	virtual bool OnShowPermissionPrompt(CefRefPtr<CefBrowser> browser,
+					    uint64_t prompt_id,
+					    const CefString& requesting_origin,
+					    uint32_t requested_permissions,
+					    CefRefPtr<CefPermissionPromptCallback> callback) override;
 
 	void EmptyWindowClose(CefRefPtr<CefBrowser> browser)
 	{


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/407

# What this PR does / why we need it:

In some web meeting apps (as far as we confirmed,  Zoom and Google Meet), the permission prompts were displayed even we always denied or allowed them in `OnRequestMediaAccessPermission` (`EnableMediaAccessPermission` is `0` or `2`). 

E.g. In Zoom:


![image](https://github.com/user-attachments/assets/86043639-1264-4184-b77a-eca361ae4a6c)

If we clicked the "Use microphone and camera" button, then a permission prompt was displayed even `EnableMediaAccessPermission` was `0` or `2`.

![image](https://github.com/user-attachments/assets/41bb0a8b-4577-48f0-ba97-cace29a2aff3)

FYI: https://github.com/ThinBridge/Chronos/pull/287#issuecomment-2808105567

We can handle them with `OnShowPermissionPrompt`.

https://cef-builds.spotifycdn.com/docs/135.0/classCefPermissionHandler.html#a749ce2a4fc34250d8fea3c64e687f58a

This patch suppresses those unnecessary prompts.

# How to verify the fixed issue:


* Specify `EnableMediaAccessPermission=0` in ChronosDefault.conf
* Restart Chronos
* Open web meeting app on Chronos
  * On Zoom and Google Meet: 
    * A dialog asking using mic and camera is displayed
    * Click the "Use mic and camera" button
    * [x] Confirm that no dialog for request permissions is displayed.
    * [x] Confirm that we can not use camera
    * [x] Confirm that we can not use mic
  * Others:
    * [x] Confirm that no dialog for request permissions is displayed.
    * [x] Confirm that we can not use camera
    * [x] Confirm that we can not use mic
* Login to the meeting page
* Try to screen sharing
  * [x] Confirm that no dialog for request permissions is displayed.
    * Note that a host user must allow guest users to share screen on some meeting apps like Zoom
  * [x] Confirm that we can not share screen
* Stop Chronos
* Specify `EnableMediaAccessPermission=1` in ChronosDefault.conf
* Restart Chronos
* Open web meeting app on Chronos
  * On Zoom and Google Meet: 
    * A dialog asking using mic and camera is displayed
    * Click the "Use mic and camera" button
    * [x] Confirm that a dialog for request camera permission is displayed.
      * [x] Confirm that we can use camera if we permit to use camera
      * [x] Confirm that we can not use camera if we don't permit to use camera
    * [x] Confirm that a dialog for request mic permission is displayed.
      * [x] Confirm that we can use mic if we permit to use mic
      * [x] Confirm that we can not use mic if we don't permit to use mic
  * Others:
    * [x] Confirm that a dialog for request camera permission is displayed.
      * [x] Confirm that we can use camera if we permit to use camera
      * [x] Confirm that we can not use camera if we don't permit to use camera
    * [x] Confirm that a dialog for request mic permission is displayed.
      * [x] Confirm that we can use mic if we permit to use mic
      * [x] Confirm that we can not use mic if we don't permit to use mic
* Login to the meeting page
* Try to screen sharing
  * [x] Confirm that a dialog to select window is displayed
    * Note that a host user must allow guest users to share screen on some meeting apps like Zoom
* Select "cancel"
  * [x] Confirm that we can not share screen
* Try to screen sharing
* Select "Window" tab
* Select a window to share
  * [x] Confirm that a selected window is shared
* Stop screen sharing
* Try to screen sharing
* Select "Full screen" tab
* Select a full screen
  * [x] Confirm that we can share the full screen
* Stop Chronos
* Specify `EnableMediaAccessPermission=2` in ChronosDefault.conf
* Restart Chronos
* Open web meeting app on Chronos
  * On Zoom and Google Meet: 
    * A dialog asking using mic and camera is displayed
    * Click the "Use mic and camera" button
    * [x] Confirm that no dialog for request permissions is displayed.
    * [x] Confirm that we can use camera
    * [x] Confirm that we can use mic
  * Others:
    * [x] Confirm that not dialog for request camera permission is displayed.
    * [x] Confirm that no dialog for request mic permission is displayed.
    * [x] Confirm that we can use camera
    * [x] Confirm that we can use mic
* Login to the meeting page
* Try to screen sharing
  * [x] Confirm that a dialog to select window is displayed
    * Note that a host user must allow guest users to share screen on some meeting apps like Zoom
* Select "cancel"
  * [x] Confirm that we can not share screen
* Try to screen sharing
* Select "Window" tab
* Select a window to share
  * [x] Confirm that a selected window is shared
* Stop screen sharing
* Try to screen sharing
* Select "Full screen" tab
* Select a full screen
  * [x] Confirm that we can share the full screen

Do those test steps on Jitsi, Zoom and Google Meet.