### PR TITLE
Revise maximum number of tabs

### DIFF
--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -1567,7 +1567,7 @@ BOOL CDlgSetCAP::OnInitDialog()
 
 	//ウィンドウ数 最大値
 	iW = theApp.m_AppSettingsDlgCurrent.GetWindowCountLimit();
-	if (iW < 1)
+	if (iW < 1 || iW > 999)
 		iW = 999;
 	SetDlgItemInt(IDC_WindowCountLimit, iW);
 
@@ -1621,7 +1621,7 @@ LRESULT CDlgSetCAP::Set_OK(WPARAM wParam, LPARAM lParam)
 
 	//ウィンドウ数 最大値
 	iW = GetDlgItemInt(IDC_WindowCountLimit);
-	if (iW < 1)
+	if (iW < 1 || iW > 999)
 		iW = 999;
 	theApp.m_AppSettingsDlgCurrent.SetWindowCountLimit(iW);
 

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1686,7 +1686,7 @@ public:
 				{
 					int iW = 0;
 					iW = _ttoi(strTemp3);
-					if (0 <= iW && iW <= 4096)
+					if (0 <= iW && iW <= 999)
 						WindowCountLimit = iW;
 					else
 						WindowCountLimit = 999;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

> Describe issue number. If issue doesn't exist, fill N/A.

https://github.com/ThinBridge/Chronos-SG/issues/316

# What this PR does / why we need it:

> Explain the detail of the problem.

Limit the number of tabs to open concurrently to 999, as many as documentation.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Start Chronos
2. Open "設定"
3. Change "タブ数 最大値" in "機能制限設定" to 1000 from the default value of 60, then click [OK]

## Expected result:

> Describe the obvious situation to verify.

* [x] The value sets as 999
