### PR TITLE
Limit MemoryUsageLimit to 4096

### DIFF
--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -1561,7 +1561,7 @@ BOOL CDlgSetCAP::OnInitDialog()
 	int iW = 0;
 	//メモリー 最大値(MB)
 	iW = theApp.m_AppSettingsDlgCurrent.GetMemoryUsageLimit();
-	if (iW < 1)
+	if (iW < 1 || iW > 4096)
 		iW = 1224;
 	SetDlgItemInt(IDC_MemoryUsageLimit, iW);
 
@@ -1615,7 +1615,7 @@ LRESULT CDlgSetCAP::Set_OK(WPARAM wParam, LPARAM lParam)
 	int iW = 0;
 	//メモリー 最大値(MB)
 	iW = GetDlgItemInt(IDC_MemoryUsageLimit);
-	if (iW < 1)
+	if (iW < 1 || iW > 4096)
 		iW = 1224;
 	theApp.m_AppSettingsDlgCurrent.SetMemoryUsageLimit(iW);
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

> Describe issue number. If issue doesn't exist, fill N/A.

https://github.com/ThinBridge/Chronos-SG/issues/353

# What this PR does / why we need it:

> Explain the detail of the problem.

Limit the maximum memory size to 4096 MB as specified in documentation.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Start Chronos
2. Open "設定"
3. Change "メモリー 最大値(MB)" in "機能制限設定" to 4097 from the default value of 2048, then click [OK]

## Expected result:

> Describe the obvious situation to verify.

* [x] The value sets as 1224 as a fallback
