### PR TITLE
User config: add support for environment variable

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1005,7 +1005,9 @@ void CSazabi::ParseSingleParam(CString param) {
 			int pos = trimmedParam.Find(_T('='));
 			if (pos != -1)
 			{
-				m_strUserConfigFilePath = trimmedParam.Right(trimmedParam.GetLength() - pos - 1).Trim(_T('"'));
+				CString strOriginalUserConfigFilePath = trimmedParam.Right(trimmedParam.GetLength() - pos - 1).Trim(_T('"'));
+				m_strUserConfigFilePath = SBUtil::ExpandEnvironmentStringsEx(strOriginalUserConfigFilePath);
+				
 				// 引数解析の際に、パラメータで使用している""が削除される。
 				// そのため、ここで明示的に""を足す。
 				m_strConfigParam.Format(_T("/ChronosConfig=\"%s\""), (LPCTSTR)m_strUserConfigFilePath);

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -866,6 +866,30 @@ namespace SBUtil
 		}
 		return strRet;
 	}
+	static CString ExpandEnvironmentStringsEx(LPCTSTR lpSrc)
+	{
+		CString strRet;
+		if (!lpSrc)
+		{
+			return strRet;
+		}
+		DWORD dwSize = ExpandEnvironmentStrings(lpSrc, NULL, 0);
+		if (dwSize == 0)
+		{
+			return strRet;
+		}
+		LPWSTR pBuf = strRet.GetBuffer(dwSize);
+		if (ExpandEnvironmentStrings(strRet, pBuf, dwSize) == 0)
+		{
+			strRet.ReleaseBuffer(0);
+			return strRet;
+		}
+		ExpandEnvironmentStrings(lpSrc, pBuf, dwSize);
+		strRet.ReleaseBuffer();
+		return strRet;
+	}
+
+
 }; // namespace SBUtil
 //////////////////////////////////////////////////////////////////////
 static int wildcmp(const char* wild, const char* string)

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -876,16 +876,15 @@ namespace SBUtil
 		DWORD dwSize = ExpandEnvironmentStrings(lpSrc, NULL, 0);
 		if (dwSize == 0)
 		{
-			return strRet;
+			return lpSrc;
 		}
 		LPWSTR pBuf = strRet.GetBuffer(dwSize);
-		if (ExpandEnvironmentStrings(strRet, pBuf, dwSize) == 0)
-		{
-			strRet.ReleaseBuffer(0);
-			return strRet;
-		}
-		ExpandEnvironmentStrings(lpSrc, pBuf, dwSize);
+		dwSize = ExpandEnvironmentStrings(lpSrc, pBuf, dwSize);
 		strRet.ReleaseBuffer();
+		if (dwSize == 0)
+		{
+			return lpSrc;
+		}
 		return strRet;
 	}
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

Add support for environment variable for the user config path

E.g. /ChronosConfig="%LOCALAPPDATA%\Chronos\test.conf" is expanded to /ChronosConfig="C:\Users\user\AppData\Local\Chronos\test.conf"

# How to verify the fixed issue:

## The steps to verify:

* Create a user config file to `%LOCALAPPDATA%\Chronos\test.conf`
* Specify the following parameter to the test.conf
   ```
   EnableMemcache=1
   ```
* Execute Chronos with the following command line
  * `Chronos.exe /ChronosConfig="%LOCALAPPDATA%\Chronos\test.conf"`
* Open the setting dialog
* Open the general settings
  * [x] Confirm that enable memory cache is enabled (checked)
