### PR TITLE
Add support for reading EnableOpenedOp and DisableOpenedOpAlert parameter

### DIFF
--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1822,7 +1822,8 @@ public:
 
 				//ChFiler---------------------------------
 				// OpendはOpenedの誤字だが、既に設定ファイルに記載されている値のため、下位互換性のために修正しない。
-				if (strTemp2.CompareNoCase(_T("EnableOpendOp")) == 0)
+				if (strTemp2.CompareNoCase(_T("EnableOpendOp")) == 0 || 
+					strTemp2.CompareNoCase(_T("EnableOpenedOp")) == 0)
 				{
 					int iW = 0;
 					iW = _ttoi(strTemp3);
@@ -1838,7 +1839,8 @@ public:
 					continue;
 				}
 				// OpendはOpenedの誤字だが、既に設定ファイルに記載されている値のため、下位互換性のために修正しない。
-				if (strTemp2.CompareNoCase(_T("DisableOpendOpAlert")) == 0)
+				if (strTemp2.CompareNoCase(_T("DisableOpendOpAlert")) == 0 ||
+				    strTemp2.CompareNoCase(_T("DisableOpenedOpAlert")) == 0)
 				{
 					DisableOpenedOpAlert = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

Add support for EnableOpenedOp and DisableOpenedOpAlert parameters.

We currently support only EnableOpendOp and DisableOpendOpAlert in the config file.
However, once Chronos saves the config to the file, they are converted to  EnableOpenedOp and DisableOpenedOpAlert.
As a result, Chronos can not read those settings.

This patch fixes that bug.

# How to verify the fixed issue:

tests for this patch are done at the same time in https://github.com/ThinBridge/Chronos-SG/pull/495