### PR TITLE
Bump version to 15.0.131.1

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -589,8 +589,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 15,0,131,0
- PRODUCTVERSION 15,0,131,0
+ FILEVERSION 15,0,131,1
+ PRODUCTVERSION 15,0,131,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -606,12 +606,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "15.0.131.0"
+            VALUE "FileVersion", "15.0.131.1"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "15.0.131.0"
+            VALUE "ProductVersion", "15.0.131.1"
         END
     END
     BLOCK "VarFileInfo"
@@ -1949,8 +1949,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 15,0,131,0
- PRODUCTVERSION 15,0,131,0
+ FILEVERSION 15,0,131,1
+ PRODUCTVERSION 15,0,131,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -1966,12 +1966,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "15.0.131.0"
+            VALUE "FileVersion", "15.0.131.1"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "15.0.131.0"
+            VALUE "ProductVersion", "15.0.131.1"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Bump version to 15.0.131.1


# How to verify the fixed issue:

* [x] Confirm that the versions in `[ヘルプ] -> [システム情報]` are 15.0.131.1.

![image](https://github.com/user-attachments/assets/1fe248d3-f142-4285-bf2b-97f745825f73)
