### PR TITLE
Add feature to specify CEF commandline opption with config file

### DIFF
--- a/client_app.cpp
+++ b/client_app.cpp
@@ -24,6 +24,19 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 {
 	PROC_TIME(OnBeforeCommandLineProcessing)
 
+	// 追加のコマンドラインオプションはこの時点で反映する。
+	// 値付きSwitchは後勝ちなので、Chronosの設定により指定された値付きSwitchが優先されるようにするため。
+	CString additionalCommandLine = theApp.m_AppSettings.GetAdditionalCefCommandLine();
+	if (!additionalCommandLine.IsEmpty())
+	{
+		CefString commandLineCefString = command_line->GetCommandLineString();
+		CString commandLineString((LPCWSTR)commandLineCefString.c_str());
+		commandLineString.Append(_T(" "));
+		commandLineString.Append(additionalCommandLine);
+		CefString newCommandLineCefString(commandLineString);
+		command_line->InitFromString(newCommandLineCefString);
+	}
+
 	//CEF131では、GoBackとGoForwardでキャッシュが有効だとFaviconが更新されない問題がある。
 	//そのため、キャッシュを無効化する。
 	//https://github.com/chromiumembedded/cef/issues/3874

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -26,15 +26,15 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 
 	// 追加のコマンドラインオプションはこの時点で反映する。
 	// 値付きSwitchは後勝ちなので、Chronosの設定により指定された値付きSwitchが優先されるようにするため。
-	CString additionalCommandLine = theApp.m_AppSettings.GetAdditionalCefCommandLine();
-	if (!additionalCommandLine.IsEmpty())
+	CString commandLineFromConfig = theApp.m_AppSettings.GetCEFCommandLine();
+	if (!commandLineFromConfig.IsEmpty())
 	{
-		CefString commandLineCefString = command_line->GetCommandLineString();
-		CString commandLineString((LPCWSTR)commandLineCefString.c_str());
-		commandLineString.Append(_T(" "));
-		commandLineString.Append(additionalCommandLine);
-		CefString newCommandLineCefString(commandLineString);
-		command_line->InitFromString(newCommandLineCefString);
+		CefString originalCommandLine = command_line->GetCommandLineString();
+		CString newCommandLine((LPCWSTR)originalCommandLine.c_str());
+		newCommandLine.Append(_T(" "));
+		newCommandLine.Append(commandLineFromConfig);
+		CefString newCommandLineAsCefString(newCommandLine);
+		command_line->InitFromString(newCommandLineAsCefString);
 	}
 
 	//CEF131では、GoBackとGoForwardでキャッシュが有効だとFaviconが更新されない問題がある。

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -962,6 +962,7 @@ public:
 		CustomBrowser4.Empty();
 		CustomBrowser5.Empty();
 		InitMessage.Empty();
+		AdditionalCefCommandLine.Empty();
 		ProxyAddress.Empty();
 		ProxyBypassAddress.Empty();
 		UserAgentAppendStr.Empty();
@@ -1052,6 +1053,7 @@ public:
 		Data.CustomBrowser4 = CustomBrowser4;
 		Data.CustomBrowser5 = CustomBrowser5;
 		Data.InitMessage = InitMessage;
+		Data.AdditionalCefCommandLine = AdditionalCefCommandLine;
 		Data.ProxyAddress = ProxyAddress;
 		Data.ProxyBypassAddress = ProxyBypassAddress;
 		Data.UserAgentAppendStr = UserAgentAppendStr;
@@ -1135,6 +1137,7 @@ private:
 	CString StartURL;
 	CString EnforceInitParam;
 	CString InitMessage;
+	CString AdditionalCefCommandLine;
 
 	//インターネット接続設定
 	int ProxyType;
@@ -1247,6 +1250,7 @@ public:
 		StartURL = _T("https://www.google.co.jp/");
 		EnforceInitParam = _T("");
 		InitMessage = _T("");
+		AdditionalCefCommandLine = _T("");
 
 		/////////////////////////////////////////////////////////////////////////////////////////////////
 		//インターネット接続設定
@@ -1454,7 +1458,11 @@ public:
 					InitMessage = strTemp3;
 					continue;
 				}
-
+				if (strTemp2.CompareNoCase(_T("AdditionalCefCommandLine")) == 0)
+				{
+					AdditionalCefCommandLine = strTemp3;
+					continue;
+				}
 				/////////////////////////////////////////////////////////
 				if (strTemp2.CompareNoCase(_T("RootPath")) == 0)
 				{
@@ -2074,6 +2082,7 @@ public:
 		strRet += EXTVAL(DisableOpendOpAlert);
 
 		strRet += _T("# non GUI parameters\n");
+		strRet += EXTVAL(AdditionalCefCommandLine);
 		strRet += EXTVAL(EnableMediaAccessPermission);
 		strRet += EXTVAL(UploadBasePath);
 		strRet += EXTVAL(ExitMessage);
@@ -2125,6 +2134,7 @@ public:
 			return StartURL;
 	}
 	inline CString GetEnforceInitParam() { return EnforceInitParam; }
+	inline CString GetAdditionalCefCommandLine() { return AdditionalCefCommandLine; }
 	inline CString GetCustomBrowser() { return CustomBrowser; }
 	inline CString GetCustomBrowser2() { return CustomBrowser2; }
 	inline CString GetCustomBrowser3() { return CustomBrowser3; }

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -962,7 +962,7 @@ public:
 		CustomBrowser4.Empty();
 		CustomBrowser5.Empty();
 		InitMessage.Empty();
-		AdditionalCefCommandLine.Empty();
+		CEFCommandLine.Empty();
 		ProxyAddress.Empty();
 		ProxyBypassAddress.Empty();
 		UserAgentAppendStr.Empty();
@@ -1053,7 +1053,7 @@ public:
 		Data.CustomBrowser4 = CustomBrowser4;
 		Data.CustomBrowser5 = CustomBrowser5;
 		Data.InitMessage = InitMessage;
-		Data.AdditionalCefCommandLine = AdditionalCefCommandLine;
+		Data.CEFCommandLine = CEFCommandLine;
 		Data.ProxyAddress = ProxyAddress;
 		Data.ProxyBypassAddress = ProxyBypassAddress;
 		Data.UserAgentAppendStr = UserAgentAppendStr;
@@ -1137,7 +1137,7 @@ private:
 	CString StartURL;
 	CString EnforceInitParam;
 	CString InitMessage;
-	CString AdditionalCefCommandLine;
+	CString CEFCommandLine;
 
 	//インターネット接続設定
 	int ProxyType;
@@ -1250,7 +1250,7 @@ public:
 		StartURL = _T("https://www.google.co.jp/");
 		EnforceInitParam = _T("");
 		InitMessage = _T("");
-		AdditionalCefCommandLine = _T("");
+		CEFCommandLine = _T("");
 
 		/////////////////////////////////////////////////////////////////////////////////////////////////
 		//インターネット接続設定
@@ -1458,9 +1458,9 @@ public:
 					InitMessage = strTemp3;
 					continue;
 				}
-				if (strTemp2.CompareNoCase(_T("AdditionalCefCommandLine")) == 0)
+				if (strTemp2.CompareNoCase(_T("CEFCommandLine")) == 0)
 				{
-					AdditionalCefCommandLine = strTemp3;
+					CEFCommandLine = strTemp3;
 					continue;
 				}
 				/////////////////////////////////////////////////////////
@@ -2082,7 +2082,7 @@ public:
 		strRet += EXTVAL(DisableOpendOpAlert);
 
 		strRet += _T("# non GUI parameters\n");
-		strRet += EXTVAL(AdditionalCefCommandLine);
+		strRet += EXTVAL(CEFCommandLine);
 		strRet += EXTVAL(EnableMediaAccessPermission);
 		strRet += EXTVAL(UploadBasePath);
 		strRet += EXTVAL(ExitMessage);
@@ -2134,7 +2134,7 @@ public:
 			return StartURL;
 	}
 	inline CString GetEnforceInitParam() { return EnforceInitParam; }
-	inline CString GetAdditionalCefCommandLine() { return AdditionalCefCommandLine; }
+	inline CString GetCEFCommandLine() { return CEFCommandLine; }
 	inline CString GetCustomBrowser() { return CustomBrowser; }
 	inline CString GetCustomBrowser2() { return CustomBrowser2; }
 	inline CString GetCustomBrowser3() { return CustomBrowser3; }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/317

# What this PR does / why we need it:

Add a new config parameter "CEFCommandLine" which enables to specify additional CEF commandline options.

Usage:

```
CEFCommandLine=--proxy-server=127.0.0.1:3128 --disable-back-forward-cache
```

Parameters specified internally by Chronos are used with priority.

We can specify any options with `CEFCommandLine`, but the switches and arguments specified internally by Chronos cannot be overwritten.

# How to verify the fixed issue:

## The steps to verify:

* Open ChronosDefault.conf
* Specify `--proxy-server=127.0.0.1:8080` to `CEFCommandLine` (`127.0.0.1:8080` is a invalid proxy server URL)
    ``` 
    CEFCommandLine=--proxy-server=127.0.0.1:8080
    ```
* Start Chronos.exe
  * [x] Confirm that an error "Not connected to internet" are displayed. 
  <img width="1396" height="719" alt="image" src="https://github.com/user-attachments/assets/b9c6504f-aed9-4efa-9477-67f3f2ff0bc8" />
* Close Chronos.exe
* Open ChronosDefault.conf
* Specify empty to `CEFCommandLine`
    ``` 
    CEFCommandLine=
    ```
* Start Chronos.exe
  * [x] Confirm that a top page is displayed 
* Close Chronos.exe

