### PR TITLE
Specify upload log url type

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -1940,7 +1940,7 @@ LRESULT CChildView::OnBeforeBrowse(WPARAM wParam, LPARAM lParam)
 		{
 			BOOL bTopPage = FALSE;
 			UINT* pbRet = NULL;
-			m_strLastBrowsedURL == strURL;
+			m_strLastBrowsedURL = strURL;
 
 			//TOPページ(Frameなし)
 			if (lParam)

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -302,11 +302,11 @@ void CChildView::UpDateAddressBar()
 {
 	if (theApp.IsWnd(FRM))
 	{
-		if (this->m_UpDateAddressBarURL_Cache != m_strURL)
+		if (this->m_UpDateAddressBarURL_Cache != m_strTopPageURL)
 		{
-			if (FRM->OnSetUrlString((LPCTSTR)m_strURL))
+			if (FRM->OnSetUrlString((LPCTSTR)m_strTopPageURL))
 			{
-				this->m_UpDateAddressBarURL_Cache = m_strURL;
+				this->m_UpDateAddressBarURL_Cache = m_strTopPageURL;
 			}
 		}
 	}
@@ -1477,7 +1477,7 @@ void CChildView::OnUpdatePaste(CCmdUI* pCmdUI)
 }
 void CChildView::OnAppAbout()
 {
-	theApp.m_strCurrentURL4DlgSetting = m_strURL;
+	theApp.m_strCurrentURL4DlgSetting = m_strTopPageURL;
 	CAboutDlg aboutDlg(this);
 	aboutDlg.pParentFrm = m_pwndFrame;
 	aboutDlg.DoModal();
@@ -1488,7 +1488,7 @@ void CChildView::OnSettings()
 	CString logmsg;
 	logmsg.Format(_T("CV_WND:0x%08p OnSettings"), theApp.SafeWnd(this->m_hWnd));
 	theApp.WriteDebugTraceDateTime(logmsg, DEBUG_LOG_TYPE_AC);
-	theApp.m_strCurrentURL4DlgSetting = m_strURL;
+	theApp.m_strCurrentURL4DlgSetting = m_strTopPageURL;
 	theApp.ShowSettingDlg(m_pwndFrame);
 }
 void CChildView::OnBroBack(UINT nID)
@@ -1936,11 +1936,11 @@ LRESULT CChildView::OnBeforeBrowse(WPARAM wParam, LPARAM lParam)
 	if (wParam)
 	{
 		CString strURL((LPCTSTR)wParam);
-		m_strURL = strURL;
 		if (!strURL.IsEmpty())
 		{
 			BOOL bTopPage = FALSE;
 			UINT* pbRet = NULL;
+			m_strLastBrowsedURL == strURL;
 
 			//TOPページ(Frameなし)
 			if (lParam)
@@ -1952,6 +1952,7 @@ LRESULT CChildView::OnBeforeBrowse(WPARAM wParam, LPARAM lParam)
 				if (*pbRet == 1)
 				{
 					bTopPage = TRUE;
+					m_strTopPageURL = strURL;
 				}
 			}
 			DebugWndLogData dwLogData;
@@ -2086,7 +2087,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 	}
 	if (theApp.m_AppSettings.IsEnableLogging() && theApp.m_AppSettings.IsEnableBrowsingLogging())
 	{
-		if (SBUtil::IsURL_HTTP(m_strURL))
+		if (SBUtil::IsURL_HTTP(m_strTopPageURL))
 		{
 			CString strHost;
 			strHost = m_strTitle;
@@ -2096,7 +2097,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 			if (strHost.IsEmpty())
 			{
 				CefURLParts cfURLpa;
-				CefString cefURL(m_strURL);
+				CefString cefURL(m_strTopPageURL);
 				if (CefParseURL(cefURL, cfURLpa))
 				{
 					CefString cfHost(&cfURLpa.host);
@@ -2104,7 +2105,7 @@ LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 				}
 			}
 			if (theApp.m_pLogDisp)
-				theApp.m_pLogDisp->SendLog(LOG_BROWSING, strHost, m_strURL);
+				theApp.m_pLogDisp->SendLog(LOG_BROWSING, strHost, m_strTopPageURL);
 		}
 	}
 
@@ -2268,7 +2269,7 @@ LRESULT CChildView::OnSetRendererPID(WPARAM wParam, LPARAM lParam)
 LRESULT CChildView::OnAddressChange(WPARAM wParam, LPARAM lParam)
 {
 	CString strURL((LPCTSTR)wParam);
-	m_strURL = strURL;
+	m_strTopPageURL = strURL;
 	UpDateAddressBar();
 	if (!strURL.IsEmpty())
 	{

--- a/BroView.h
+++ b/BroView.h
@@ -24,7 +24,8 @@ public:
 	void SetWheelZoom(int iDel);
 	double m_dbZoomSize;
 	double m_dbZoomSizeDefault;
-	CString m_strURL;
+	CString m_strTopPageURL;
+	CString m_strLastBrowsedURL;
 	//scale = 100 * 1.2^zoomSize -> zoomSize = log1.2_(scale / 100)
 	//https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=11491
 	//ここでは敢えて昇順に宣言しているが、std::mapは実際の宣言順に関わらず昇順になる点に注意。
@@ -91,6 +92,19 @@ public:
 		{
 			CefString strURL;
 			strURL = m_cefBrowser->GetMainFrame()->GetURL();
+			strRet = (LPCWSTR)strURL.c_str();
+		}
+		return strRet;
+	}
+	CString GetFocusedFrameURL()
+	{
+		CString strRet;
+		if (IsBrowserNull())
+			return strRet;
+		if (m_cefBrowser->GetFocusedFrame())
+		{
+			CefString strURL;
+			strURL = m_cefBrowser->GetFocusedFrame()->GetURL();
 			strRet = (LPCWSTR)strURL.c_str();
 		}
 		return strRet;

--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -648,6 +648,7 @@ CDlgSetLog::CDlgSetLog() : CPropertyPage(CDlgSetLog::IDD)
 void CDlgSetLog::DoDataExchange(CDataExchange* pDX)
 {
 	CPropertyPage::DoDataExchange(pDX);
+	DDX_Control(pDX, IDC_UPLOAD_LOGGING_URL_TYPE_COMBO, m_ComboUploadLoggingType);
 	//{{AFX_DATA_MAP(CDlgSetLog)
 	//}}AFX_DATA_MAP
 }
@@ -698,6 +699,7 @@ void CDlgSetLog::OnEnableLogging()
 		GetDlgItem(IDC_CHECK_ENABLE_UPLOAD_LOG)->EnableWindow(TRUE);
 		GetDlgItem(IDC_CHECK_EnableBrowsingLogging)->EnableWindow(TRUE);
 		GetDlgItem(IDC_CHECK_EnableAccessAllLogging)->EnableWindow(TRUE);
+		m_ComboUploadLoggingType.EnableWindow(TRUE);
 	}
 	else
 	{
@@ -709,6 +711,7 @@ void CDlgSetLog::OnEnableLogging()
 		GetDlgItem(IDC_CHECK_ENABLE_UPLOAD_LOG)->EnableWindow(FALSE);
 		GetDlgItem(IDC_CHECK_EnableBrowsingLogging)->EnableWindow(FALSE);
 		GetDlgItem(IDC_CHECK_EnableAccessAllLogging)->EnableWindow(FALSE);
+		m_ComboUploadLoggingType.EnableWindow(FALSE);
 	}
 	return;
 }
@@ -782,6 +785,14 @@ BOOL CDlgSetLog::OnInitDialog()
 	else
 		((CButton*)GetDlgItem(IDC_CHECK_EnableAccessAllLogging))->SetCheck(0);
 
+	size_t labelIdArraySize = sizeof(kUploadLoggingTypeLabelIdArray) / sizeof(kUploadLoggingTypeLabelIdArray[0]);
+	for (size_t i = 0; i < labelIdArraySize; i++)
+	{
+		CString label;
+		label.LoadString(kUploadLoggingTypeLabelIdArray[i]);
+		m_ComboUploadLoggingType.AddString(label);
+	}
+	m_ComboUploadLoggingType.SetCurSel(theApp.m_AppSettingsDlgCurrent.GetUploadLoggingURLType());
 	OnEnableLog();
 	OnEnableLogging();
 	return FALSE;
@@ -854,6 +865,8 @@ LRESULT CDlgSetLog::Set_OK(WPARAM wParam, LPARAM lParam)
 		theApp.m_AppSettingsDlgCurrent.SetEnableLogging(1);
 	else
 		theApp.m_AppSettingsDlgCurrent.SetEnableLogging(0);
+
+	theApp.m_AppSettingsDlgCurrent.SetUploadLoggingURLType(m_ComboUploadLoggingType.GetCurSel());
 	return 0;
 }
 

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -339,6 +339,12 @@ class CDlgSetLog : public CPropertyPage
 {
 	DECLARE_DYNCREATE(CDlgSetLog)
 public:
+	static constexpr int kUploadLoggingTypeLabelIdArray[] = {
+		IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED,
+		IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE,
+		IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME
+	};
+
 	CDlgSetLog();
 	//{{AFX_DATA(CDlgSetTab1)
 #pragma warning(push)
@@ -351,6 +357,7 @@ public:
 	};
 #pragma warning(pop)
 	//}}AFX_DATA
+	CComboBox m_ComboUploadLoggingType;
 
 	// オーバーライド
 	// ClassWizard は仮想関数のオーバーライドを生成します。

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -669,7 +669,23 @@ void CSazabi::SendLoggingMsg(int LOG_TYPE, LPCTSTR lpFileName, HWND hWnd)
 	{
 		if (IsWnd(&pFrame->m_wndView))
 		{
-			strURL = pFrame->m_wndView.m_strURL;
+			AppSettings::EnumUploadLoggingURLType urlType = static_cast<AppSettings::EnumUploadLoggingURLType>(m_AppSettings.GetUploadLoggingURLType());
+			if (urlType == AppSettings::EnumUploadLoggingURLType::LAST_BROWSED_URL)
+			{
+				strURL = pFrame->m_wndView.m_strLastBrowsedURL;
+			}
+			else if (urlType == AppSettings::EnumUploadLoggingURLType::MAIN_FRAME)
+			{
+				strURL = pFrame->m_wndView.m_strTopPageURL;
+			}
+			else if (urlType == AppSettings::EnumUploadLoggingURLType::ACTIVE_FRAME)
+			{
+				strURL = pFrame->m_wndView.GetFocusedFrameURL();
+			}
+			if (!strURL)
+			{
+				strURL = pFrame->m_wndView.m_strTopPageURL;
+			}
 			if (m_pLogDisp)
 			{
 				m_pLogDisp->SendLog(LOG_TYPE, strFileName, strURL);

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -259,9 +259,10 @@ BEGIN
     CONTROL         "GET:URLクエリパラメータ形式",IDC_RADIO_LOG_GET,"Button",BS_AUTORADIOBUTTON,27,198,193,10
     CONTROL         "POST:JSON形式",IDC_RADIO_LOG_POST,"Button",BS_AUTORADIOBUTTON,27,211,193,10
     CONTROL         "ダウンロード操作を記録する",IDC_CHECK_ENABLE_DOWNLOAD_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,226,135,10
-    CONTROL         "アップロード操作を記録する",IDC_CHECK_ENABLE_UPLOAD_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,241,135,10
+    CONTROL         "アップロード操作を記録する：",IDC_CHECK_ENABLE_UPLOAD_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,241,88,10
     CONTROL         "閲覧履歴を記録する",IDC_CHECK_EnableBrowsingLogging,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,256,135,10
     CONTROL         "詳細な閲覧履歴を記録する",IDC_CHECK_EnableAccessAllLogging,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,271,135,10
+    COMBOBOX        IDC_UPLOAD_LOGGING_URL_TYPE_COMBO,117,240,138,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 END
 
 IDD_SETTINGS_DLG_DSP DIALOGEX 0, 0, 370, 291
@@ -1430,6 +1431,9 @@ BEGIN
     IDS_STRING_SETTINGS_DLG_TITLE_POPUP_FILTER "ポップアップフィルター設定"
     ID_CANNOT_SAVE_POPUP_FILTER 
                             "[ポップアップフィルター設定]\nファイルの保存に失敗しました。\n他のプログラムがファイルを開いている可能性があります。\n他のプログラムを終了させ再度実行して下さい。\n%s"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED "最後に読み込んだURLを出力する"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "トップページのURLを出力する"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME "アクティブなフレームのURLを出力する"
 END
 
 #endif    // 日本語 (日本) resources
@@ -1668,11 +1672,12 @@ BEGIN
     CONTROL         "GET:as URL query parameters",IDC_RADIO_LOG_GET,"Button",BS_AUTORADIOBUTTON,27,198,193,10
     CONTROL         "POST:as JSON",IDC_RADIO_LOG_POST,"Button",BS_AUTORADIOBUTTON,27,211,193,10
     CONTROL         "Log downloads",IDC_CHECK_ENABLE_DOWNLOAD_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,226,135,10
-    CONTROL         "Log uploads",IDC_CHECK_ENABLE_UPLOAD_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,241,135,10
+    CONTROL         "Log uploads:",IDC_CHECK_ENABLE_UPLOAD_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,241,51,10
     CONTROL         "Log browsing histories",IDC_CHECK_EnableBrowsingLogging,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,256,135,10
     CONTROL         "Log detailed browsing histories",IDC_CHECK_EnableAccessAllLogging,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,27,271,135,10
+    COMBOBOX        IDC_UPLOAD_LOGGING_URL_TYPE_COMBO,80,240,138,30,CBS_DROPDOWNLIST | CBS_SORT | NOT WS_VISIBLE | WS_VSCROLL | WS_TABSTOP
 END
 
 IDD_SETTINGS_DLG_DSP DIALOGEX 0, 0, 370, 291
@@ -2871,6 +2876,9 @@ BEGIN
     IDS_STRING_SETTINGS_DLG_TITLE_POPUP_FILTER "Popup filtering"
     ID_CANNOT_SAVE_POPUP_FILTER 
                             "[Popup filter]\nCould not save the file.\nIt may be held by some other applications.\nPlease retry after closing other applications.\n%s"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED "Output last browsed URL"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "Output top page URL"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME "Output active frame URL"
 END
 
 #endif    // 英語 (ニュートラル) resources

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -1432,7 +1432,7 @@ BEGIN
     ID_CANNOT_SAVE_POPUP_FILTER 
                             "[ポップアップフィルター設定]\nファイルの保存に失敗しました。\n他のプログラムがファイルを開いている可能性があります。\n他のプログラムを終了させ再度実行して下さい。\n%s"
     IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED "最後に読み込んだURLを出力する"
-    IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "トップページのURLを出力する"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "アドレスバーのURLを出力する"
     IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME "アクティブなフレームのURLを出力する"
 END
 
@@ -2877,8 +2877,8 @@ BEGIN
     ID_CANNOT_SAVE_POPUP_FILTER 
                             "[Popup filter]\nCould not save the file.\nIt may be held by some other applications.\nPlease retry after closing other applications.\n%s"
     IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED "Output last browsed URL"
-    IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "Output top page URL"
-    IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME "Output active frame URL"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "Output URL of address bar"
+    IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME "Output URL of active frame"
 END
 
 #endif    // 英語 (ニュートラル) resources

--- a/resource.h
+++ b/resource.h
@@ -299,7 +299,10 @@
 #define IDS_STRING_SETTINGS_DLG_TITLE_POPUP_FILTER 440
 #define ID_CANNOT_SAVE_POPUP_FILTER     441
 #define IDD_SETTINGS_DLG_POPUP_FILTER   442
+#define IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED 442
 #define IDD_DLG_POPUP                   443
+#define IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE 443
+#define IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME 444
 #define IDC_EDIT1                       1000
 #define IDC_EDIT_PW                     1001
 #define IDC_EDIT2                       1002
@@ -365,6 +368,7 @@
 #define IDC_CERTIFICATION_COMBO         1095
 #define IDC_CERTIFICATE_STATIC_SITE_INFO 1096
 #define IDC_CHECK_ENABLE_POPUP_FILTER   1097
+#define IDC_UPLOAD_LOGGING_URL_TYPE_COMBO 1098
 #define IDC_PAGE_FRAME                  1200
 #define IDC_TREE_CTRL                   1201
 #define IDC_CAPTION_BAR                 1202
@@ -528,9 +532,9 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_3D_CONTROLS                     1
-#define _APS_NEXT_RESOURCE_VALUE        439
+#define _APS_NEXT_RESOURCE_VALUE        442
 #define _APS_NEXT_COMMAND_VALUE         33015
-#define _APS_NEXT_CONTROL_VALUE         1098
+#define _APS_NEXT_CONTROL_VALUE         1099
 #define _APS_NEXT_SYMED_VALUE           104
 #endif
 #endif

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1313,7 +1313,7 @@ public:
 		AdvancedLogLevel = 0;
 		EnableLogging = 0;
 		EnableUploadLogging = 0;
-		UploadLoggingURLType = static_cast<int>(AppSettings::EnumUploadLoggingURLType::LAST_BROWSED_URL);
+		UploadLoggingURLType = static_cast<int>(AppSettings::EnumUploadLoggingURLType::MAIN_FRAME);
 		EnableDownloadLogging = 0;
 		EnableBrowsingLogging = 0;
 		EnableAccessAllLogging = 0;
@@ -1800,7 +1800,7 @@ public:
 					else
 					{
 						// Regard as no permission for invalid value
-						UploadLoggingURLType = static_cast<int>(AppSettings::EnumUploadLoggingURLType::LAST_BROWSED_URL);
+						UploadLoggingURLType = static_cast<int>(AppSettings::EnumUploadLoggingURLType::MAIN_FRAME);
 					}
 					continue;
 				}

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1790,11 +1790,6 @@ public:
 				}
 				if (strTemp2.CompareNoCase(_T("UploadLoggingURLType")) == 0)
 				{
-					EnableUploadLogging = (strTemp3 == _T("1")) ? TRUE : FALSE;
-					continue;
-				}
-				if (strTemp2.CompareNoCase(_T("UploadLoggingURLType")) == 0)
-				{
 					int iW = 0;
 					iW = _ttoi(strTemp3);
 					if (static_cast<int>(AppSettings::EnumUploadLoggingURLType::LAST_BROWSED_URL) <= iW &&
@@ -2102,6 +2097,7 @@ public:
 		strRet += EXTVAL(LogMethod);
 		strRet += EXTVAL(EnableDownloadLogging);
 		strRet += EXTVAL(EnableUploadLogging);
+		strRet += EXTVAL(UploadLoggingURLType);
 		strRet += EXTVAL(EnableBrowsingLogging);
 		strRet += EXTVAL(EnableAccessAllLogging);
 	

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -932,6 +932,12 @@ public:
 		MANUAL_MEDIA_APPROVAL,
 		DEFAULT_MEDIA_APPROVAL
 	};
+	enum class EnumUploadLoggingURLType
+	{
+		LAST_BROWSED_URL,
+		MAIN_FRAME,
+		ACTIVE_FRAME
+	};
 	void Clear()
 	{
 		EnableAdvancedLogMode = 0;
@@ -984,6 +990,7 @@ public:
 
 		EnableLogging = 0;
 		EnableUploadLogging = 0;
+		UploadLoggingURLType = 0;
 		EnableDownloadLogging = 0;
 		EnableBrowsingLogging = 0;
 		EnableAccessAllLogging = 0;
@@ -1075,6 +1082,7 @@ public:
 
 		Data.EnableLogging = EnableLogging;
 		Data.EnableUploadLogging = EnableUploadLogging;
+		Data.UploadLoggingURLType = UploadLoggingURLType;
 		Data.EnableDownloadLogging = EnableDownloadLogging;
 		Data.EnableBrowsingLogging = EnableBrowsingLogging;
 		Data.EnableAccessAllLogging = EnableAccessAllLogging;
@@ -1183,6 +1191,7 @@ private:
 	//////////////////////////////////////////////////
 	int EnableLogging;
 	int EnableUploadLogging;
+	int UploadLoggingURLType;
 	int EnableDownloadLogging;
 	int EnableBrowsingLogging;
 	int EnableAccessAllLogging;
@@ -1304,6 +1313,7 @@ public:
 		AdvancedLogLevel = 0;
 		EnableLogging = 0;
 		EnableUploadLogging = 0;
+		UploadLoggingURLType = static_cast<int>(AppSettings::EnumUploadLoggingURLType::LAST_BROWSED_URL);
 		EnableDownloadLogging = 0;
 		EnableBrowsingLogging = 0;
 		EnableAccessAllLogging = 0;
@@ -1778,6 +1788,27 @@ public:
 					EnableUploadLogging = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
+				if (strTemp2.CompareNoCase(_T("UploadLoggingURLType")) == 0)
+				{
+					EnableUploadLogging = (strTemp3 == _T("1")) ? TRUE : FALSE;
+					continue;
+				}
+				if (strTemp2.CompareNoCase(_T("UploadLoggingURLType")) == 0)
+				{
+					int iW = 0;
+					iW = _ttoi(strTemp3);
+					if (static_cast<int>(AppSettings::EnumUploadLoggingURLType::LAST_BROWSED_URL) <= iW &&
+					    iW <= static_cast<int>(AppSettings::EnumUploadLoggingURLType::ACTIVE_FRAME))
+					{
+						UploadLoggingURLType = iW;
+					}
+					else
+					{
+						// Regard as no permission for invalid value
+						UploadLoggingURLType = static_cast<int>(AppSettings::EnumUploadLoggingURLType::LAST_BROWSED_URL);
+					}
+					continue;
+				}
 				if (strTemp2.CompareNoCase(_T("EnableDownloadLogging")) == 0)
 				{
 					EnableDownloadLogging = (strTemp3 == _T("1")) ? TRUE : FALSE;
@@ -2170,6 +2201,7 @@ public:
 
 	inline BOOL IsEnableLogging() { return EnableLogging; }
 	inline BOOL IsEnableUploadLogging() { return EnableUploadLogging; }
+	inline int GetUploadLoggingURLType() { return UploadLoggingURLType; }
 	inline BOOL IsEnableDownloadLogging() { return EnableDownloadLogging; }
 	inline BOOL IsEnableBrowsingLogging() { return EnableBrowsingLogging; }
 	inline BOOL IsEnableAccessAllLogging() { return EnableAccessAllLogging; }
@@ -2289,6 +2321,7 @@ public:
 		}
 	}
 	inline void SetEnableUploadLogging(DWORD dVal) { EnableUploadLogging = dVal ? 1 : 0; }
+	inline void SetUploadLoggingURLType(DWORD dVal) { UploadLoggingURLType = dVal; }
 	inline void SetEnableDownloadLogging(DWORD dVal) { EnableDownloadLogging = dVal ? 1 : 0; }
 	inline void SetEnableBrowsingLogging(DWORD dVal) { EnableBrowsingLogging = dVal ? 1 : 0; }
 	inline void SetEnableAccessAllLogging(DWORD dVal) { EnableAccessAllLogging = dVal ? 1 : 0; }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/482

# What this PR does / why we need it:

https://github.com/ThinBridge/Chronos/pull/255 has changed output URLs of file upload audit logs.
Before https://github.com/ThinBridge/Chronos/pull/255 has been merged, the output URL had been "a main frame URL (URL in address bar)".
However, after https://github.com/ThinBridge/Chronos/pull/255 has been merged, the output URL has been changed to "a last loaded sub frame URL in a main frame".

This patch enables to specify the output URL of the file upload audit logs.
We can specify the output URL by Log settings dialog.
The output URL types are following three type:

* "Output last browsed URL" ("最後に読み込んだURLを表示する”)
* "Output URL of address bar" ("アドレスバーのURLを出力する")
* "Output URL of active frame"("アクティブなフレームのURLを出力する")

<img width="842" height="535" alt="image" src="https://github.com/user-attachments/assets/c33a99e6-8371-42d9-80dd-d80d2f240920" />

<img width="839" height="532" alt="image" src="https://github.com/user-attachments/assets/449ec958-dfda-4457-96f4-6d99f00f195a" />

<img width="842" height="535" alt="image" src="https://github.com/user-attachments/assets/3987b135-d453-4ddc-90f7-d12f2226bfef" />

# How to verify the fixed issue:

## The steps to verify:

### Preparation

* Extract the attached file ([UploadLoggingURLType.zip](https://github.com/user-attachments/files/23541986/UploadLoggingURLType.zip)) to any folder. In this case, the destination folder is set to C:\temp\UploadLoggingTest.  
  The folder contains `main_frame.html` and `sub_frame.html`.
* Start [httpsserver.ps1](https://github.com/ThinBridge/Chronos-SG/blob/main/Documents/Tools/httpserver.ps1) (web server for test) with Powershell
* Start Chronos
* Open "設定" -> "ログ出力設定"
* Check "監査ログ出力を有効にする"
* Specify "http://localhost:8001" to "ログサーバーURL"
* Check "アップロード操作を記録する"
* Click "OK" button

### Tests

1. (Default settings)  
   * [x] Confirm that value is "アドレスバーのURLを出力する"
2. (Validity of default settings)  
   * Specify `C:\temp\UploadLoggingTest\main_frame.html` in the address bar and open main_frame.html.  
   * From the file upload button on the main frame side, upload any file.  
     * [x] Confirm that the URL of `main_frame.html` appears in the file upload log. 
   * From the file upload button on the subframe side, upload any file.  
     * [x] Confirm that the URL of `main_frame.html` appears in the file upload log. 
3. (Function to change setting values)  
   * Select "最後に読み込んだURLを表示する" and click [OK], then reopen:  
     * [x] Confirm that the change is reflected.  
   * Select "アクティブなフレームのURLを出力する" and click [OK], then reopen:  
     * [x] Confirm that the change is reflected. 
4. (Validity of changed settings)  
   * Save with the setting "最後に読み込んだURLを表示する" and click [OK]:  
   * Specify `C:\temp\UploadLoggingTest\main_frame.html` in the address bar and open main_frame.html.  
   * From the file upload button on the main frame side, upload any file.  
     * [x] Confirm that the URL of `sub_frame.html` appears in the file upload log.  
   * From the file upload button on the subframe side, upload any file.  
     * [x] Confirm that the URL of `sub_frame.html` appears in the file upload log.  
   * Save with the setting "アクティブなフレームのURLを出力する" and click [OK]:  
   * Again specify `C:\temp\UploadLoggingTest\main_frame.html` in the address bar and open main_frame.html.  
   * From the file upload button on the main frame side, upload any file.  
     * [x] Confirm that the URL of `main_frame.html` appears in the file upload log.  
   * From the file upload button on the subframe side, upload any file.  
     * [x] Confirm that the URL of `sub_frame.html` appears in the file upload log.  