### PR TITLE
Bump CEF version to 135.0.22+g442c600+chromium-135.0.7049.115

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=135.0.17+gcbc1c5b+chromium-135.0.7049.52
+VERSION=135.0.22+g442c600+chromium-135.0.7049.115
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_135.0.17+gcbc1c5b+chromium-135.0.7049.52_windows32_minimal
+  set CEFVER=cef_binary_135.0.22+g442c600+chromium-135.0.7049.115_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We should update CEF to the version using Chromium 135.0.7049.95+ because there is a vulnerability in Chromium 135.0.7049.95-.

https://chromereleases.googleblog.com/2025/04/stable-channel-update-for-desktop_15.html

This patch update CEF to the latest of the CEF135 line.

# How to verify the fixed issue:

* [x] Confirm that the build successes
* [x] Confirm that Chronos starts successfully

More detail tests will be done on pre-release tests. 