### PR TITLE
Fix media access for Teams

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -2058,33 +2058,14 @@ bool ClientHandler::OnRequestMediaAccessPermission(
     uint32 requested_permissions,
     CefRefPtr<CefMediaAccessCallback> callback)
 {
-	if (requested_permissions == CEF_MEDIA_PERMISSION_NONE)
-		return false;
-
 	AppSettings::MediaAccessPermission permission = static_cast<AppSettings::MediaAccessPermission>(theApp.m_AppSettings.GetMediaAccessPermission());
-	switch (permission)
+	if (permission == AppSettings::MediaAccessPermission::NO_MEDIA_ACCESS)
 	{
-	case AppSettings::MediaAccessPermission::MANUAL_MEDIA_APPROVAL:
-		// 単にfalseでreturnすることでデフォルト動作をする。
-		// Chrome runtime styleモードでのデフォルト動作は「ユーザーによる承認」であり
-		// このパラメータの挙動と一致する。
-		// https://cef-builds.spotifycdn.com/docs/135.0/classCefPermissionHandler.html#a05723b8cdd0a3f410ea52d05e2a41e16
-		return false;
-	case AppSettings::MediaAccessPermission::DEFAULT_MEDIA_APPROVAL:
-		if (requested_permissions & CEF_MEDIA_PERMISSION_DESKTOP_AUDIO_CAPTURE ||
-		    requested_permissions & CEF_MEDIA_PERMISSION_DESKTOP_VIDEO_CAPTURE)
-		{
-			// callback->Continue(requested_permissions)すると、共有するウィンドウの選択ダイアログが表示されず
-			// 全画面が強制的に共有されてしまう。デフォルト動作であれば共有するウィンドウの選択がダイアログが
-			// 表示されるため、デスクトップオーディオまたはビデオのキャプチャを含む場合はデフォルト動作とする。
-			return false;
-		}
-		callback->Continue(requested_permissions);
-		return true;
-	default:
+		//OnShowPermissionPromptではなくOnRequestMediaAccessPermission内で拒否しないと、デスクトップ画面の共有が許可されてしまう。
 		callback->Continue(CEF_MEDIA_PERMISSION_NONE);
 		return true;
 	}
+	return false;
 }
 
 bool ClientHandler::OnShowPermissionPrompt(CefRefPtr<CefBrowser> browser,


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/434

# What this PR does / why we need it:

We could not enable camera and mic for Microsoft Teams when specifying `EnableMediaAccessPermission=2`.

We should use not OnRequestMediaAccessPermission but OnShowPermissionPrompt when specifying `EnableMediaAccessPermission=2`.

https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=20018

# How to verify the fixed issue: 

* Specify `EnableMediaAccessPermission=0` in ChronosDefault.conf
* Restart Chronos
* Open web meeting app on Chronos
  * [x] Confirm that no dialog for request permissions is displayed.
  * [x] Confirm that we can not use camera
  * [x] Confirm that we can not use mic
* Login to the meeting page
* Try to screen sharing
  * [x] Confirm that no dialog for request permissions is displayed.
    * Note that a host user must allow guest users to share screen on some meeting apps like Zoom
  * [x] Confirm that we can not share screen
* Stop Chronos
* Specify `EnableMediaAccessPermission=1` in ChronosDefault.conf
* Restart Chronos
* Open web meeting app on Chronos
  * [x] Confirm that a dialog for request camera permission is displayed.
    * [x] Confirm that we can use camera if we permit to use camera
    * [x] Confirm that we can not use camera if we don't permit to use camera
  * [x] Confirm that a dialog for request mic permission is displayed.
    * [x] Confirm that we can use mic if we permit to use mic
    * [x] Confirm that we can not use mic if we don't permit to use mic
* Login to the meeting page
* Try to screen sharing
  * [x] Confirm that a dialog to select window is displayed
    * Note that a host user must allow guest users to share screen on some meeting apps like Zoom
* Select "cancel"
  * [x] Confirm that we can not share screen
* Try to screen sharing
* Select "Window" tab
* Select a window to share
  * [x] Confirm that a selected window is shared
* Stop screen sharing
* Try to screen sharing
* Select "Full screen" tab
* Select a full screen
  * [x] Confirm that we can share the full screen
* Stop Chronos
* Specify `EnableMediaAccessPermission=2` in ChronosDefault.conf
* Restart Chronos
* Open web meeting app on Chronos
  * [x] Confirm that not dialog for request camera permission is displayed.
  * [x] Confirm that no dialog for request mic permission is displayed.
  * [x] Confirm that we can use camera
  * [x] Confirm that we can use mic
* Login to the meeting page
* Try to screen sharing
  * [x] Confirm that a dialog to select window is displayed
    * Note that a host user must allow guest users to share screen on some meeting apps like Zoom
* Select "cancel"
  * [x] Confirm that we can not share screen
* Try to screen sharing
* Select "Window" tab
* Select a window to share
  * [x] Confirm that a selected window is shared
* Stop screen sharing
* Try to screen sharing
* Select "Full screen" tab
* Select a full screen
  * [x] Confirm that we can share the full screen

Do the above test procedures in Jitsi, Zoom and Teams.

Note that the Teams screen sharing requires proprietary video codec, so we should use self built CEF: https://github.com/ThinBridge/Self-Build-CEF for Teams screen sharing.
