### PR TITLE
Make Alt F4 shortcut key work

### DIFF
--- a/client_handler.h
+++ b/client_handler.h
@@ -48,7 +48,8 @@ class ClientHandler : public CefClient,
 		      public CefResourceRequestHandler,
 		      public CefJSDialogHandler,
 		      public CefDragHandler,
-		      public CefPermissionHandler
+		      public CefPermissionHandler,
+			  public CefKeyboardHandler
 {
 public:
 	// Interface implemented to handle off-screen rendering.
@@ -78,6 +79,7 @@ public:
 	virtual CefRefPtr<CefJSDialogHandler> GetJSDialogHandler() override { return this; }
 	virtual CefRefPtr<CefDragHandler> GetDragHandler() override { return this; }
 	virtual CefRefPtr<CefPermissionHandler> GetPermissionHandler() override { return this; }
+	virtual CefRefPtr<CefKeyboardHandler> GetKeyboardHandler() override { return this; }
 
 	// CefLifeSpanHandler methods
 	virtual bool DoClose(CefRefPtr<CefBrowser> browser) override;
@@ -199,6 +201,16 @@ public:
 					    const CefString& requesting_origin,
 					    uint32_t requested_permissions,
 					    CefRefPtr<CefPermissionPromptCallback> callback) override;
+	virtual bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
+					      CefRefPtr<CefFrame> frame,
+					      CefProcessId source_process,
+					      CefRefPtr<CefProcessMessage> message) override;
+#if CHROME_VERSION_MAJOR >= 135
+	virtual bool OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
+						  const CefKeyEvent& event,
+						  CefEventHandle os_event,
+						  bool* is_keyboard_shortcut) override;
+#endif
 
 	void EmptyWindowClose(CefRefPtr<CefBrowser> browser)
 	{
@@ -303,11 +315,6 @@ public:
 
 		return szText;
 	}
-	virtual bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
-					      CefRefPtr<CefFrame> frame,
-					      CefProcessId source_process,
-					      CefRefPtr<CefProcessMessage> message) override;
-
 	CString GetSerialNumberAsHexString(const CefRefPtr<CefX509Certificate> certificate);
 	CString GetSerialNumberAsHexString(PCERT_INFO pCertInfo);
 

--- a/client_handler.h
+++ b/client_handler.h
@@ -49,7 +49,7 @@ class ClientHandler : public CefClient,
 		      public CefJSDialogHandler,
 		      public CefDragHandler,
 		      public CefPermissionHandler,
-			  public CefKeyboardHandler
+		      public CefKeyboardHandler
 {
 public:
 	// Interface implemented to handle off-screen rendering.


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/436

# What this PR does / why we need it:

The Alt + F4 shortcut key should close all tabs but that shortcut key closed only one tab.
This patch fixed that bug.

# How to verify the fixed issue:

* Start Chronos
* Open setting dialog
* Check "Enable tab"
* Close setting dialog
* Open some tabs
* Input `Alt + F4`
  * [x] Confirm that a confirmation dialog "全てのタブを閉じますか?" is displayed.
* Click "No" of the confirmation dialog
  * [x] Confirm that an active tab does not close.
* Input `Alt + F4`
  * [x] Confirm that the confirmation dialog "全てのタブを閉じますか?" is displayed.
* Click "Yes" of the confirmation dialog
  * [x] Confirm that all tabs close and Chronos closes
* Start Chronos
* Open setting dialog
* Uncheck (disable) "Enable tab"
* Close setting dialog
* Start multiple Chronos windows
* Input `Alt + F4`
  * [x] Confirm that the confirmation dialog "全てのタブを閉じますか?" is **not** displayed.
  * [x] Confirm that only an active window(Chronos) closes