### PR TITLE
Fix spelling part 2

### DIFF
--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -2712,7 +2712,7 @@ CDlgSetFileMgr::CDlgSetFileMgr() : CPropertyPage(CDlgSetFileMgr::IDD)
 void CDlgSetFileMgr::DoDataExchange(CDataExchange* pDX)
 {
 	CPropertyPage::DoDataExchange(pDX);
-	DDX_Control(pDX, IDC_EnableOpendOp, m_Combo);
+	DDX_Control(pDX, IDC_EnableOpenedOp, m_Combo);
 }
 
 BEGIN_MESSAGE_MAP(CDlgSetFileMgr, CPropertyPage)
@@ -2740,16 +2740,16 @@ BOOL CDlgSetFileMgr::OnInitDialog()
 		intoOpenOpLabel.LoadString(gInfoOpenOp[i]);
 		m_Combo.AddString(intoOpenOpLabel);
 	}
-	int iEnableOpendOp = 0;
-	iEnableOpendOp = theApp.m_AppSettingsDlgCurrent.GetEnableOpendOp();
-	if (iEnableOpendOp < 0 || iEnableOpendOp >= InfoOpenOpMaxCnt)
-		iEnableOpendOp = 0;
-	m_Combo.SetCurSel(iEnableOpendOp);
+	int iEnableOpenedOp = 0;
+	iEnableOpenedOp = theApp.m_AppSettingsDlgCurrent.GetEnableOpenedOp();
+	if (iEnableOpenedOp < 0 || iEnableOpenedOp >= InfoOpenOpMaxCnt)
+		iEnableOpenedOp = 0;
+	m_Combo.SetCurSel(iEnableOpenedOp);
 
-	if (theApp.m_AppSettingsDlgCurrent.IsDisableOpendOpAlert())
-		((CButton*)GetDlgItem(IDC_DisableOpendOpAlert))->SetCheck(1);
+	if (theApp.m_AppSettingsDlgCurrent.IsDisableOpenedOpAlert())
+		((CButton*)GetDlgItem(IDC_DisableOpenedOpAlert))->SetCheck(1);
 	else
-		((CButton*)GetDlgItem(IDC_DisableOpendOpAlert))->SetCheck(0);
+		((CButton*)GetDlgItem(IDC_DisableOpenedOpAlert))->SetCheck(0);
 
 	if (theApp.m_AppSettingsDlgCurrent.IsShowUploadTab())
 		((CButton*)GetDlgItem(IDC_ShowUploadTab))->SetCheck(1);
@@ -2831,12 +2831,12 @@ LRESULT CDlgSetFileMgr::Set_OK(WPARAM wParam, LPARAM lParam)
 
 	int iID = 0;
 	iID = m_Combo.GetCurSel();
-	theApp.m_AppSettingsDlgCurrent.SetEnableOpendOp(iID);
+	theApp.m_AppSettingsDlgCurrent.SetEnableOpenedOp(iID);
 
-	if (((CButton*)GetDlgItem(IDC_DisableOpendOpAlert))->GetCheck() == 1)
-		theApp.m_AppSettingsDlgCurrent.SetDisableOpendOpAlert(1);
+	if (((CButton*)GetDlgItem(IDC_DisableOpenedOpAlert))->GetCheck() == 1)
+		theApp.m_AppSettingsDlgCurrent.SetDisableOpenedOpAlert(1);
 	else
-		theApp.m_AppSettingsDlgCurrent.SetDisableOpendOpAlert(0);
+		theApp.m_AppSettingsDlgCurrent.SetDisableOpenedOpAlert(0);
 
 	if (((CButton*)GetDlgItem(IDC_ShowUploadTab))->GetCheck() == 1)
 		theApp.m_AppSettingsDlgCurrent.SetShowUploadTab(1);

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -358,8 +358,8 @@ BEGIN
     CONTROL         "アップロードアイテムを表示する",IDC_ShowUploadTab,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,198,104,10
     GROUPBOX        "機能設定",IDC_STATIC,8,245,343,42
     LTEXT           "右クリックメニュー設定",IDC_STATIC,12,259,64,8
-    COMBOBOX        IDC_EnableOpendOp,87,257,221,127,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "「開封済みにする」を行った場合に、確認メッセージを表示しない",IDC_DisableOpendOpAlert,
+    COMBOBOX        IDC_EnableOpenedOp,87,257,221,127,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "「開封済みにする」を行った場合に、確認メッセージを表示しない",IDC_DisableOpenedOpAlert,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,273,202,10
     LTEXT           "※拡張子を複数設定する場合は、|で区切ります。例）.elf|.lnk",IDC_STATIC,12,87,187,8
     CONTROL         "アップロードアイテムを自動更新する",IDC_EnableUploadSync,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,213,119,10
@@ -1773,8 +1773,8 @@ BEGIN
     CONTROL         "Show upload items",IDC_ShowUploadTab,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,196,104,10
     GROUPBOX        "Feature options",IDC_STATIC,7,245,343,42
     LTEXT           "Context menu options",IDC_STATIC,11,259,64,8
-    COMBOBOX        IDC_EnableOpendOp,86,257,221,127,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    CONTROL         "Never confirm for ""mark as opened"" command",IDC_DisableOpendOpAlert,
+    COMBOBOX        IDC_EnableOpenedOp,86,257,221,127,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Never confirm for ""mark as opened"" command",IDC_DisableOpenedOpAlert,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,273,202,10
     LTEXT           "*Separate multiple file extensions with a pipe |. For example: .elf|.lnk",IDC_STATIC,10,86,267,8
     CONTROL         "Auto-sync upload items",IDC_EnableUploadSync,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,211,119,10

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -10,3 +10,6 @@ devtools
 ORG_CreateDCW
 lpbi
 pwsz
+lpsz
+logmsg
+lpdi

--- a/resource.h
+++ b/resource.h
@@ -320,7 +320,7 @@
 #define IDC_ShowUploadTab               1019
 #define IDC_CHECK_ENABLE_CUSTOM_SCRIPT  1020
 #define IDC_UploadSyncInterval          1021
-#define IDC_EnableOpendOp               1022
+#define IDC_EnableOpenedOp               1022
 #define IDC_EnableUploadSync            1023
 #define IDC_EDIT_PW_NEW                 1024
 #define IDC_EDIT_PW_NEW2                1025
@@ -342,7 +342,7 @@
 #define IDC_TransferSubFolder           1043
 #define IDC_UploadPath                  1044
 #define IDC_EDIT_SEARCH                 1045
-#define IDC_DisableOpendOpAlert         1046
+#define IDC_DisableOpenedOpAlert         1046
 #define IDC_SetShowUploadTab            1047
 #define IDC_EDIT_PW_CURRENT             1048
 #define IDC_CHECK_DISABLE_MULTIPLE_INSTANCE 1049

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1003,13 +1003,13 @@ public:
 		RootPath.Empty();
 		UploadBasePath.Empty();
 		ExtFilter.Empty();
-		EnableOpendOp = 0;
+		EnableOpenedOp = 0;
 		EnableTransferLog = 0;
 		EnableUploadSync = 0;
 		EnableUploadSyncMirror = 0;
 		UploadSyncInterval = 0;
 		EnableAutoTransfer = 0;
-		DisableOpendOpAlert = 0;
+		DisableOpenedOpAlert = 0;
 		DisableExitOpAlert = 0;
 		ConfirmAutoRefresh = 0;
 		TransferPath.Empty();
@@ -1095,13 +1095,13 @@ public:
 		Data.RootPath = RootPath;
 		Data.UploadBasePath = UploadBasePath;
 		Data.ExtFilter = ExtFilter;
-		Data.EnableOpendOp = EnableOpendOp;
+		Data.EnableOpenedOp = EnableOpenedOp;
 		Data.EnableTransferLog = EnableTransferLog;
 		Data.EnableUploadSync = EnableUploadSync;
 		Data.EnableUploadSyncMirror = EnableUploadSyncMirror;
 		Data.UploadSyncInterval = UploadSyncInterval;
 		Data.EnableAutoTransfer = EnableAutoTransfer;
-		Data.DisableOpendOpAlert = DisableOpendOpAlert;
+		Data.DisableOpenedOpAlert = DisableOpenedOpAlert;
 		Data.DisableExitOpAlert = DisableExitOpAlert;
 		Data.ConfirmAutoRefresh = ConfirmAutoRefresh;
 		Data.TransferPath = TransferPath;
@@ -1203,9 +1203,9 @@ private:
 	//ChFiler---------------------------------
 	CString RootPath;
 	CString ExtFilter;
-	int EnableOpendOp;
+	int EnableOpenedOp;
 	int EnableTransferLog;
-	int DisableOpendOpAlert;
+	int DisableOpenedOpAlert;
 	int DisableExitOpAlert;
 	int ConfirmAutoRefresh;
 	CString TransferPath;
@@ -1326,13 +1326,13 @@ public:
 		RootPath = _T("B:\\");
 		UploadBasePath = _T("O:\\");
 		ExtFilter = _T(".*");
-		EnableOpendOp = 1;
+		EnableOpenedOp = 1;
 		EnableTransferLog = 0;
 		EnableUploadSync = 0;
 		EnableUploadSyncMirror = 0;
 		UploadSyncInterval = 5000;
 		EnableAutoTransfer = 0;
-		DisableOpendOpAlert = 0;
+		DisableOpenedOpAlert = 0;
 		DisableExitOpAlert = 2;
 		ConfirmAutoRefresh = 2;
 		TransferPath = _T("");
@@ -1821,14 +1821,15 @@ public:
 				}
 
 				//ChFiler---------------------------------
+				// OpendはOpenedの誤字だが、既に設定ファイルに記載されている値のため、下位互換性のために修正しない。
 				if (strTemp2.CompareNoCase(_T("EnableOpendOp")) == 0)
 				{
 					int iW = 0;
 					iW = _ttoi(strTemp3);
 					if (0 <= iW && iW <= 2)
-						EnableOpendOp = iW;
+						EnableOpenedOp = iW;
 					else
-						EnableOpendOp = 0;
+						EnableOpenedOp = 0;
 					continue;
 				}
 				if (strTemp2.CompareNoCase(_T("EnableTransferLog")) == 0)
@@ -1836,9 +1837,10 @@ public:
 					EnableTransferLog = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
+				// OpendはOpenedの誤字だが、既に設定ファイルに記載されている値のため、下位互換性のために修正しない。
 				if (strTemp2.CompareNoCase(_T("DisableOpendOpAlert")) == 0)
 				{
-					DisableOpendOpAlert = (strTemp3 == _T("1")) ? TRUE : FALSE;
+					DisableOpenedOpAlert = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
 				if (strTemp2.CompareNoCase(_T("DisableExitOpAlert")) == 0)
@@ -2115,8 +2117,8 @@ public:
 		strRet += EXTVAL(EnableUploadSyncMirror);
 		strRet += EXTVAL(UploadSyncInterval);
 		strRet += EXTVAL(EnableAutoTransfer);
-		strRet += EXTVAL(EnableOpendOp);
-		strRet += EXTVAL(DisableOpendOpAlert);
+		strRet += EXTVAL(EnableOpenedOp);
+		strRet += EXTVAL(DisableOpenedOpAlert);
 
 		strRet += _T("# non GUI parameters\n");
 		strRet += EXTVAL(CEFCommandLine);
@@ -2218,13 +2220,13 @@ public:
 	inline CString GetExitMessage() { return ExitMessage; }
 
 	//ChFiler---------------------------------
-	inline int GetEnableOpendOp() { return EnableOpendOp; }
+	inline int GetEnableOpenedOp() { return EnableOpenedOp; }
 	inline BOOL IsEnableTransferLog() { return EnableTransferLog; }
 	inline BOOL IsEnableUploadSync() { return EnableUploadSync; }
 	inline BOOL IsEnableUploadSyncMirror() { return EnableUploadSyncMirror; }
 	inline int GetUploadSyncInterval() { return UploadSyncInterval; }
 	inline BOOL IsEnableAutoTransfer() { return EnableAutoTransfer; }
-	inline BOOL IsDisableOpendOpAlert() { return DisableOpendOpAlert; }
+	inline BOOL IsDisableOpenedOpAlert() { return DisableOpenedOpAlert; }
 	inline BOOL IsDisableExitOpAlert() { return DisableExitOpAlert; }
 	inline int GetConfirmAutoRefresh() { return ConfirmAutoRefresh; }
 	inline BOOL IsShowUploadTab() { return ShowUploadTab; }
@@ -2338,13 +2340,13 @@ public:
 	inline void SetExitMessage(LPCTSTR str) { ExitMessage = str; }
 
 	//ChFiler---------------------------------
-	inline void SetEnableOpendOp(DWORD dVal) { EnableOpendOp = dVal; }
+	inline void SetEnableOpenedOp(DWORD dVal) { EnableOpenedOp = dVal; }
 	inline void SetEnableTransferLog(DWORD dVal) { EnableTransferLog = dVal; }
 	inline void SetEnableUploadSync(DWORD dVal) { EnableUploadSync = dVal; }
 	inline void SetEnableUploadSyncMirror(DWORD dVal) { EnableUploadSyncMirror = dVal; }
 	inline void SetUploadSyncInterval(DWORD dVal) { UploadSyncInterval = dVal; }
 	inline void SetEnableAutoTransfer(DWORD dVal) { EnableAutoTransfer = dVal; }
-	inline void SetDisableOpendOpAlert(DWORD dVal) { DisableOpendOpAlert = dVal; }
+	inline void SetDisableOpenedOpAlert(DWORD dVal) { DisableOpenedOpAlert = dVal; }
 	inline void SetDisableExitOpAlert(DWORD dVal) { DisableExitOpAlert = dVal; }
 	inline void SetConfirmAutoRefresh(DWORD dVal) { ConfirmAutoRefresh = dVal; }
 	inline void SetShowUploadTab(DWORD dVal) { ShowUploadTab = dVal; }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

[#419](https://github.com/ThinBridge/Chronos-SG/issues/419)

# What this PR does / why we need it:

We have fixed some spell misses with #331 but there remains some other miss spells.


* Modify "Opend" to "Opened"
* Ignore some false positive cases

# How to verify the fixed issue:

## The steps to verify:

* [x] Confirm that build passed
* [x] Confirm that the the file manager setting dialog on SG-mode, especially the file opened operation setting is not broken

<img width="836" height="194" alt="image" src="https://github.com/user-attachments/assets/106d62f6-e0f7-4979-9ed8-c9fcffebe2b9" />


More detailed tests will be done in the pre-release tests.