### PR TITLE
ContextMenu: display print and reload only when we need them

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -353,8 +353,8 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 		model->Remove(commandId);
 	}
 	removeCommandIds.clear();
-	bool needReload = true;
-	bool needPrint = true;
+	bool addReloadItem = true;
+	bool addPrintItem = true;
 	cef_context_menu_type_flags_t Flg = CM_TYPEFLAG_NONE;
 	Flg = params->GetTypeFlags();
 	if ((Flg & (CM_TYPEFLAG_PAGE | CM_TYPEFLAG_FRAME)) != 0)
@@ -395,8 +395,8 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			CefString cefContextMenuSaveLinkLabel(contextMenuSaveLinkLabel);
 			model->InsertItemAt(3, CEF_MENU_ID_SAVE_FILE, cefContextMenuSaveLinkLabel);
 			
-			needReload = false;
-			needPrint = false;
+			addReloadItem = false;
+			addPrintItem = false;
 		}
 		if ((Flg & (CM_TYPEFLAG_MEDIA)) != 0)
 		{
@@ -447,8 +447,8 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 				CefString cefContextMenuCopyImgLinkLabel(contextMenuCopyImgLinkLabel);
 				model->AddItem(CEF_MENU_ID_IMG_COPY_LINK, cefContextMenuCopyImgLinkLabel);
 
-				needReload = false;
-				needPrint = false;
+				addReloadItem = false;
+				addPrintItem = false;
 			}
 		}
 		if (Flg & CM_TYPEFLAG_SELECTION)
@@ -470,18 +470,18 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 				model->InsertItemAt(0, CEF_MENU_ID_OPEN_SEARCH, strCFmt);
 			}
 
-			needReload = false;
-			needPrint = true;
+			addReloadItem = false;
+			addPrintItem = true;
 		}
 	}
-	if (needReload)
+	if (addReloadItem)
 	{
 		CString contextMenuReloadLabel;
 		contextMenuReloadLabel.LoadString(ID_CONTEXT_MENU_RELOAD);
 		CefString cefContextMenuReloadLabel(contextMenuReloadLabel);
 		model->AddItem(IDC_RELOAD, cefContextMenuReloadLabel);
 	}
-	if (needPrint)
+	if (addPrintItem)
 	{
 		CString contextMenuPrintLabel;
 		contextMenuPrintLabel.LoadString(ID_CONTEXT_MENU_PRINT);

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -353,6 +353,8 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 		model->Remove(commandId);
 	}
 	removeCommandIds.clear();
+	bool needReload = true;
+	bool needPrint = true;
 	cef_context_menu_type_flags_t Flg = CM_TYPEFLAG_NONE;
 	Flg = params->GetTypeFlags();
 	if ((Flg & (CM_TYPEFLAG_PAGE | CM_TYPEFLAG_FRAME)) != 0)
@@ -392,6 +394,9 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 			contextMenuSaveLinkLabel.LoadString(ID_CONTEXT_MENU_SAVE_LINK);
 			CefString cefContextMenuSaveLinkLabel(contextMenuSaveLinkLabel);
 			model->InsertItemAt(3, CEF_MENU_ID_SAVE_FILE, cefContextMenuSaveLinkLabel);
+			
+			needReload = false;
+			needPrint = false;
 		}
 		if ((Flg & (CM_TYPEFLAG_MEDIA)) != 0)
 		{
@@ -441,6 +446,9 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 				contextMenuCopyImgLinkLabel.LoadString(ID_CONTEXT_MENU_COPY_IMG_LINK);
 				CefString cefContextMenuCopyImgLinkLabel(contextMenuCopyImgLinkLabel);
 				model->AddItem(CEF_MENU_ID_IMG_COPY_LINK, cefContextMenuCopyImgLinkLabel);
+
+				needReload = false;
+				needPrint = false;
 			}
 		}
 		if (Flg & CM_TYPEFLAG_SELECTION)
@@ -461,18 +469,25 @@ void ClientHandler::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser,
 				CefString strCFmt(strFmt);
 				model->InsertItemAt(0, CEF_MENU_ID_OPEN_SEARCH, strCFmt);
 			}
+
+			needReload = false;
+			needPrint = true;
 		}
 	}
-
-	CString contextMenuReloadLabel;
-	contextMenuReloadLabel.LoadString(ID_CONTEXT_MENU_RELOAD);
-	CefString cefContextMenuReloadLabel(contextMenuReloadLabel);
-	model->AddItem(IDC_RELOAD, cefContextMenuReloadLabel);
-
-	CString contextMenuPrintLabel;
-	contextMenuPrintLabel.LoadString(ID_CONTEXT_MENU_PRINT);
-	CefString cefContextMenuPrintLabel(contextMenuPrintLabel);
-	model->AddItem(IDC_PRINT, cefContextMenuPrintLabel);
+	if (needReload)
+	{
+		CString contextMenuReloadLabel;
+		contextMenuReloadLabel.LoadString(ID_CONTEXT_MENU_RELOAD);
+		CefString cefContextMenuReloadLabel(contextMenuReloadLabel);
+		model->AddItem(IDC_RELOAD, cefContextMenuReloadLabel);
+	}
+	if (needPrint)
+	{
+		CString contextMenuPrintLabel;
+		contextMenuPrintLabel.LoadString(ID_CONTEXT_MENU_PRINT);
+		CefString cefContextMenuPrintLabel(contextMenuPrintLabel);
+		model->AddItem(IDC_PRINT, cefContextMenuPrintLabel);
+	}
 	
 	// メニュー項目調整後、Separatorが連続することがあるので、連続している場合は削除する。
 	count = model->GetCount();


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/346

# What this PR does / why we need it:

"Reload" in the context menu reloads all the page.
"Print" in the context menu for media and links prints all the page.
"Print" in the context menu for selected texts prints the selected texts.

Considering the above behavior, I think the following behavior is better.

||Media|Links|Selected texts|
|--|--|--|--|
|Reload|No|No|No|
|Print|No|No|YES|

# How to verify the fixed issue:

* Right click on a blank space on the page
  * [x] Confirm that "Reload" and "Print" are displayed in the context menu
* Right click on an image
  * [x] Confirm that "Reload" and "Print" are **not** displayed in the context menu
* Right click on an link
  * [x] Confirm that "Reload" and "Print" are **not** displayed in the context menu
* Right click on a selected text
  * [x] Confirm that "Reload" is **not** displayed in the context menu
  * [x] Confirm that "Print" is displayed in the context menu
