### PR TITLE
Add the disable-chrome-login-prompt

### DIFF
--- a/client_app.cpp
+++ b/client_app.cpp
@@ -35,6 +35,11 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 	//command_line->AppendSwitchWithValue(_T("disable-features"), _T("NetworkService"));
 	//2019-07-24 動くようになった。
 	//Chromium Embedded Framework Version 75.1.4+g4210896+chromium-75.0.3770.100
+
+	//Chrome runtime modeではdisable-chrome-login-promptを指定しないとGetAuthCredentialsが呼ばれず、
+	//Chromeのデフォルトのログインプロンプトが表示される。
+	//https://github.com/chromiumembedded/cef/issues/3603
+	command_line->AppendSwitch(_T("disable-chrome-login-prompt"));
 	
 #if CHROME_VERSION_MAJOR < 122
 	//CEF119: FirstPartySetsが有効だとYouTubeの検索窓にカーソルを合わせるとクラッシュする問題への対処。


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

In the Chrome runtime mode, if you do not specify disable-chrome-login-prompt, GetAuthCredentials will not be called and the Chrome login prompt will be displayed. At this time, the screen will become an error page.

![image](https://github.com/user-attachments/assets/dfa53de0-7d44-4b7a-9b7f-6955429a2308)

To avoid this, specify disable-chrome-login-prompt to display Chronos' original dialog.

![image](https://github.com/user-attachments/assets/7a0347f0-e205-42f5-ab68-724a6eb596a1)

Add the disable-chrome-login-prompt arg in order to enable GetAuthCredentials.

# How to verify the fixed issue:

## Setup Windows Authentication Web site

* Install IIS
  * Setup Windows Server
    * If you use Azure, don't forget to open port 80 on Azure console.
    * ![image](https://github.com/user-attachments/assets/3abc1056-0bf0-487c-9c25-19930a7cb0b5)
  * Start "Server Manager"
  * Select "Add Roles and Features"
  * Select "Web Server (IIS)" and proceed to the next step
  * On the "Select Role Services" screen, check "Windows Authentication"
    * Also select "Basic Authentication" and "Application Development" as needed
  * Complete the installation
* Enabling Windows Authentication
  * Start IIS Manager
  * Open "Internet Information Services (IIS) Manager"
  * Select the target website or application
  * Open the "Authentication" feature
  * Enable "Windows Authentication"
  * Disabling "Anonymous Authentication"
  * Restart website

## Test

* Access to the created web site by another machine
* [x] Confirm that the Chronos original authentication dialog is displayed.
  * ![image](https://github.com/user-attachments/assets/7a0347f0-e205-42f5-ab68-724a6eb596a1)
* Open https://www.google.com/
* Try to login to Google by "Login" button
  * [x] Confirm that Google login page is displayed.
  * [x] Confirm that  the Chronos original authentication dialog is **not** displayed.
* Open  https://azure.microsoft.com
* Try to sign in to Azure by "Sign in" button
  * [x] Confirm that Azure login page is displayed.
  * [x] Confirm that  the Chronos original authentication dialog is **not** displayed.