### PR TITLE
Add a commandline param to specify a config file path

### DIFF
--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -542,7 +542,6 @@ BOOL CMainFrame::ParseCommandLineAndNewWnd(CString strCommandLine)
 		{
 			str.TrimLeft('-');
 			str.TrimLeft('/');
-			optionParamValue = str;
 			// Ignore the ChronosConfig option because it is not used
 			// in this function.
 			if (str.CompareNoCase(_T("NEW")) == 0 ||

--- a/MainFrm.cpp
+++ b/MainFrm.cpp
@@ -543,6 +543,16 @@ BOOL CMainFrame::ParseCommandLineAndNewWnd(CString strCommandLine)
 			str.TrimLeft('-');
 			str.TrimLeft('/');
 			optionParamValue = str;
+			// Ignore the ChronosConfig option because it is not used
+			// in this function.
+			if (str.CompareNoCase(_T("NEW")) == 0 ||
+			    str.CompareNoCase(_T("VIEW")) == 0 ||
+			    str.CompareNoCase(_T("MAX")) == 0 ||
+			    str.CompareNoCase(_T("MIN")) == 0 ||
+			    str.CompareNoCase(_T("NORMAL")) == 0)
+			{
+				optionParamValue = str;
+			}
 		}
 		// URLかFilePathの場合は、強制的にCommandParamとする。
 		else if (SBUtil::IsURL(str))

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -505,7 +505,7 @@ BOOL CSazabi::InitInstance()
 		CHRONOS_LEAVE_CRITICAL_SECTION(hMutex, dwWaitResult);
 		return FALSE;
 	}
-	RefrectEnforcedOptionParam();
+	ReflectEnforcedOptionParam();
 	InitAtomParam();
 
 	// VOS以外（物理環境で直接このEXEが起動された場合は、VOS環境で再実行）
@@ -911,20 +911,20 @@ BOOL CSazabi::InitMultipleInstance()
  * -の代わりに/も使用可能
  */
 void CSazabi::ParseSingleParam(CString param) {
-	CString trimedParam(param);
-	trimedParam.Replace(_T("\""), _T(""));
-	trimedParam.TrimLeft();
-	trimedParam.TrimRight();
+	CString trimmedParam(param);
+	trimmedParam.Replace(_T("\""), _T(""));
+	trimmedParam.TrimLeft();
+	trimmedParam.TrimRight();
 
-	if (trimedParam.IsEmpty())
+	if (trimmedParam.IsEmpty())
 	{
 		return;
 	}
 
-	if (trimedParam.Find(_T("-")) == 0 || trimedParam.Find(_T("/")) == 0)
+	if (trimmedParam.Find(_T("-")) == 0 || trimmedParam.Find(_T("/")) == 0)
 	{
 		//-または/で始まる値はオプション
-		CString paramValue(trimedParam);
+		CString paramValue(trimmedParam);
 		paramValue.TrimLeft('-');
 		paramValue.TrimLeft('/');
 		paramValue.MakeLower();
@@ -939,30 +939,30 @@ void CSazabi::ParseSingleParam(CString param) {
 		}
 		else if (paramValue.CompareNoCase(_T("MAX")) == 0)
 		{
-			m_strOptionParam = trimedParam;
+			m_strOptionParam = trimmedParam;
 		}
 		else if (paramValue.CompareNoCase(_T("MIN")) == 0)
 		{
-			m_strOptionParam = trimedParam;
+			m_strOptionParam = trimmedParam;
 		}
 		else if (paramValue.CompareNoCase(_T("NORMAL")) == 0)
 		{
-			m_strOptionParam = trimedParam;
+			m_strOptionParam = trimmedParam;
 		}
 		else if (paramValue.Find(_T("chronosconfig")) == 0)
 		{
-			m_strConfigParam = trimedParam;
+			m_strConfigParam = trimmedParam;
 		}
 	}
-	else if (SBUtil::IsURL(trimedParam))
+	else if (SBUtil::IsURL(trimmedParam))
 	{
 		// URL。強制的にCommandParamとする。
-		m_strCommandParam = trimedParam;
+		m_strCommandParam = trimmedParam;
 	}
-	else if (trimedParam.Find(_T(":")) == 1)
+	else if (trimmedParam.Find(_T(":")) == 1)
 	{
 		// ファイルパス。強制的にCommandParamとする。
-		m_strCommandParam = trimedParam;
+		m_strCommandParam = trimmedParam;
 	}
 }
 
@@ -1028,7 +1028,7 @@ void CSazabi::InitAtomParam()
 	}
 }
 
-void CSazabi::RefrectEnforcedOptionParam()
+void CSazabi::ReflectEnforcedOptionParam()
 {
 	if (!m_strOptionParam.IsEmpty())
 	{

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -82,29 +82,26 @@ BOOL CSazabi::InitFunc_ExecOnVOS()
 		//Chronos.exeを実行する
 		if (PathFileExists(strChronosVirtAppPath))
 		{
-			CString strCommandParam;
-			if (!m_strCommandParam.IsEmpty() && !m_strOptionParam.IsEmpty())
+			CString strCommand;
+			strCommand.Format(_T("\"%s\""), (LPCTSTR)strChronosVirtAppPath);
+			if (!m_strCommandParam.IsEmpty())
 			{
-				strCommandParam.Format(_T("\"%s\" %s"), (LPCTSTR)m_strCommandParam, (LPCTSTR)m_strOptionParam);
+				strCommand.Format(_T("%s \"%s\""), (LPCTSTR)strCommand, (LPCTSTR)m_strCommandParam);
 			}
-			else
+			if (!m_strOptionParam.IsEmpty())
 			{
-				if (!m_strCommandParam.IsEmpty())
-					strCommandParam.Format(_T("\"%s\""), (LPCTSTR)m_strCommandParam);
-				if (!m_strOptionParam.IsEmpty())
-					strCommandParam.Format(_T("%s"), (LPCTSTR)m_strOptionParam);
+				strCommand.Format(_T("%s %s"), (LPCTSTR)strCommand, (LPCTSTR)m_strOptionParam);
 			}
-			CString strCommandC;
-			if (strCommandParam.IsEmpty())
-				strCommandC.Format(_T("\"%s\""), (LPCTSTR)strChronosVirtAppPath);
-			else
-				strCommandC.Format(_T("\"%s\" %s"), (LPCTSTR)strChronosVirtAppPath, (LPCTSTR)strCommandParam);
+			if (!m_strConfigParam.IsEmpty())
+			{
+				strCommand.Format(_T("%s %s"), (LPCTSTR)strCommand, (LPCTSTR)m_strConfigParam);
+			}
 
 			STARTUPINFO siC = {0};
 			PROCESS_INFORMATION piC = {0};
 			siC.cb = sizeof(siC);
 			unsigned long ecodeC = 0;
-			if (!CreateProcess(NULL, (LPTSTR)(LPCTSTR)strCommandC, NULL, NULL, FALSE, 0, NULL, NULL, &siC, &piC))
+			if (!CreateProcess(NULL, (LPTSTR)(LPCTSTR)strCommand, NULL, NULL, FALSE, 0, NULL, NULL, &siC, &piC))
 			{
 				SetLastError(NO_ERROR);
 				//Retry
@@ -113,7 +110,7 @@ BOOL CSazabi::InitFunc_ExecOnVOS()
 					SetLastError(NO_ERROR);
 					if (::ShellExecute(NULL, _T("open"), strChronosVirtAppPath, NULL, NULL, SW_SHOW) <= HINSTANCE(32))
 					{
-						::ShellExecute(NULL, NULL, strCommandC, NULL, NULL, SW_SHOW);
+						::ShellExecute(NULL, NULL, strCommand, NULL, NULL, SW_SHOW);
 					}
 				}
 			}
@@ -275,21 +272,42 @@ BOOL CSazabi::InitFunc_Settings()
 	// 設定データの初期値を読み込む
 	this->m_AppSettings.LoadDefaultData();
 
-	// ChronosDefault.confから設定データを読み込む
-	if (PathFileExists(m_strSettingFileFullPath))
+	CString userConfigFilePath;
+	if (!m_strConfigParam.IsEmpty())
 	{
-		this->m_AppSettings.LoadDataFromFile(m_strSettingFileFullPath);
+		int pos = m_strConfigParam.Find(_T('='));
+		if (pos != -1)
+		{
+			userConfigFilePath = m_strConfigParam.Right(m_strConfigParam.GetLength() - pos - 1).Trim(_T('"'));
+		}
 	}
 
-	// ThinApp環境ではChronos.confから設定を追加で読み込む。
-	if (InVirtualEnvironment() == VE_THINAPP)
+	if (InVirtualEnvironment() == VE_NA)
 	{
-		CString strTS_Path;
-		strTS_Path = GetThinAppEntryPointFolderPath();
-		strTS_Path += _T("Chronos.conf");
-		if (PathFileExists(strTS_Path))
+		// ネイティブ環境の場合、設定ファイルパスが指定されていればそちらから、
+		// 指定されていなければChronosDefault.confから設定データを読み込む
+		CString configPath = userConfigFilePath.IsEmpty() ? 
+			m_strSettingFileFullPath : 
+			userConfigFilePath;
+		if (PathFileExists(configPath))
 		{
-			this->m_AppSettings.LoadDataFromFile(strTS_Path);
+			this->m_AppSettings.LoadDataFromFile(configPath);
+		}
+	}
+	else if (InVirtualEnvironment() == VE_THINAPP)
+	{
+		//  ThinApp環境では、必ず最初にChronosDefault.confから設定データを読み込む
+		if (PathFileExists(m_strSettingFileFullPath))
+		{
+			this->m_AppSettings.LoadDataFromFile(m_strSettingFileFullPath);
+		}
+		// 更にChronos.confまたは指定されたファイルから設定を追加で読み込む
+		CString additionalConfigPath = userConfigFilePath.IsEmpty() ?
+			GetThinAppEntryPointFolderPath() + _T("Chronos.conf") :
+			userConfigFilePath;
+		if (PathFileExists(additionalConfigPath))
+		{
+			this->m_AppSettings.LoadDataFromFile(additionalConfigPath);
 		}
 	}
 
@@ -478,15 +496,17 @@ BOOL CSazabi::InitInstance()
 		m_strThisAppName = gstrThisAppNameR;
 	}
 
+	// コマンドラインオプションを解析する
+	this->InitParseCommandLine();
+
 	// 設定ファイル初期読み込み
 	if (!InitFunc_Settings())
 	{
 		CHRONOS_LEAVE_CRITICAL_SECTION(hMutex, dwWaitResult);
 		return FALSE;
 	}
-
-	// コマンドラインオプションを解析する
-	this->InitParseCommandLine();
+	RefrectEnforcedOptionParam();
+	InitAtomParam();
 
 	// VOS以外（物理環境で直接このEXEが起動された場合は、VOS環境で再実行）
 	if (!InitFunc_ExecOnVOS())
@@ -886,6 +906,7 @@ BOOL CSazabi::InitMultipleInstance()
  * -MAX    ... 最大化モード (MainFrm.cpp)
  * -MIN    ... 最小化モード (MainFrm.cpp)
  * -NORMAL ... ウィンドウモード
+ * -ChronosConfig="path to config file" ... 設定ファイルを指定する
  * 
  * -の代わりに/も使用可能
  */
@@ -906,6 +927,7 @@ void CSazabi::ParseSingleParam(CString param) {
 		CString paramValue(trimedParam);
 		paramValue.TrimLeft('-');
 		paramValue.TrimLeft('/');
+		paramValue.MakeLower();
 		// CEFのパラメータを解釈しないように、明示的にChronosのパラメータのみ確認する。
 		if (paramValue.CompareNoCase(_T("NEW")) == 0)
 		{
@@ -926,6 +948,10 @@ void CSazabi::ParseSingleParam(CString param) {
 		else if (paramValue.CompareNoCase(_T("NORMAL")) == 0)
 		{
 			m_strOptionParam = trimedParam;
+		}
+		else if (paramValue.Find(_T("chronosconfig")) == 0)
+		{
+			m_strConfigParam = trimedParam;
 		}
 	}
 	else if (SBUtil::IsURL(trimedParam))
@@ -958,29 +984,15 @@ void CSazabi::InitParseCommandLine()
 	m_strCommandParam.Empty();
 	m_strOptionParam.Empty();
 
-	//起動時の強制パラメータを確認
-	CString strEnforceInitParam;
-	strEnforceInitParam = m_AppSettings.GetEnforceInitParam();
-
-	//整形
-	strEnforceInitParam.TrimLeft();
-	strEnforceInitParam.TrimRight();
-	strEnforceInitParam.Replace(_T("\""), _T(""));
-
-	//一旦クリア
-	m_strAtomParam.Empty();
-
-	if (!strEnforceInitParam.IsEmpty())
-	{
-		m_strOptionParam = strEnforceInitParam;
-	}
-
 	for (int i = 1; i < __argc; i++)
 	{
 		CString param(__wargv[i]);
 		ParseSingleParam(param);
 	}
+}
 
+void CSazabi::InitAtomParam()
+{
 	if (m_bNewInstanceParam)
 	{
 		if (m_strOptionParam.IsEmpty())
@@ -989,20 +1001,55 @@ void CSazabi::InitParseCommandLine()
 		}
 	}
 
-	//両方セットされている場合
-	if (!m_strCommandParam.IsEmpty() && !m_strOptionParam.IsEmpty())
+	// 一旦クリア
+	m_strAtomParam.Empty();
+
+	if (!m_strCommandParam.IsEmpty())
 	{
-		m_strAtomParam.Format(_T("%s|@@|%s"), (LPCTSTR)m_strCommandParam, (LPCTSTR)m_strOptionParam);
+		m_strAtomParam = m_strCommandParam;
 	}
-	else
+
+	if (!m_strOptionParam.IsEmpty())
 	{
-		//Commandのみ
-		if (!m_strCommandParam.IsEmpty())
-			m_strAtomParam = m_strCommandParam;
-		//Optionのみ
-		if (!m_strOptionParam.IsEmpty())
-			m_strAtomParam = m_strOptionParam;
+		if (!m_strAtomParam.IsEmpty())
+		{
+			m_strAtomParam += _T("|@@|");
+		}
+		m_strAtomParam += m_strOptionParam;
 	}
+
+	if (!m_strConfigParam.IsEmpty())
+	{
+		if (!m_strAtomParam.IsEmpty())
+		{
+			m_strAtomParam += _T("|@@|");
+		}
+		m_strAtomParam += m_strConfigParam;
+	}
+}
+
+void CSazabi::RefrectEnforcedOptionParam()
+{
+	if (!m_strOptionParam.IsEmpty())
+	{
+		// 既にコマンドラインパラメータがある場合は、そちらを優先する
+		return;
+	}
+
+	// 起動時の強制パラメータを確認
+	CString strEnforceInitParam;
+	strEnforceInitParam = m_AppSettings.GetEnforceInitParam();
+
+	// 整形
+	strEnforceInitParam.TrimLeft();
+	strEnforceInitParam.TrimRight();
+	strEnforceInitParam.Replace(_T("\""), _T(""));
+
+	if (strEnforceInitParam.IsEmpty())
+	{
+		return;
+	}
+	m_strOptionParam = strEnforceInitParam;
 }
 
 void CSazabi::ExitKillZombieProcess()

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -145,6 +145,7 @@ public:
 	CString m_strAtomParam;
 	CString m_strCommandParam;
 	CString m_strOptionParam;
+	CString m_strConfigParam;
 
 	BOOL m_bNewInstanceParam;
 	BOOL m_bTabWndChanging;
@@ -266,6 +267,8 @@ public:
 	void InitLogWrite();
 	void ParseSingleParam(CString param);
 	void InitParseCommandLine();
+	void InitAtomParam();
+	void RefrectEnforcedOptionParam();
 	BOOL InitMultipleInstance();
 	void InitReadConfSetting();
 	void InitializeCef();

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -268,7 +268,7 @@ public:
 	void ParseSingleParam(CString param);
 	void InitParseCommandLine();
 	void InitAtomParam();
-	void RefrectEnforcedOptionParam();
+	void ReflectEnforcedOptionParam();
 	BOOL InitMultipleInstance();
 	void InitReadConfSetting();
 	void InitializeCef();


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/274

# What this PR does / why we need it:

Currently, the config files are fixed path:

* Native mode:
  * User (default) config file:
    *  `.\ChronosDefault.conf`
* SG-mode: 
  * Default config file: 
    * `.\ChronosDefault.conf` in the virtual environment 
  * User config file: 
    * C:\Chronos\Chronos.conf

This patch enables to specify a **user config file** with commandline argument.
Chronos uses the specified file instead of "User config file".
In the native mode, Chronos uses the specified file.
In the SG mode, Chronos uses the specified file instead of `C:\Chronos\Chronos.conf`, `.\ChronosDefault.conf` is used as default config even if the config file is specified.

Usage:

```
ChronosN.exe -ChronosConfig="path/to/config/file"
ChronosN.exe /ChronosConfig="path/to/config/file"
```


# How to verify the fixed issue:

## ネイティブモード

### 準備

* Chronos.zip を https://github.com/ThinBridge/Chronos/actions/runs/14611953230 からダウンロードする
* Chronos.zipを解凍する
* Chronosを実行する
* ChronosN.exeと同じフォルダにChronosDefault.confが作成される
* Chronosを終了する
* `ChronosDefault.conf`を開く
* `EnableCrashRecovery=0`を`EnableCrashRecovery=1`に変更し、保存する
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル。また、パスは実際にはどこでも良い。）
* `C:\Chronos\MyChronos.conf`に`EnablePDFExtension=0`を記載する
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされて**いない**こと
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いない**こと
* Chronosを終了する
* `ChronosDefault.conf`を開く
* `EnableMultipleInstance`について、`EnableMultipleInstance=0`に変更し、保存する（存在しなければ追記する）
* `C:\Chronos\MyChronos.conf`を開く
* `EnableMultipleInstance`について、`EnableMultipleInstance=0`に変更し、保存する（存在しなければ追記する）
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「インスタンスの二重起動を許可する」がOFFであることを確認する
* 設定画面を閉じる
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] 既存のChronosに新しいタブが作成されること
* 設定画面を開く
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いる**こと（`C:\Chronos\MyChronos.conf`が読み込まれていないこと）
* 設定画面を閉じる
* 新しく作成されたタブで、何らかのPDFを表示する
  * [x] Chronos上でPDFが表示されること（`C:\Chronos\MyChronos.conf`が読み込まれていないこと）
* Chronosを終了する
* `ChronosDefault.conf`を開く
* `EnableMultipleInstance`について、`EnableMultipleInstance=1`に変更し、保存する（存在しなければ追記する）
* `C:\Chronos\MyChronos.conf`を開く
* `EnableMultipleInstance`について、`EnableMultipleInstance=1`に変更し、保存する（存在しなければ追記する）
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「インスタンスの二重起動を許可する」がONであることを確認する
* 設定画面を閉じる
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] 新しいChronosのインスタンスが起動すること
* 設定画面を開く
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いない**こと（`C:\Chronos\MyChronos.conf`が読み込まれていること）
* 設定画面を閉じる
* 新しく作成されたタブで、何らかのPDFを表示する
  * [x] PDFのダウンロードダイアログが表示されること（`C:\Chronos\MyChronos.conf`が読み込まれていること）

## SGモード

### 準備

* Chronos.zip を https://github.com/ThinBridge/Chronos/actions/runs/14611953230 からダウンロードする
* ダウンロードしたChronos.zipを元に、インストーラーを作成する
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーでChronosをインストールする
* https://github.com/ThinBridge/Chronos-SG/releases/tag/v15.0.131.0 からChronosSG_Project.zipをダウンロードする
* ChronosSG_Project.zipを解凍する
* `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf` を開く
* `EnableCrashRecovery=0`を`EnableCrashRecovery=1`に変更しておく
* その他のパラメータは変更しない
  * 後々、EnableCrashRecoveryの値でChronosDefault.confが読み込まれているか確認するため。
* build.batを実行し、Chronos.exe/altを作成する。
* Chronos.exe/altをC:\Chronosに移動する
* `C:\Chronos\Chronos.conf`が存在する場合、削除する

### テスト

* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* `C:\Chronos\Chronos.conf`を作成する（空ファイル）
* `C:\Chronos\Chronos.conf`に`EnableGPURendering=0`を記載する
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル）
* `C:\Chronos\MyChronos.conf`に`EnablePDFExtension=0`を記載する
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされて**いない**こと
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていないこと
* Chronosを終了する
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「インスタンスの二重起動を許可する」がOFFであることを確認する
* 設定画面を閉じる
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] 既存のChronosに新しいタブが作成されること
* 設定画面を開く
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いる**こと（`C:\Chronos\MyChronos.conf`が読み込まれていないこと）
* 設定画面を閉じる
* 新しく作成されたタブで、何らかのPDFを表示する
  * [x] Chronos上でPDFが表示されること（`C:\Chronos\MyChronos.conf`が読み込まれていないこと）
 * 設定画面を開く
* 全般機能の「インスタンスの二重起動を許可する」にチェックを入れる
* 設定画面を閉じる
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] 新しいChronosのインスタンスが起動すること
* 設定画面を開く
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いない**こと（`C:\Chronos\MyChronos.conf`が読み込まれていること）
* 設定画面を閉じる
* 新しく作成されたタブで、何らかのPDFを表示する
  * PDFのダウンロードダイアログが表示されること（`C:\Chronos\MyChronos.conf`が読み込まれていること）

#### 引数解析部分のテスト

* Chronosを全て終了する
* `C:\Chronos\ChronosN.exe https://www.yahoo.co.jp -MAX /ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] ホームページが https://www.yahoo.co.jp で起動すること
  * [x] 全画面表示で起動すること
* 設定画面を開く
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされて**いない**こと
* Chronosを終了する

#### 起動時の表示オプションのテスト

設定ファイルに`EnforceInitParam`で表示モードの指定があるとき、コマンドライン引数で表示モードの指定がなければ、`EnforceInitParam`の表示モードが使用される。コマンドライン引数で表示モードの指定があれば、コマンドライン引数の方が優先される。

* `C:\Chronos\MyChronos.conf`に`EnforceInitParam=/MAX`を記載する
* `C:\Chronos\ChronosN.exe /ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] 全画面表示で起動すること
* Chronosを終了する
* `C:\Chronos\ChronosN.exe /NORMAL /ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] Chronosがウィンドウ（最大でも最小でもない状態）で起動すること