### PR TITLE
Disable popup on download

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -102,6 +102,8 @@ void ClientHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser)
 	requestContext->SetPreference("credentials_enable_service", value, error);
 	value->SetBool(false);
 	requestContext->SetPreference("profile.password_manager_enabled", value, error);
+	value->SetBool(false);
+	requestContext->SetPreference("download_bubble.partial_view_enabled", value, error);
 
 	//CEF126.2.7以降、disable-pdf-extensionオプションが非サポートになった。
 	//そのため、CEF126以降では、ClientHandler::OnAfterCreatedでPreferenceを指定することで同等の処理を行う。


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/284

# What this PR does / why we need it:

https://github.com/ThinBridge/Chronos/commit/8f6d2bc00f26aeb9a4a1a568510dc62c9de96b9e

After updating CEF from `135.0.17+gcbc1c5b+chromium-135.0.7049.52` to `135.0.22+g442c600+chromium-135.0.7049.115`, 
we get the following popup when downloading.

![image](https://github.com/user-attachments/assets/429540fd-45b1-45b7-808b-9331011bab42)

Chronos does not need it because Chronos implements the original file download dialog.
So suppress the CEF download popup.

Note: 

An animation after download is still displayed, I searched the way to suppress it, but I couldn't find.

Here is a sample video of the animation after download: 
See the left side of the video at 00:00:03

https://github.com/user-attachments/assets/e25eafd7-74a9-477a-8ec1-b09a39e9e86d

# How to verify the fixed issue:

* Download some file
  * [x] Confirm that the CEF download popup is not displayed

