### PR TITLE
ChronosConfig: add support for values containing space

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -272,16 +272,6 @@ BOOL CSazabi::InitFunc_Settings()
 	// 設定データの初期値を読み込む
 	this->m_AppSettings.LoadDefaultData();
 
-	CString userConfigFilePath;
-	if (!m_strConfigParam.IsEmpty())
-	{
-		int pos = m_strConfigParam.Find(_T('='));
-		if (pos != -1)
-		{
-			userConfigFilePath = m_strConfigParam.Right(m_strConfigParam.GetLength() - pos - 1).Trim(_T('"'));
-		}
-	}
-
 	if (InVirtualEnvironment() == VE_NA)
 	{
 		// ネイティブ環境の場合、設定ファイルパスが指定されていればそちらから、
@@ -292,10 +282,10 @@ BOOL CSazabi::InitFunc_Settings()
 			this->m_AppSettings.LoadDataFromFile(m_strSettingFileFullPath);
 		}
 		if (theApp.m_AppSettings.IsEnableUserConfig() && 
-		    PathFileExists(userConfigFilePath))
+		    PathFileExists(m_strUserConfigFilePath))
 		{
 			theApp.m_AppSettings.LoadDefaultData();
-			this->m_AppSettings.LoadDataFromFile(userConfigFilePath);
+			this->m_AppSettings.LoadDataFromFile(m_strUserConfigFilePath);
 		}
 	}
 	else if (InVirtualEnvironment() == VE_THINAPP)
@@ -308,9 +298,9 @@ BOOL CSazabi::InitFunc_Settings()
 		if (theApp.m_AppSettings.IsEnableUserConfig())
 		{
 			// 更にChronos.confまたは指定されたファイルから設定を追加で読み込む
-			CString additionalConfigPath = userConfigFilePath.IsEmpty() ? 
+			CString additionalConfigPath = m_strUserConfigFilePath.IsEmpty() ? 
 				GetThinAppEntryPointFolderPath() + _T("Chronos.conf") : 
-				userConfigFilePath;
+				m_strUserConfigFilePath;
 			if (PathFileExists(additionalConfigPath))
 			{
 				this->m_AppSettings.LoadDataFromFile(additionalConfigPath);
@@ -965,7 +955,14 @@ void CSazabi::ParseSingleParam(CString param) {
 		}
 		else if (paramValue.Find(_T("chronosconfig")) == 0)
 		{
-			m_strConfigParam = trimmedParam;
+			int pos = trimmedParam.Find(_T('='));
+			if (pos != -1)
+			{
+				m_strUserConfigFilePath = trimmedParam.Right(trimmedParam.GetLength() - pos - 1).Trim(_T('"'));
+				// 引数解析の際に、パラメータで使用している""が削除される。
+				// そのため、ここで明示的に""を足す。
+				m_strConfigParam.Format(_T("/ChronosConfig=\"%s\""), (LPCTSTR)m_strUserConfigFilePath);
+			}
 		}
 	}
 	else if (SBUtil::IsURL(trimmedParam))

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -146,6 +146,7 @@ public:
 	CString m_strCommandParam;
 	CString m_strOptionParam;
 	CString m_strConfigParam;
+	CString m_strUserConfigFilePath;
 
 	BOOL m_bNewInstanceParam;
 	BOOL m_bTabWndChanging;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/274

# What this PR does / why we need it:

Windows argument parser removes `"` from arguments, for example, when we execute `Chronos.exe /ChronosConfig="foo bar.conf`, `Chronos.exe` gets `/ChronosConfig=foo bar.conf` as a command line argument. Then, `Chronos.exe` calls `SpC.exe` with `SpC.exe /ChronosConfig=foo bar.conf`. As a result, `SpC.exe` gets `/ChronosConfig=foo` and `bar.conf` as separated parameters. It is not our intended behavior. To avoid it, this patch add `"` to the `ChronosConfig` value.
# How to verify the fixed issue:

注意: Chronos本体は元々/ChronosConfigで空白を含んだファイルパスをサポートしている。本修正が影響するのはファイルマネージャーおよびタスクマネージャーである。

### 準備

* Chronos.zip を artifacts からダウンロードする
* https://github.com/ThinBridge/Chronos-SG/pull/418 のPRのブランチをチェックアウトする
* ダウンロードしたChronos.zipを元に、インストーラーを作成する
  * 手順: https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* 作成したインストーラーでChronosをインストールする
* https://github.com/ThinBridge/Chronos-SG/pull/418 のPRのブランチのChronosSG_Projectを開く
  * ※インストーラー作成の手順で、最新のChronos関連モジュールがビルドされ、ChronosSG_Project配下に配置されている
* `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf` を開く
* `EnableCrashRecovery=0`を`EnableCrashRecovery=1`に変更しておく
* その他のパラメータは変更しない
  * 後々、EnableCrashRecoveryの値でChronosDefault.confが読み込まれているか確認するため。
* build.batを実行し、Chronos.exe/altを作成する。
* Chronos.exe/altをC:\Chronosに移動する
* `C:\Chronos\Chronos.conf`が存在する場合、削除する

### テスト

* Chronosをダブルクリックで起動する
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示されていること
* タスクマネージャーを起動する
  * [x] VOSのプロセスのみ表示されていること
  * [x] 表示が通常（詳細でない）であること
* Chronosを終了する
* `C:\Chronos\My Chronos.conf`を作成する（空ファイル）
  * ファイル名に空白が含まれている点に注意
* `C:\Chronos\My Chronos.conf`に`TASK_LIST_TYPE=2`を記載する
* `C:\Chronos\My Chronos.conf`に`ShowUploadTab=0`を記載する
* コマンドプロンプトを起動する
* コマンドプロンプトで`C:\Chronos`に移動する
* `ChronosN.exe /ChronosConfig="C:\Chronos\My Chronos.conf"`でChronosを起動する
  * [x] VOSのラベルが表示**されない**こと
* 設定画面を開く
* 全般機能の「自動クラッシュを回復機能を有効にする」を確認する
  * [x] チェックされていること
* 設定画面を閉じる
* ファイルマネージャーを起動する
  * [x] アップロードアイテムタブが表示**されない**こと
  * [x] VOSのラベルが表示**されない**こと
* タスクマネージャーを起動する
  * [x] VOS以外のプロセスも表示されていること
  * [x] 表示が通常（詳細でない）であること
* Chronosを終了する
