### PR TITLE
Native mode: add support for per-user config and log files

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -329,6 +329,9 @@ BOOL CSazabi::InitFunc_Settings()
 					this->m_AppSettings.SaveDataToFileEx(m_strSettingFileFullPath);
 				}
 			}
+			// このパスを通るときはユーザー設定を使用しているので、強制的にEnableUserConfigをTRUEにする。
+			// ユーザー設定でEnableUserConfigにFALSEを指定していた場合の対策。
+			theApp.m_AppSettings.SetEnableUserConfig(TRUE);
 		}
 	}
 	else if (InVirtualEnvironment() == VE_THINAPP)

--- a/Sazabi.h
+++ b/Sazabi.h
@@ -122,6 +122,7 @@ public:
 	CString m_strExeFullPath;
 	CString m_strExeFileName;
 	CString m_strExeFolderPath;
+	CString m_strUserDataFolderPath;
 	CString m_strLogFileFullPath;
 	CString m_strRecoveryFileFullPath;
 	CString m_strRecoveryFileName;
@@ -133,6 +134,7 @@ public:
 	CString m_strDBL_EXE_Default_FullPath;
 	CString m_strDBL_EXE_FullPath;
 	CString m_strDBL_EXE_FolderPath;
+	CString m_strDefaultSettingFileFullPath;
 	CString m_strSettingFileFullPath;
 
 	CString m_strCEFCachePathBase;
@@ -274,6 +276,7 @@ public:
 	void InitAtomParam();
 	void ReflectEnforcedOptionParam();
 	BOOL InitMultipleInstance();
+	CString InitConfFile(CString baseName);
 	void InitReadConfSetting();
 	void InitializeCef();
 	////////////////////////////////////////////////

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -2384,7 +2384,7 @@ public:
 	inline void SetTASK_LIST_MODE_DETAIL(DWORD dVal) { TASK_LIST_MODE_DETAIL = dVal; }
 
 	// Config file-------------------------------
-	inline int SetEnableUserConfig(DWORD dVal) { EnableUserConfig = dVal; }
+	inline void SetEnableUserConfig(DWORD dVal) { EnableUserConfig = dVal; }
 };
 
 class CIconHelper


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/339

# What this PR does / why we need it:

**The following description applies to Native mode.**

Currently, files such as Chronos_trace.log, ChronosDefault.conf  and CustomScriptDefault.conf are output to the same folder where Chronos.exe exists.
In native mode, when multiple users run Chronos on the same machine, the contents of these files conflict with each other.

Furthermore, if Chronos is installed in a location that requires administrator privileges, standard users are unable to overwrite these files.

To address these issues, this patch changes to output those log and config files under %LOCALAPPDATA% when they are persisted.
In addition, since the config will no longer be treated as a default in that case, the file (name) will be saved without “Default”.

# How to verify the fixed issue:
## The steps to verify:


* Chronosを起動する
* 設定画面を開く
* ログ出力設定画面を開く
* 「ログをファイルに出力する」を指定する
* カスタムスクリプト設定画面を開く
* カスタムクリプトを有効にし、適当な設定を追加する
* ポップアップフィルター設定画面を開く
* ポップアップフィルターを有効にし、適当な設定を追加する
* URLフィルター設定画面を開く
* URLフィルターを有効にし、適当な設定を追加する
* リダイレクト設定画面を開く
* URLリダイレクトを有効にし、スクリプトエディターウィンドウに適当な設定を行う
* OKを押して設定を保存する
  * [x] 設定の保存時にエラーにならないこと
* %LOCALAPPDATA%\Chronosを開く
  * 以下のファイルが存在すること
    * [x] Chronos.conf
      * `EnableAdvancedLogMode=1`であること
      * その他の設定は一旦確認を無視してよい
    * [x] Chronos_trace.log
    * [x] CustomScript.conf
      * カスタムスクリプトの設定が反映されていること
    * [x] PopupFilter.conf
      * ポップアップフィルターの設定が反映されていること
    * [x] RedirectFilterScript.conf
      * URLリダイレクトの設定が反映されていること
    * [x] URL_DomainFilter.conf
      * URLフィルターの設定が反映されていること
* Chronos.exeが存在するフォルダーを確認する
  * 以下のファイルが存在**しない**こと
    * [x] Chronos.conf
    * [x] Chronos_trace.log
    * [x] CustomScript.conf
    * [x] PopupFilter.conf
    * [x] RedirectFilterScript.conf
    * [x] URL_DomainFilter.conf
* Chronosを再起動する
* 設定画面を開く
* ログ出力設定画面を開く
  * [x] 「ログをファイルに出力する」が有効であること
* カスタムスクリプト設定画面を開く
  * [x] カスタムクリプトを有効にするがONであること
  * [x] カスタムスクリプトの内容が設定したものであること
* ポップアップフィルター設定画面を開く
  * [x] ポップアップフィルターを有効にするがONであること
  * [x] ポップアップフィルターの内容が設定したものであること
* URLフィルター設定画面を開く
  * [x] URLフィルターを有効にするがONであること
  * [x] URLフィルターの内容が設定したものであること
* リダイレクト設定画面を開く
  * [x] URLリダイレクトを有効にするがONであること
  * [x] スクリプトエディターウィンドウの内容が設定したものであること
* Chronosを終了する
* %LOCALAPPDATA%\Chronosを開く
* 以下のファイルを、Chronos.exeが存在するフォルダに移動する
  * CustomScript.conf
  * PopupFilter.conf
  * RedirectFilterScript.conf
  * URL_DomainFilter.conf
* 移動したファイルを以下のようにリネームする
  * CustomScriptDefault.conf
  * PopupFilterDefault.conf
  * RedirectFilterScriptDefault.conf
  * URL_DomainFilterDefault.conf
* Chronosを起動する
* 設定画面を開く
* ログ出力設定画面を開く
  * [x] 「ログをファイルに出力する」が有効であること
* カスタムスクリプト設定画面を開く
  * [x] カスタムクリプトを有効にするがONであること
  * [x] カスタムスクリプトの内容が設定したものであること
* ポップアップフィルター設定画面を開く
  * [x] ポップアップフィルターを有効にするがONであること
  * [x] ポップアップフィルターの内容が設定したものであること
* URLフィルター設定画面を開く
  * [x] URLフィルターを有効にするがONであること
  * [x] URLフィルターの内容が設定したものであること
* リダイレクト設定画面を開く
  * [x] URLリダイレクトを有効にするがONであること
  * [x] スクリプトエディターウィンドウの内容が設定したものであること
* カスタムスクリプト設定画面を開く
* カスタムクリプトの設定を任意に変更する
* ポップアップフィルター設定画面を開く
* ポップアップフィルターの設定を任意に変更する
* URLフィルター設定画面を開く
* URLフィルターの設定を任意に変更する
* リダイレクト設定画面を開く
* URLリダイレクトの設定を任意に変更する
* OKを押して設定を保存する
* Chronos.exeを終了する
* Chronos.exeが存在するフォルダを開く
* 以下のファイルを確認する
  * CustomScriptDefault.conf
    * [x] ファイルの内容が、変更前の内容であること
  * PopupFilterDefault.conf
    * [x] ファイルの内容が、変更前の内容であること
  * RedirectFilterScriptDefault.conf
    * [x] ファイルの内容が、変更前の内容であること
  * URL_DomainFilterDefault.conf
    * [x] ファイルの内容が、変更前の内容であること
* %LOCALAPPDATA%\Chronosを開く
  * 以下のファイルが存在すること
    * [x] CustomScript.conf
      * カスタムスクリプトの設定の変更が反映されていること
    * [x] PopupFilter.conf
      * ポップアップフィルターの設定の変更が反映されていること
    * [x] RedirectFilterScript.conf
      * URLリダイレクトの設定の変更が反映されていること
    * [x] URL_DomainFilter.conf
      * URLフィルターの設定の変更反映されていること
* Chronos.exeを起動する
* 設定画面を開く
* ログ出力設定画面を開く
  * [x] 「ログをファイルに出力する」が有効であること
* カスタムスクリプト設定画面を開く
  * [x] カスタムクリプトを有効にするがONであること
  * [x] カスタムスクリプトの内容が変更後の設定であること
* ポップアップフィルター設定画面を開く
  * [x] ポップアップフィルターを有効にするがONであること
  * [x] ポップアップフィルターの内容が変更後の設定であること
* URLフィルター設定画面を開く
  * [x] URLフィルターを有効にするがONであること
  * [x] URLフィルターの内容が変更後の設定であること
* リダイレクト設定画面を開く
  * [x] URLリダイレクトを有効にするがONであること
  * [x] スクリプトエディターウィンドウの内容が変更後の設定であること
* Chronos.exeを閉じる
* Chronos.exeが存在するフォルダを開く
* ChronosDefault.confを開く
* 以下の内容を変更する
  * 変更前: `EnableUserConfig=1`
  * 変更後: `EnableUserConfig=0`
* Chronos.exeを起動する
* ログ出力設定画面を開く
  * [x] 「ログをファイルに出力する」が無効であること
* カスタムスクリプト設定画面を開く
  * [x] カスタムクリプトを有効にするがOFFであること
  * [x] カスタムスクリプトの内容が変更前の設定であること
* ポップアップフィルター設定画面を開く
  * [x] ポップアップフィルターを有効にするがOFFであること
  * [x] ポップアップフィルターの内容が変更前の設定であること
* URLフィルター設定画面を開く
  * [x] URLフィルターを有効にするがOFFであること
  * [x] URLフィルターの内容が変更前の設定であること
* リダイレクト設定画面を開く
  * [x] URLリダイレクトを有効にするがOFFであること
  * [x] スクリプトエディターウィンドウの内容が変更前の設定であること
* ※`EnableUserConfig=0`で起動した後、`%LOCALAPPDATA%\Chronos\CustomScript.conf`などを確認すると、デフォルト設定の方で上書されているが、これはそのような仕様であり問題ない。