### PR TITLE
ContextMenu: do not compare Flg to CM_MEDIATYPE_IMAGE

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -393,7 +393,7 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			CefString cefContextMenuSaveLinkLabel(contextMenuSaveLinkLabel);
 			model->InsertItemAt(3, CEF_MENU_ID_SAVE_FILE, cefContextMenuSaveLinkLabel);
 		}
-		if ((Flg & (CM_TYPEFLAG_MEDIA | CM_MEDIATYPE_IMAGE)) != 0)
+		if ((Flg & (CM_TYPEFLAG_MEDIA)) != 0)
 		{
 			if (!params->GetSourceUrl().empty())
 			{


### PR DESCRIPTION
# Which issue(s) this PR fixes:

This PR fixes a part of https://github.com/ThinBridge/Chronos/issues/304.

# What this PR does / why we need it:

Flg is a cef_context_menu_type_flags_t type but CM_MEDIATYPE_IMAGE is a cef_context_menu_media_type_t type. They should not be compared.

This patch makes no effects for runtime behavior.

# How to verify the fixed issue:

* Right click an image
  * [x] Confirm that "新しいタブを画像で開く" exists in the context menu
* Right click an audio. E.g. https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/audio
  * [x] Confirm that "新しいタブを画像で開く" exists in the context menu
  * Note: this is expected behavior because this patch makes no effects