### PR TITLE
Rename AllowToChangeFileExtension to EnableFileExtChangeRestriction

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -745,7 +745,7 @@ public:
 				}
 			}
 
-			if (!theApp.m_AppSettings.IsAllowToChangeFileExtension())
+			if (theApp.m_AppSettings.IsEnableFileExtChangeRestriction())
 			{
 				CString strSelExt = SBUtil::GetFileExt(strSelPath);
 				if (strSelExt.CompareNoCase(originalExt) != 0)

--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -1532,14 +1532,14 @@ BOOL CDlgSetCAP::OnInitDialog()
 		((CButton*)GetDlgItem(IDC_EnableUploadRestriction))->SetCheck(0);
 	}
 
-	// DisallowToChangeFileExtension
-	if (theApp.m_AppSettingsDlgCurrent.IsAllowToChangeFileExtension())
+	//EnableFileExtChangeRestriction
+	if (theApp.m_AppSettingsDlgCurrent.IsEnableFileExtChangeRestriction())
 	{
-		((CButton*)GetDlgItem(IDC_DisallowToChangeFileExtension))->SetCheck(0);
+		((CButton*)GetDlgItem(IDC_EnableFileExtChangeRestriction))->SetCheck(1);
 	}
 	else
 	{
-		((CButton*)GetDlgItem(IDC_DisallowToChangeFileExtension))->SetCheck(1);
+		((CButton*)GetDlgItem(IDC_EnableFileExtChangeRestriction))->SetCheck(0);
 	}
 
 	//running
@@ -1593,11 +1593,11 @@ LRESULT CDlgSetCAP::Set_OK(WPARAM wParam, LPARAM lParam)
 	else
 		theApp.m_AppSettingsDlgCurrent.SetEnableUploadRestriction(0);
 
-	// DisallowToChangeFileExtension
-	if (((CButton*)GetDlgItem(IDC_DisallowToChangeFileExtension))->GetCheck() == 1)
-		theApp.m_AppSettingsDlgCurrent.SetAllowToChangeFileExtension(0);
+	//EnableFileExtChangeRestriction
+	if (((CButton*)GetDlgItem(IDC_EnableFileExtChangeRestriction))->GetCheck() == 1)
+		theApp.m_AppSettingsDlgCurrent.SetEnableFileExtChangeRestriction(1);
 	else
-		theApp.m_AppSettingsDlgCurrent.SetAllowToChangeFileExtension(1);
+		theApp.m_AppSettingsDlgCurrent.SetEnableFileExtChangeRestriction(0);
 
 	//running
 	if (((CButton*)GetDlgItem(IDC_Enable_ProcessRunTime))->GetCheck() == 1)

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -501,7 +501,7 @@ BEGIN
     EDITTEXT        IDC_MemoryUsageLimit,83,119,52,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
     LTEXT           "タブ数 最大値",IDC_STATIC,11,142,64,8
     EDITTEXT        IDC_WindowCountLimit,84,140,52,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
-    CONTROL         "ファイルの拡張子の変更を禁止する",IDC_DisallowToChangeFileExtension,
+    CONTROL         "ファイルの拡張子の変更を禁止する",IDC_EnableFileExtChangeRestriction,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,43,177,10
 END
 
@@ -1916,7 +1916,7 @@ BEGIN
     EDITTEXT        IDC_MemoryUsageLimit,89,119,52,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
     LTEXT           "Maximum count of tabs",IDC_STATIC,11,142,77,8
     EDITTEXT        IDC_WindowCountLimit,89,140,52,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
-    CONTROL         "Forbid to change file extensions",IDC_DisallowToChangeFileExtension,
+    CONTROL         "Forbid to change file extensions",IDC_EnableFileExtChangeRestriction,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,8,43,177,10
 END
 

--- a/resource.h
+++ b/resource.h
@@ -406,7 +406,7 @@
 #define IDC_EnableUploadRestriction     1341
 #define IDC_Enable_ProcessRunTime       1342
 #define IDC_EnableDownloadRestriction   1343
-#define IDC_DisallowToChangeFileExtension 1344
+#define IDC_EnableFileExtChangeRestriction 1344
 #define IDC_EDIT_LIMIT_TIME             1345
 #define IDC_VOS_CLOSE_PROCESS           1346
 #define IDC_SHOW_DEV_TOOLS              1347

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -972,7 +972,7 @@ public:
 
 		EnableDownloadRestriction = 0;
 		EnableUploadRestriction = 0;
-		AllowToChangeFileExtension = 0;
+		EnableFileExtChangeRestriction = 0;
 		EnableRunningTime = 0;
 		RunningLimitTime = 0;
 		EnableURLRedirect = 0;
@@ -1061,7 +1061,7 @@ public:
 
 		Data.EnableDownloadRestriction = EnableDownloadRestriction;
 		Data.EnableUploadRestriction = EnableUploadRestriction;
-		Data.AllowToChangeFileExtension = AllowToChangeFileExtension;
+		Data.EnableFileExtChangeRestriction = EnableFileExtChangeRestriction;
 		Data.EnableRunningTime = EnableRunningTime;
 		Data.RunningLimitTime = RunningLimitTime;
 		Data.EnableURLRedirect = EnableURLRedirect;
@@ -1145,7 +1145,7 @@ private:
 	//制限設定
 	int EnableDownloadRestriction;
 	int EnableUploadRestriction;
-	int AllowToChangeFileExtension;
+	int EnableFileExtChangeRestriction;
 	int EnableRunningTime;
 	int RunningLimitTime;
 	int MemoryUsageLimit;
@@ -1259,7 +1259,7 @@ public:
 		//制限設定
 		EnableDownloadRestriction = FALSE;
 		EnableUploadRestriction = FALSE;
-		AllowToChangeFileExtension = TRUE;
+		EnableFileExtChangeRestriction = FALSE;
 
 		EnableRunningTime = FALSE;
 		RunningLimitTime = 1440;
@@ -1708,9 +1708,9 @@ public:
 					continue;
 				}
 
-				if (strTemp2.CompareNoCase(_T("AllowToChangeFileExtension")) == 0)
+				if (strTemp2.CompareNoCase(_T("EnableFileExtChangeRestriction")) == 0)
 				{
-					AllowToChangeFileExtension = (strTemp3 == _T("1")) ? TRUE : FALSE;
+					EnableFileExtChangeRestriction = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
 
@@ -2014,7 +2014,7 @@ public:
 		strRet += _T("# Restriction\n");
 		strRet += EXTVAL(EnableDownloadRestriction);
 		strRet += EXTVAL(EnableUploadRestriction);
-		strRet += EXTVAL(AllowToChangeFileExtension);
+		strRet += EXTVAL(EnableFileExtChangeRestriction);
 		strRet += EXTVAL(EnableRunningTime);
 		strRet += EXTVAL(RunningLimitTime);
 		strRet += EXTVAL(MemoryUsageLimit);
@@ -2138,7 +2138,7 @@ public:
 
 	inline BOOL IsEnableDownloadRestriction() { return EnableDownloadRestriction; }
 	inline BOOL IsEnableUploadRestriction() { return EnableUploadRestriction; }
-	inline BOOL IsAllowToChangeFileExtension() { return AllowToChangeFileExtension; }
+	inline BOOL IsEnableFileExtChangeRestriction() { return EnableFileExtChangeRestriction; }
 	inline BOOL IsEnableRunningTime() { return EnableRunningTime; }
 	inline int GetRunningLimitTime() { return RunningLimitTime; }
 
@@ -2235,7 +2235,7 @@ public:
 
 	inline void SetEnableDownloadRestriction(DWORD dVal) { EnableDownloadRestriction = dVal ? 1 : 0; }
 	inline void SetEnableUploadRestriction(DWORD dVal) { EnableUploadRestriction = dVal ? 1 : 0; }
-	inline void SetAllowToChangeFileExtension(DWORD dVal) { AllowToChangeFileExtension = dVal; }
+	inline void SetEnableFileExtChangeRestriction(DWORD dVal) { EnableFileExtChangeRestriction = dVal; }
 	inline void SetEnableRunningTime(DWORD dVal) { EnableRunningTime = dVal ? 1 : 0; }
 	inline void SetRunningLimitTime(DWORD dVal) { RunningLimitTime = dVal; }
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

[#365](https://github.com/ThinBridge/Chronos-SG/issues/365)

# What this PR does / why we need it:

As mentioned in https://github.com/ThinBridge/Chronos-SG/pull/426#discussion_r2102017015, using parameter names starting with `Allow...` does not match the labels displayed on the screen and makes the documentation less intuitive. Therefore, we will change the format to `Enable...Restriction`.

# How to verify the fixed issue:

## The steps to verify:

## SG-mode mode

### Preparation

* Download Chronos.zip from artifacts
* Checkout a branch of https://github.com/ThinBridge/Chronos-SG/pull/429
* Create an installer with downloaded Chronos.zip
  * https://github.com/ThinBridge/Chronos-SG/tree/main/Setup/ChronosSetup#%E4%BD%9C%E6%88%90%E6%B8%88%E3%81%BF%E3%81%AEchronos%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
* Install Chronos with created Chronos-installer
* Open ChronosSG_Project of https://github.com/ThinBridge/Chronos-SG/pull/429
  * In the installer creation procedure, the latest Chronos-related modules are built and placed under the ChronosSG_Project directory.
* Open `ChronosSG_Project\%drive_C%\Chronos\ChronosDefault.conf`
* Execute build.bat and create Chronos.exe/alt
* Move Chronos.exe/alt to `C:\Chronos`

### Tests

* Open the setting dialog
* Open "Restriction" setting 
* Enable (Check) "Forbid to change file extensions"
* Close the setting dialog with the OK button
* Try to download a file
* Save the file with no change
  * [x] Confirm that the file is downloaded
* Try to download a file
* Save the file with changing the file name
  * [x] Confirm that the file is downloaded
* Save the file with changing the file extension
  * [x] Confirm that a warning dialog with message "拡張子は変更できません。\n\n拡張子に[%s]を指定してください。" is displayed 
  * [x] Confirm that the file save dialog is re-opened 
  * [x] Confirm that the file is **not** downloaded
  * [x] Confirm that Chronos does not crash  
* Open the file manager
* Try to rename the downloaded file
* Rename the file with no change
  * [x] Confirm that the file is renamed
* Rename the file with changing the file name
  * [x] Confirm that the file is renamed
* Rename the file with changing the file extension
  * [x] Confirm that a warning dialog with message "拡張子は変更できません。\n\n拡張子に[%s]を指定してください。" is displayed 
  * [x] Confirm that the file is **not** renamed
* Close the file manager
* Open the setting dialog
* Open "Restriction" setting 
* Disable (Uncheck) "Forbid to change file extensions"
* Close the setting dialog with the OK button
* Try to download a file
* Save the file with no change
  * [x] Confirm that the file is downloaded
* Try to download a file
* Save the file with changing the file name
  * [x] Confirm that the file is downloaded
* Save the file with changing the file extension
  * [x] Confirm that the file is downloaded
* Open the file manager
* Try to rename the downloaded file
* Rename the file with no change
  * [x] Confirm that the file is renamed
* Rename the file with changing the file name
  * [x] Confirm that the file is renamed
* Rename the file with changing the file extension
  * [x] Confirm that the file is renamed
* Close the file manager
* Close Chronos
