### PR TITLE
Add support for ChronosConfig command line argument to Chronos-SG modules

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -389,8 +389,8 @@ BOOL CSazabi::InitFunc_SGMode()
 		CString strCommandC;
 		CString strParam;
 
-		strCommandC.Format(_T("\"%s\" \"%s\""), (LPCTSTR)strSpCAppPath, (LPCTSTR)m_AppSettings.GetRootPath());
-		strParam.Format(_T("\"%s\""), (LPCTSTR)m_AppSettings.GetRootPath());
+		strParam.Format(_T("\"%s\" %s"), (LPCTSTR)m_AppSettings.GetRootPath(), (LPCTSTR)m_strConfigParam);
+		strCommandC.Format(_T("\"%s\" %s"), (LPCTSTR)strSpCAppPath, (LPCTSTR)strParam);
 		STARTUPINFO siC = {0};
 		PROCESS_INFORMATION piC = {0};
 		siC.cb = sizeof(siC);
@@ -1171,14 +1171,14 @@ void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 				strOpenPath = lpOpenPath;
 				strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
 				LPCTSTR mode = initMode == CHFILER_INIT_MODE::OPEN ? _T("") : _T("/Transfer");
-				strParam.Format(_T("%s \"%s\""), mode, (LPCTSTR)strOpenPath);
+				strParam.Format(_T("%s %s \"%s\""), mode, (LPCTSTR)m_strConfigParam, (LPCTSTR)strOpenPath);
 				strExecCommand.Format(_T("\"%sChFiler.exe\" %s"), (LPCTSTR)m_strExeFolderPath, (LPCTSTR)strParam);
 			}
 			else
 			{
 				strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
-				strExecCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
-				strParam = _T("");
+				strParam = m_strConfigParam;
+				strExecCommand.Format(_T("\"%sChFiler.exe\" %s"), (LPCTSTR)m_strExeFolderPath, (LPCTSTR)strParam);
 			}
 			CString strFrmWnd;
 			strFrmWnd = _T("CFiler:");
@@ -1297,8 +1297,8 @@ void CSazabi::OpenChTaskMgr()
 	}
 	CString strCommand;
 	CString strParam;
-	strCommand.Format(_T("\"%s\" /RESIDENT"), (LPCTSTR)strtSGPathResult);
-	strParam = _T("/RESIDENT");
+	strParam.Format(_T("/RESIDENT %s"), (LPCTSTR)m_strConfigParam);
+	strCommand.Format(_T("\"%s\" %s"), (LPCTSTR)strtSGPathResult, (LPCTSTR)strParam);
 	STARTUPINFO si = {0};
 	PROCESS_INFORMATION pi = {0};
 	si.cb = sizeof(si);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/274

# What this PR does / why we need it:

日本語ネイティブのみのChronosSGリポジトリを前提とした変更であるため、日本語にて記載する。

https://github.com/ThinBridge/Chronos/pull/293 にてChronosの設定ファイルを指定する`ChronosConfig`コマンドライン引数を追加したが、このパラメータは、`ChFiler.exe`、`ChTaskMgr.exe`、`SpC.exe`に反映されていなかった（渡されていなかった）。
本変更により、`Chronos.exe`に対して指定した設定ファイルがChronos-SG関連モジュールにも反映されるようになる。

# How to verify the fixed issue:

### 準備

* Chronos.zip を artifacts からダウンロードする
* https://github.com/ThinBridge/Chronos-SG/pull/415 のPRのブランチをチェックアウトする
* ダウンロードしたChronos.zipを元に、インストーラーを作成する
  * 手順: https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーでChronosをインストールする
* https://github.com/ThinBridge/Chronos-SG/pull/415 のPRのブランチのChronosSG_Projectを開く
  * ※インストーラー作成の手順で、最新のChronos関連モジュールがビルドされ、ChronosSG_Project配下に配置されている
* `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf` を開く
* `EnableCrashRecovery=0`を`EnableCrashRecovery=1`に変更しておく
* その他のパラメータは変更しない
  * 後々、EnableCrashRecoveryの値でChronosDefault.confが読み込まれているか確認するため。
* build.batを実行し、Chronos.exe/altを作成する。
* Chronos.exe/altをC:\Chronosに移動する
* `C:\Chronos\Chronos.conf`が存在する場合、削除する

### テスト

* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示されていること
* タスクマネージャーを起動する
  * [x] VOSのプロセスのみ表示されていること
  * [x] 表示が通常（詳細でない）であること
* Chronosを終了する
* `C:\Chronos\Chronos.conf`を作成する（空ファイル）
* `C:\Chronos\Chronos.conf`に`TASK_LIST_MODE_DETAIL=1`を記載する
* `C:\Chronos\Chronos.conf`に`LABEL_TYPE=2`を記載する
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル）
* `C:\Chronos\MyChronos.conf`に`TASK_LIST_TYPE=2`を記載する
* `C:\Chronos\MyChronos.conf`に`ShowUploadTab=0`を記載する
* Chronosをダブルクリックで起動する
  * [x] VOSのラベルが表示されること
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示されていること
  * [x] VOSのラベルが表示されること
* タスクマネージャーを起動する
  * ※VOSのラベルは表示されない
  * [x] VOSのプロセスのみ表示されていること
  * [x] 表示が詳細であること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] VOSのラベルが表示**されない**こと
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示**されない**こと
  * [x] VOSのラベルが表示**されない**こと
* タスクマネージャーを起動する
  * [x] VOS以外のプロセスも表示されていること
  * [x] 表示が通常（詳細でない）であること
* Chronosを終了する

### 複数のインスタンスの起動を許可している場合の挙動

Chronos-SG関連モジュールについては、以下のように設定が反映されるので、そのことを確認する。

ChTaskMgr（タスクマネージャー）については、最初に起動したときのChronosのパラメータが使用される。
これは、最初にChronosが起動した後、VOS上でChTaskMgrが常駐するからである。
なお、VOSラベル機能もChTaskMgrの機能なので、こちらで制御される。

ChFiler（ファイルマネージャー）については、起動時の最新のChronosDefault.conf+指定した設定がマージされた設定が使用される。
ここで注意すべきは、ChronosDefault.confについては、起動するたびに指定した設定ファイルがマージされていき、後続のChronosはそのChronosDefault.confを使用するという点。つまり、最後に起動したChronosは、今まで指定してきたすべての設定ファイルがマージされた状態のChronosDefault.confと、今回指定した設定ファイルがマージされるが使用される。
そのため、Chronos.confとMyChronos.confで異なるパラメータを指定していると、それぞれが独立にChronosDefault.confに反映される。なお、このようになるのは、Chronosの起動時の処理で、ChronosDefault.confと指定された設定ファイルをマージして、ChronosDefault.confとして保存するため。

ここでは、それを避けるために、Chronos.confとMyChronos.confで同じパラメータに別の値を明示的に指定する。
これにより、各Chronosは起動したときの設定が使用される。

* `C:\Chronos\Chronos.conf`を作成する（空ファイル）
* `C:\Chronos\Chronos.conf`に以下の記載を行う。
  ```
  EnableMultipleInstance=1
  TASK_LIST_MODE_DETAIL=1
  LABEL_TYPE=2
  TASK_LIST_TYPE=1
  ShowUploadTab=1
  ``` 
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル）
  ```
  EnableMultipleInstance=1
  TASK_LIST_MODE_DETAIL=0
  LABEL_TYPE=1
  TASK_LIST_TYPE=2
  ShowUploadTab=0
  ``` 
* Chronosをダブルクリックで起動する（インスタンスAとする）
  * [x] VOSのラベルが表示されること
* 設定画面を開く
* 全般機能の「インスタンスの二重起動を許可する」にチェックを入れる
* 設定画面を閉じる
* インスタンスAでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示されていること
* `ChronosN.exe -ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する（インスタンスBとする）
  * [x] 新しいChronosのインスタンスが起動すること
  * [x] VOSのラベルが表示されること
* インスタンスAでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示されていること
* ファイルマネージャーはそのままで、インスタンスBでファイルマネージャーを開く
  * [x] 既存のファイルマネージャーにフォーカスされること
  * [x] アップロードアイテムタブが表示されていること
* ファイルマネージャーを閉じる
* 改めてインスタンスBでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示**されない**こと
* インスタンスAでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示**されない**こと
* ファイルマネージャーを閉じる
* 改めてインスタンスAでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示されていること
* すべてのChronosのインスタンスを閉じる