### PR TITLE
Fix a bug that ChFiler and SpC does not load a specified user config

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -389,7 +389,7 @@ BOOL CSazabi::InitFunc_SGMode()
 		CString strCommandC;
 		CString strParam;
 
-		strParam.Format(_T("\"%s\" %s"), (LPCTSTR)m_AppSettings.GetRootPath(), (LPCTSTR)m_strConfigParam);
+		strParam.Format(_T("\"%s\" %s"), (LPCTSTR)m_AppSettings.GetRootPath().TrimRight(_T("\\")), (LPCTSTR)m_strConfigParam);
 		strCommandC.Format(_T("\"%s\" %s"), (LPCTSTR)strSpCAppPath, (LPCTSTR)strParam);
 		STARTUPINFO siC = {0};
 		PROCESS_INFORMATION piC = {0};
@@ -1169,6 +1169,7 @@ void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 			if (lpOpenPath)
 			{
 				strOpenPath = lpOpenPath;
+				strOpenPath.TrimRight(_T("\\"));
 				strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
 				LPCTSTR mode = initMode == CHFILER_INIT_MODE::OPEN ? _T("") : _T("/Transfer");
 				strParam.Format(_T("%s %s \"%s\""), mode, (LPCTSTR)m_strConfigParam, (LPCTSTR)strOpenPath);

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -389,6 +389,13 @@ BOOL CSazabi::InitFunc_SGMode()
 		CString strCommandC;
 		CString strParam;
 
+		// https://github.com/ThinBridge/Chronos/pull/300
+		// 
+		// `SpC.exe "B:\" /ChronosConfig="path/to/config"`といったコマンドラインが作成された場合、`\"`がエスケープされ
+		// SpC.exeは`B:\" /ChronosConfig="path/to/config`という一つの引数を受け取る。先頭の`"`は文字列開始の`"`として
+		// 解釈され、対応する`"`がないので消えている。本来は`B:\`と`/ChronosConfig="path/to/config`という二つの引数となるべきである。
+		// これは、`\"`とならなければ回避可能である。そのため、フォルダーの末尾の`\`が存在すれば削除し、`\"`とならないようにしている。
+		// （なお、`\\"`としても回避可能ではある）
 		strParam.Format(_T("\"%s\" %s"), (LPCTSTR)m_AppSettings.GetRootPath().TrimRight(_T("\\")), (LPCTSTR)m_strConfigParam);
 		strCommandC.Format(_T("\"%s\" %s"), (LPCTSTR)strSpCAppPath, (LPCTSTR)strParam);
 		STARTUPINFO siC = {0};
@@ -1169,6 +1176,13 @@ void CSazabi::OpenChFiler(CHFILER_INIT_MODE initMode, LPCTSTR lpOpenPath)
 			if (lpOpenPath)
 			{
 				strOpenPath = lpOpenPath;
+				// https://github.com/ThinBridge/Chronos/pull/300
+				//
+				// `ChFiler.exe "B:\" /ChronosConfig="path/to/config"`といったコマンドラインが作成された場合、`\"`がエスケープされ
+				// ChFiler.exeは`B:\" /ChronosConfig="path/to/config`という一つの引数を受け取る。先頭の`"`は文字列開始の`"`として
+				// 解釈され、対応する`"`がないので消えている。本来は`B:\`と`/ChronosConfig="path/to/config`という二つの引数となるべきである。
+				// これは、`\"`とならなければ回避可能である。そのため、フォルダーの末尾の`\`が存在すれば削除し、`\"`とならないようにしている。
+				// （なお、`\\"`としても回避可能ではある）
 				strOpenPath.TrimRight(_T("\\"));
 				strCommand.Format(_T("\"%sChFiler.exe\""), (LPCTSTR)m_strExeFolderPath);
 				LPCTSTR mode = initMode == CHFILER_INIT_MODE::OPEN ? _T("") : _T("/Transfer");


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Chronos starts SpC.exe (ChFiler.exe) with a command line like below.

```
SpC.exe "B:\" /ChronosConfig=/path/to/config/file
```

In that case, SpC gets a single argument `B:" /ChronosConfig=/path/to/config/file` because `\"` is escaped to `"` and the first `"` is ignored as there is no corresponding `"`, but it is not intentional. Chronos wants to pass `B:\` and `/ChronosConfig=/path/to/config/file` to SpC.exe.
To avoid that behavior, this patch removes trailing `\`s when we specify folder path.


# How to verify the fixed issue:

### 準備

* Chronos.zip を artifacts からダウンロードする
* ダウンロードしたChronos.zipを元に、インストーラーを作成する
  * 手順: https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーでChronosをインストールする
* https://github.com/ThinBridge/Chronos-SG のChronosSG_Projectを開く
  * ※インストーラー作成の手順で、最新のChronos関連モジュールがビルドされ、ChronosSG_Project配下に配置されている
* `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf` を開く
* `EnableCrashRecovery=0`を`EnableCrashRecovery=1`に変更しておく
* その他のパラメータは変更しない
  * 後々、EnableCrashRecoveryの値でChronosDefault.confが読み込まれているか確認するため。
* build.batを実行し、Chronos.exe/altを作成する。
* Chronos.exe/altをC:\Chronosに移動する
* `C:\Chronos\Chronos.conf`が存在する場合、削除する

### テスト

* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示されていること
* タスクマネージャーを起動する
  * [x] VOSのプロセスのみ表示されていること
  * [x] 表示が通常（詳細でない）であること
* Chronosを終了する
* `C:\Chronos\Chronos.conf`を作成する（空ファイル）
* `C:\Chronos\Chronos.conf`に`TASK_LIST_MODE_DETAIL=1`を記載する
* `C:\Chronos\Chronos.conf`に`LABEL_TYPE=2`を記載する
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル）
* `C:\Chronos\MyChronos.conf`に`TASK_LIST_TYPE=2`を記載する
* `C:\Chronos\MyChronos.conf`に`ShowUploadTab=0`を記載する
* Chronosをダブルクリックで起動する
  * [x] VOSのラベルが表示されること
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示されていること
  * [x] VOSのラベルが表示されること
* タスクマネージャーを起動する
  * ※VOSのラベルは表示されない
  * [x] VOSのプロセスのみ表示されていること
  * [x] 表示が詳細であること
* Chronosを終了する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe /ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する
  * [x] VOSのラベルが表示**されない**こと
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示**されない**こと
  * [x] VOSのラベルが表示**されない**こと
* タスクマネージャーを起動する
  * [x] VOS以外のプロセスも表示されていること
  * [x] 表示が通常（詳細でない）であること
* Chronosを終了する

### 複数のインスタンスの起動を許可している場合の挙動

Chronos-SG関連モジュールについては、以下のように設定が反映されるので、そのことを確認する。

ChTaskMgr（タスクマネージャー）については、最初に起動したときのChronosのパラメータが使用される。
これは、最初にChronosが起動した後、VOS上でChTaskMgrが常駐するからである。
なお、VOSラベル機能もChTaskMgrの機能なので、こちらで制御される。

ChFiler（ファイルマネージャー）については、起動時の最新のChronosDefault.conf+指定した設定がマージされた設定が使用される。
ここで注意すべきは、ChronosDefault.confについては、起動するたびに指定した設定ファイルがマージされていき、後続のChronosはそのChronosDefault.confを使用するという点。つまり、最後に起動したChronosは、今まで指定してきたすべての設定ファイルがマージされた状態のChronosDefault.confと、今回指定した設定ファイルがマージされるが使用される。
そのため、Chronos.confとMyChronos.confで異なるパラメータを指定していると、それぞれが独立にChronosDefault.confに反映される。なお、このようになるのは、Chronosの起動時の処理で、ChronosDefault.confと指定された設定ファイルをマージして、ChronosDefault.confとして保存するため。

ここでは、それを避けるために、Chronos.confとMyChronos.confで同じパラメータに別の値を明示的に指定する。
これにより、各Chronosは起動したときの設定が使用される。

* `C:\Chronos\Chronos.conf`を作成する（空ファイル）
* `C:\Chronos\Chronos.conf`に以下の記載を行う。
  ```
  EnableMultipleInstance=1
  TASK_LIST_MODE_DETAIL=1
  LABEL_TYPE=2
  TASK_LIST_TYPE=1
  ShowUploadTab=1
  ``` 
* `C:\Chronos\MyChronos.conf`を作成する（空ファイル）
  ```
  EnableMultipleInstance=1
  TASK_LIST_MODE_DETAIL=0
  LABEL_TYPE=1
  TASK_LIST_TYPE=2
  ShowUploadTab=0
  ``` 
* Chronosをダブルクリックで起動する（インスタンスAとする）
  * [x] VOSのラベルが表示されること
* インスタンスAでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示されていること
* `ChronosN.exe /ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する（インスタンスBとする）
  * [x] 新しいChronosのインスタンスが起動すること
  * [x] VOSのラベルが表示されること
* インスタンスAでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示されていること
* ファイルマネージャーはそのままで、インスタンスBでファイルマネージャーを開く
  * [x] 既存のファイルマネージャーにフォーカスされること
  * [x] アップロードアイテムタブが表示されていること
* ファイルマネージャーを閉じる
* 改めてインスタンスBでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示**されない**こと
* ファイルマネージャーはそのままで、インスタンスAでファイルマネージャーを開く
  * [x] 既存のファイルマネージャーにフォーカスされること
  * [x] アップロードアイテムタブが表示**されない**こと
* ファイルマネージャーを閉じる
* 改めてインスタンスAでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示されていること
* すべてのChronosのインスタンスを閉じる
* `ChronosN.exe /ChronosConfig="C:\Chronos\MyChronos.conf"`でChronosを起動する（インスタンスCとする）
  * [x] VOSのラベルが表示**されない**こと
* インスタンスCでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示**されない**こと
  * [x] VOSのラベルが表示**されない**こと
* Chronosをダブルクリックで起動する（インスタンスDとする）
  * [x] VOSのラベルが表示**されない**こと
* ファイルマネージャーはそのままで、インスタンスDでファイルマネージャーを開く
  * [x] 既存のファイルマネージャーにフォーカスされること
  * [x] アップロードアイテムタブが表示**されない**こと
* ファイルマネージャーを閉じる
* 改めてインスタンスDでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示されること
* ファイルマネージャーはそのままで、インスタンスCでファイルマネージャーを開く
  * [x] 既存のファイルマネージャーにフォーカスされること
  * [x] アップロードアイテムタブが表示されること
* ファイルマネージャーを閉じる
* 改めてインスタンスCでファイルマネージャーを開く
  * [x] アップロードアイテムタブが表示**されない**こと
* すべてのChronosのインスタンスを閉じる