### PR TITLE
Add support drag and drop blocking

### DIFF
--- a/client_handler.h
+++ b/client_handler.h
@@ -181,9 +181,11 @@ public:
 				bool& suppress_message) override;
 
 	//CefDragHandler
+#if CHROME_VERSION_MAJOR < 135
 	virtual bool OnDragEnter(CefRefPtr<CefBrowser> browser,
 				 CefRefPtr<CefDragData> dragData,
 				 DragOperationsMask mask) override;
+#endif
 
 	virtual void OnResetDialogState(CefRefPtr<CefBrowser> browser) override;
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/433

# What this PR does / why we need it:

`ClientHandler::OnDragEnter` is not called on Chrome runtime style.
So blocking drag and drop with MFC function.

Note that the icon while dragging over is not "forbid icon" as before changed.
As far as I confirmed, we can not change the icon while draggind over if we use `RevokeDragDrop`.

After changed:

![image](https://github.com/user-attachments/assets/3caa4baf-6519-4bb2-ae68-1397a04cb9a4)

Before changed:

![image](https://github.com/user-attachments/assets/e64b9099-536e-4fc3-9e8f-bb55c8302539)


# How to verify the fixed issue:

## Native mode

* Specify `EnableDownloadRestriction=0` and `EnableUploadRestriction=0`
* Drag and drop an image to Chronos
  * [x] Confirm that we can drag and drop the image
* Specify `EnableDownloadRestriction=1` and `EnableUploadRestriction=0`
* Restart Chronos (or create new tab)
* Drag and drop an image to Chronos
  * [x] Confirm that we can **not** drag and drop the image
* Specify `EnableDownloadRestriction=0` and `EnableUploadRestriction=1`
* Restart Chronos (or create new tab)
* Drag and drop an image to Chronos
  * [x] Confirm that we can **not** drag and drop the image

## SG mode

* Specify `EnableDownloadRestriction=0` and `EnableUploadRestriction=0`
* Restart Chronos (or create new tab)
* Drag and drop an image to Chronos
  * [x] Confirm that we can **not** drag and drop the image

### Check if web contents that require drag and drop only on web works fine if drag and drop is disabled

* Open https://github.com/orgs/ThinBridge/projects/2 
* Move a panel to the other group with drag and drop
  * [x] Confirm that we can drag and drop the panel