### PR TITLE
Substitute m_strURL only when it is a main frame.

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1936,7 +1936,6 @@ LRESULT CChildView::OnBeforeBrowse(WPARAM wParam, LPARAM lParam)
 	if (wParam)
 	{
 		CString strURL((LPCTSTR)wParam);
-		m_strURL = strURL;
 		if (!strURL.IsEmpty())
 		{
 			BOOL bTopPage = FALSE;
@@ -1952,6 +1951,7 @@ LRESULT CChildView::OnBeforeBrowse(WPARAM wParam, LPARAM lParam)
 				if (*pbRet == 1)
 				{
 					bTopPage = TRUE;
+					m_strURL = strURL;
 				}
 			}
 			DebugWndLogData dwLogData;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/483

This is also related to https://github.com/ThinBridge/Chronos-SG/issues/106.

# What this PR does / why we need it:

https://github.com/ThinBridge/Chronos/pull/255 has changed output URLs of access audit logs.
Before https://github.com/ThinBridge/Chronos/pull/255 has been merged, the output URL had been "a main frame URL (URL in address bar)".
However, after https://github.com/ThinBridge/Chronos/pull/255 has been merged, the output URL has been changed to "a last loaded sub frame URL in a main frame".

For example, when we access  https://www.yahoo.co.jp/, current Chronos output a URL like below as access audit log:

```
BODY: {"operation": "browsing","pcname": "TH-NOTE-PC","userid": "TH-NOTE-PC\\hashi","name": "Yahoo! JAPAN","url": "https:\/\/476e3506db2178f94c997b523ec3b680.safeframe.googlesyndication.com\/safeframe\/1-0-45\/html\/container.html","time": "2025-11-13 16:22:59"}
```

In this case, `"url": "https:\/\/476e3506db2178f94c997b523ec3b680.safeframe.googlesyndication.com\/safeframe\/1-0-45\/html\/container.html"` should be `"url": "https:\/\/www.yahoo.co.jp"`.

# How to verify the fixed issue:

## The steps to verify:

# How to verify the fixed issue:

* Start [httpsserver.ps1](https://github.com/ThinBridge/Chronos-SG/blob/main/Documents/Tools/httpserver.ps1) (web server for test) with Powershell
* Start Chronos
* Open "設定" -> "ログ出力設定"
* Check "監査ログ出力を有効にする"
* Specify "http://localhost:8001" to "ログサーバーURL"
* Check "閲覧履歴を記録する"
* Click "OK" button
* Open https://www.google.co.jp/
  * [x] Confirm that the web page is displayed correctly
* Confirm Powershell prompt
  * [x] Confirm that the audit log like below is output, especially confirm url is correct
    ```
    GET: /?operation=browsing&pcname=TH-NOTE-PC&userid=TH-NOTE-PC%5Chashi&name=www.google.co.jp&url=https%3A%2F%2Fwww.google.co.jp%2F&time=2024-12-13%2016%3A00%3A14
    Cache-Control: no-cache
    Connection: Keep-Alive
    Pragma: no-cache
    Host: localhost:8001
    User-Agent: CSGAgent
    ```
* Open http://example.jp in the same tab
* Confirm Powershell prompt
  * [x] Confirm that the audit log like below is output, especially confirm url is correct
    ```
    GET: /?operation=browsing&pcname=TH-NOTE-PC&userid=TH-NOTE-PC%5Chashi&name=%E3%82%A8%E3%83%A9%E3%83%BC%3A%20%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%81%95%E3%82%8C%E3%81%9F%20URL%20%E3%81%AF%E5%8F%96%E5%BE%97%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%9B%E3%82%93%E3%81%A7%E3%81%97%E3%81%9F&url=http%3A%2F%2Fexample.jp%2F&time=2024-12-13%2016%3A10%3A54
    Cache-Control: no-cache
    Connection: Keep-Alive
    Pragma: no-cache
    Host: localhost:8001
    User-Agent: CSGAgent
    ```
* Open https://www.yahoo.co.jp/
* Confirm Powershell prompt
  * [x] Confirm that the audit log like below is output, especially confirm url is  https://www.yahoo.co.jp/
     ```
     GET: /?operation=browsing&pcname=TH-NOTE-PC&userid=TH-NOTE-PC%5Chashi&name=Yahoo!%20JAPAN&url=https%3A%2F%2Fwww.yahoo.co.jp%2F&time=2025-11-13%2016%3A41%3A29
     Cache-Control: no-cache
     Connection: Keep-Alive
     Pragma: no-cache
     Host: localhost:8001
     User-Agent: CSGAgent
     ```
