### PR TITLE
Update default CEF version to 140.1.14

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=135.0.22+g442c600+chromium-135.0.7049.115
+VERSION=140.1.14+geb1c06e+chromium-140.0.7339.185
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_135.0.22+g442c600+chromium-135.0.7049.115_windows32_minimal
+  set CEFVER=cef_binary_140.1.14+geb1c06e+chromium-140.0.7339.185_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We decided to use CEF 140 for new Chronos version.
So update the default CEF version to 140.1.14.

Note that the most latest official built CEF in 140 line is 140.1.14, on the other hand, the self built CEF is 140.1.20.
We use  CEF 140.1.14 for this repository but use CEF 140.1.20 for Chronos-SG.

# How to verify the fixed issue:

* [x] Confirm that the CEF version is updated to 140.1.14

<img width="793" height="279" alt="image" src="https://github.com/user-attachments/assets/79800c11-6859-42c5-871f-a376411b9097" />
