### PR TITLE
Avoid crash on login to jitsi meeting room with Google account

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -93,14 +93,21 @@ void ClientHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 	PROC_TIME(OnAfterCreated)
 
 #if CHROME_VERSION_MAJOR >= 126
+	//Chrome runtime styleのとき、Jitsiのミーティングルームにおいて、Googleアカウント経由でログインする際、「パスワードを保存」
+	//プロンプトが表示されるとChronosがクラッシュする。パスワードマネージャー機能を無効化し、プロンプトが表示されないようにする。
+	CefRefPtr<CefRequestContext> requestContext = browser->GetHost()->GetRequestContext();
+	CefString error;
+	CefRefPtr<CefValue> value = CefValue::Create();
+	value->SetBool(false);
+	requestContext->SetPreference("credentials_enable_service", value, error);
+	value->SetBool(false);
+	requestContext->SetPreference("profile.password_manager_enabled", value, error);
+
 	//CEF126.2.7以降、disable-pdf-extensionオプションが非サポートになった。
 	//そのため、CEF126以降では、ClientHandler::OnAfterCreatedでPreferenceを指定することで同等の処理を行う。
 	//https://github.com/cefsharp/CefSharp/issues/4880
 	if (!theApp.m_AppSettings.IsEnablePDFExtension())
 	{
-		CefRefPtr<CefRequestContext> requestContext = browser->GetHost()->GetRequestContext();
-		CefString error;
-		CefRefPtr<CefValue> value = CefValue::Create();
 		value->SetBool(true);
 		requestContext->SetPreference("plugins.always_open_pdf_externally", value, error);
 	}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/pull/289#issuecomment-2811986946

# What this PR does / why we need it:

CSG crashes when CEF's "save password" prompt is displayed on Jitsi meeting.
This patch disables password manager feature and suppresses the "save password" prompt in order to avoid the crash.

FYI: https://issues.chromium.org/issues/41228209

# How to verify the fixed issue:

1. https://meet.jit.si/
2. start meeting clicking "Start meeting"
3. Click "join meeting"
4. Shown "waiting for an authenticated user", so Click "Log-In"
5. Click "Sign in with Google"
6. Process sign in with google, as authenticated user
   * [x] Confirm that the "save password" prompt is not displayed.
   * [x] Confirm that Chronos does not crash
   * [x] Confirm that the Jitsi meeting starts correctly.

