### PR TITLE
Fix mutex name typo

### DIFF
--- a/Sazabi.h
+++ b/Sazabi.h
@@ -49,7 +49,7 @@
 	{                                                                      \
 		hMutex = {0};                                                      \
 		dwWaitResult = WAIT_FAILED;                                        \
-		hMutex = ::CreateMutex(NULL, FALSE, _T("Chronos_Gobal_Mutex"));    \
+		hMutex = ::CreateMutex(NULL, FALSE, _T("Chronos_Global_Mutex"));    \
 		if (hMutex)                                                        \
 		{                                                                  \
 			dwWaitResult = WaitForSingleObject(hMutex, waitMilliSec);      \


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

`Chronos_Gobal_Mutex` seems typo of `Chronos_Global_Mutex`.

# How to verify the fixed issue:

* [x] Confirm that all actions pass.