### PR TITLE
Add config param to forbid using user config

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -287,7 +287,7 @@ BOOL CSazabi::InitFunc_Settings()
 		// ネイティブ環境の場合、設定ファイルパスが指定されていればそちらから、
 		// 指定されていなければChronosDefault.confから設定データを読み込む
 		CString configPath = userConfigFilePath.IsEmpty() ? 
-			m_strSettingFileFullPath : 
+			m_strSettingFileFullPath :
 			userConfigFilePath;
 		if (PathFileExists(configPath))
 		{
@@ -301,13 +301,16 @@ BOOL CSazabi::InitFunc_Settings()
 		{
 			this->m_AppSettings.LoadDataFromFile(m_strSettingFileFullPath);
 		}
-		// 更にChronos.confまたは指定されたファイルから設定を追加で読み込む
-		CString additionalConfigPath = userConfigFilePath.IsEmpty() ?
-			GetThinAppEntryPointFolderPath() + _T("Chronos.conf") :
-			userConfigFilePath;
-		if (PathFileExists(additionalConfigPath))
+		if (theApp.IsEnableUserConfig())
 		{
-			this->m_AppSettings.LoadDataFromFile(additionalConfigPath);
+			// 更にChronos.confまたは指定されたファイルから設定を追加で読み込む
+			CString additionalConfigPath = userConfigFilePath.IsEmpty() ? 
+				GetThinAppEntryPointFolderPath() + _T("Chronos.conf") : 
+				userConfigFilePath;
+			if (PathFileExists(additionalConfigPath))
+			{
+				this->m_AppSettings.LoadDataFromFile(additionalConfigPath);
+			}
 		}
 	}
 

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -286,12 +286,16 @@ BOOL CSazabi::InitFunc_Settings()
 	{
 		// ネイティブ環境の場合、設定ファイルパスが指定されていればそちらから、
 		// 指定されていなければChronosDefault.confから設定データを読み込む
-		CString configPath = userConfigFilePath.IsEmpty() ? 
-			m_strSettingFileFullPath :
-			userConfigFilePath;
-		if (PathFileExists(configPath))
+		CString configPath = m_strSettingFileFullPath;
+		if (PathFileExists(m_strSettingFileFullPath))
 		{
-			this->m_AppSettings.LoadDataFromFile(configPath);
+			this->m_AppSettings.LoadDataFromFile(m_strSettingFileFullPath);
+		}
+		if (theApp.m_AppSettings.IsEnableUserConfig() && 
+		    PathFileExists(userConfigFilePath))
+		{
+			theApp.m_AppSettings.LoadDefaultData();
+			this->m_AppSettings.LoadDataFromFile(userConfigFilePath);
 		}
 	}
 	else if (InVirtualEnvironment() == VE_THINAPP)
@@ -301,7 +305,7 @@ BOOL CSazabi::InitFunc_Settings()
 		{
 			this->m_AppSettings.LoadDataFromFile(m_strSettingFileFullPath);
 		}
-		if (theApp.IsEnableUserConfig())
+		if (theApp.m_AppSettings.IsEnableUserConfig())
 		{
 			// 更にChronos.confまたは指定されたファイルから設定を追加で読み込む
 			CString additionalConfigPath = userConfigFilePath.IsEmpty() ? 

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -999,6 +999,9 @@ public:
 		LABEL_ALPHA_BLEND = 0;
 		TASK_LIST_TYPE = 0;
 		TASK_LIST_MODE_DETAIL = 0;
+
+		//Config file-------------------------------
+		EnableUserConfig = 0;
 	}
 	void CopyData(AppSettings& Data)
 	{
@@ -1084,6 +1087,9 @@ public:
 		Data.LABEL_ALPHA_BLEND = LABEL_ALPHA_BLEND;
 		Data.TASK_LIST_TYPE = TASK_LIST_TYPE;
 		Data.TASK_LIST_MODE_DETAIL = TASK_LIST_MODE_DETAIL;
+
+		//Config file-------------------------------
+		Data.EnableUserConfig = EnableUserConfig;
 	}
 
 private:
@@ -1182,6 +1188,9 @@ private:
 	int LABEL_ALPHA_BLEND;
 	int TASK_LIST_TYPE;
 	int TASK_LIST_MODE_DETAIL;
+	//Config file-------------------------------
+	int EnableUserConfig;
+
 
 public:
 	//SystemGuardModeの判定用
@@ -1294,6 +1303,9 @@ public:
 		LABEL_ALPHA_BLEND = 196;
 		TASK_LIST_TYPE = 1;
 		TASK_LIST_MODE_DETAIL = 1;
+
+		//Config file-------------------------------
+		EnableUserConfig = 1;
 	}
 
 	BOOL SaveDataToFileEx(LPCTSTR pstrFilePath)
@@ -1836,6 +1848,11 @@ public:
 					TASK_LIST_MODE_DETAIL = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
+				if (strTemp2.CompareNoCase(_T("EnableUserConfig")) == 0)
+				{
+					EnableUserConfig = (strTemp3 == _T("1")) ? TRUE : FALSE;
+					continue;
+				}
 			}
 		}
 		in.Close();
@@ -2024,6 +2041,8 @@ public:
 		strRet += EXTVAL(LABEL_TYPE);
 		strRet += EXTVAL(LABEL_CHK_INTERVAL);
 		strRet += EXTVAL(LABEL_ALPHA_BLEND);
+		//Config file-------------------------------
+		strRet += EXTVAL(EnableUserConfig);
 
 		return strRet;
 	}
@@ -2119,6 +2138,9 @@ public:
 	inline int GetLABEL_ALPHA_BLEND() { return LABEL_ALPHA_BLEND; }
 	inline int GetTASK_LIST_TYPE() { return TASK_LIST_TYPE; }
 	inline int GetTASK_LIST_MODE_DETAIL() { return TASK_LIST_MODE_DETAIL; }
+
+	//Config file-------------------------------
+	inline BOOL IsEnableUserConfig() { return EnableUserConfig; }
 
 	//Set Functions Setter##########################################################
 	inline void SetAdvancedLogMode(DWORD dVal) { EnableAdvancedLogMode = dVal ? 1 : 0; }
@@ -2232,6 +2254,9 @@ public:
 	inline void SetLABEL_ALPHA_BLEND(DWORD dVal) { LABEL_ALPHA_BLEND = dVal; }
 	inline void SetTASK_LIST_TYPE(DWORD dVal) { TASK_LIST_TYPE = dVal; }
 	inline void SetTASK_LIST_MODE_DETAIL(DWORD dVal) { TASK_LIST_MODE_DETAIL = dVal; }
+
+	// Config file-------------------------------
+	inline int SetEnableUserConfig(DWORD dVal) { EnableUserConfig = dVal; }
 };
 
 class CIconHelper


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/274
https://github.com/ThinBridge/Chronos-SG/issues/53

# What this PR does / why we need it:

We now become to be able to specify a user config file path with #293 .
However, sometimes administrators want to forbid users using the user config.

This patch add a non-gui config parameter `EnableUserConfig`.

If `EnableUserConfig=1`, users can use a user config file, and if `EnableUserConfig=0`, users can not use a user config file.

For the backword compatibility, the default value is `EnableUserConfig=1`.

We also need to add `EnableUserConfig=1` to ChronosDefault.conf (another PR).

# How to verify the fixed issue:

## ネイティブモード

### 準備

* Chronos.zip を Artifacts からダウンロードする
* Chronos.zipを解凍する
* Chronosを実行する
* ChronosN.exeと同じフォルダにChronosDefault.confが作成される
* Chronosを終了する
* `ChronosDefault.conf`を開く
  * [x] `EnableUserConfig=1`が記載されていること
* `EnableCrashRecovery=0`を`EnableCrashRecovery=1`に変更し、保存する
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル。また、パスは実際にはどこでも良い。）
* `C:\Chronos\MyChronos.conf`に`EnablePDFExtension=0`を記載する
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされて**いない**こと
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いない**こと
* Chronosを終了する
* `ChronosDefault.conf`を開く
* `EnableUserConfig`を`EnableUserConfig=0`に変更する
* Chronosをダブルクリックで起動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
* 設定画面を開く
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いる**こと（`C:\Chronos\MyChronos.conf`が読み込まれていないこと）
* 設定画面を閉じる

## SGモード

### 準備

* Chronos.zip を Artifacts からダウンロードする
* ダウンロードしたChronos.zipを元に、インストーラーを作成する
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーでChronosをインストールする
* https://github.com/ThinBridge/Chronos-SG/releases/tag/v15.0.131.0 からChronosSG_Project.zipをダウンロードする
* ChronosSG_Project.zipを解凍する
* `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf` を開く
* `EnableCrashRecovery=0`を`EnableCrashRecovery=1`に変更しておく
* その他のパラメータは変更しない
  * 後々、EnableCrashRecoveryの値でChronosDefault.confが読み込まれているか確認するため。
* build.batを実行し、Chronos.exe/altを作成する。
* Chronos.exe/altをC:\Chronosに移動する
* `C:\Chronos\Chronos.conf`が存在する場合、削除する

### テスト

#### デフォルト動作（`EnableUserConfig`が存在しない場合に、`EnableUserConfig=1`と同等の動作をすること）

* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* `C:\Chronos\Chronos.conf`を作成する（空ファイル）
* `C:\Chronos\Chronos.conf`に`EnableGPURendering=0`を記載する
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル）
* `C:\Chronos\MyChronos.conf`に`EnablePDFExtension=0`を記載する
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされて**いない**こと
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いない**こと
* Chronosを終了する

#### `EnableUserConfig=1`指定時の動作

* `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf` を開く
* `EnableUserConfig=1`を追加する
* build.batを実行し、Chronos.exe/altを作成する。
* Chronos.exe/altをC:\Chronosに移動する
* `C:\Chronos\Chronos.conf`がなければ、「デフォルト動作」のテスト手順で作成する
* `C:\Chronos\MyChronos.conf`がなければ、「デフォルト動作」のテスト手順で作成する
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされて**いない**こと
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされて**いない**こと
* Chronosを終了する

#### `EnableUserConfig=0`指定時の動作

* `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf` を開く
*  `EnableUserConfig=1`を`EnableUserConfig=0`に変更する
* build.batを実行し、Chronos.exe/altを作成する。
* Chronos.exe/altをC:\Chronosに移動する
* `C:\Chronos\Chronos.conf`がなければ、「デフォルト動作」のテスト手順で作成する
* `C:\Chronos\MyChronos.conf`がなければ、「デフォルト動作」のテスト手順で作成する
* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「GPUレンダリングを有効にする」を確認する
  * [x] チェックされていること
* 画面表示設定の「PDF表示を有効にする」を確認する
  * [x] チェックされていること
* Chronosを終了する
