### PR TITLE
Native: add features to specify upload path and download path

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -51,7 +51,7 @@ public:
 		}
 	}
 
-	HRESULT SetUp()
+	HRESULT SetUp(HWND hwndOwner)
 	{
 
 		CString strPath;
@@ -116,6 +116,9 @@ public:
 		hresult = ::SHParseDisplayName(strPath, 0, &pidl, SFGAO_FOLDER, 0);
 		if (FAILED(hresult))
 		{
+			CString strMsg;
+			strMsg.Format(L"アップロードフォルダー[%s]の取得に失敗しました。\n\nアップロードフォルダーが存在し、アクセス可能であることを確認してください。", (LPCWSTR)strPath);
+			::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 			return hresult;
 		}
 
@@ -315,7 +318,7 @@ public:
 			return E_ACCESSDENIED;
 		}
 
-		HRESULT hresult = SetUp();
+		HRESULT hresult = SetUp(hwndOwner);
 		if (FAILED(hresult))
 			return hresult;
 
@@ -430,7 +433,7 @@ public:
 		}
 	}
 
-	HRESULT SetUp()
+	HRESULT SetUp(HWND hwndOwner)
 	{
 		FILEOPENDIALOGOPTIONS option = 0;
 		CString strPath;
@@ -476,6 +479,9 @@ public:
 		hresult = ::SHParseDisplayName(strPath, 0, &pidl, SFGAO_FOLDER, 0);
 		if (FAILED(hresult))
 		{
+			CString strMsg;
+			strMsg.Format(L"ダウンロードフォルダー[%s]の取得に失敗しました。\n\nダウンロードフォルダーが存在し、アクセス可能であることを確認してください。", (LPCWSTR)strPath);
+			::MessageBoxW(hwndOwner, strMsg, theApp.m_strThisAppName, MB_OK | MB_ICONWARNING);
 			return hresult;
 		}
 
@@ -673,7 +679,7 @@ public:
 			return E_ACCESSDENIED;
 		}
 
-		HRESULT hresult = SetUp();
+		HRESULT hresult = SetUp(hwndOwner);
 		if (FAILED(hresult))
 			return hresult;
 

--- a/DlgSetting.cpp
+++ b/DlgSetting.cpp
@@ -2855,6 +2855,47 @@ LRESULT CDlgSetFileMgr::Set_OK(WPARAM wParam, LPARAM lParam)
 	return 0;
 }
 /////////////////////////////////////////////////////////////////////////////
+// CDlgSetNativeFileTransfer ダイアログ
+
+IMPLEMENT_DYNCREATE(CDlgSetNativeFileTransfer, CPropertyPage)
+CDlgSetNativeFileTransfer::CDlgSetNativeFileTransfer() : CPropertyPage(CDlgSetNativeFileTransfer::IDD)
+{
+}
+
+void CDlgSetNativeFileTransfer::DoDataExchange(CDataExchange* pDX)
+{
+	CPropertyPage::DoDataExchange(pDX);
+}
+
+BEGIN_MESSAGE_MAP(CDlgSetNativeFileTransfer, CPropertyPage)
+	ON_WM_DESTROY()
+	ON_MESSAGE(ID_SETTING_OK, Set_OK)
+END_MESSAGE_MAP()
+
+BOOL CDlgSetNativeFileTransfer::OnInitDialog()
+{
+	CPropertyPage::OnInitDialog();
+	SetDlgItemText(IDC_NativeTransferPath, theApp.m_AppSettingsDlgCurrent.GetNativeDownloadPath());
+	SetDlgItemText(IDC_NativeUploadPath, theApp.m_AppSettingsDlgCurrent.GetNativeUploadPath());
+	return FALSE;
+}
+
+LRESULT CDlgSetNativeFileTransfer::Set_OK(WPARAM wParam, LPARAM lParam)
+{
+	CString strValue;
+
+	strValue.Empty();
+	GetDlgItemText(IDC_NativeTransferPath, strValue);
+	theApp.m_AppSettingsDlgCurrent.SetNativeDownloadPath(strValue);
+
+	strValue.Empty();
+	GetDlgItemText(IDC_NativeUploadPath, strValue);
+	theApp.m_AppSettingsDlgCurrent.SetNativeUploadPath(strValue);
+
+	return 0;
+}
+
+/////////////////////////////////////////////////////////////////////////////
 // CDlgSetCustomScript プロパティ ページ
 IMPLEMENT_DYNCREATE(CDlgSetCustomScript, CPropertyPage)
 CDlgSetCustomScript::CDlgSetCustomScript() : CPropertyPage(CDlgSetCustomScript::IDD)

--- a/DlgSetting.h
+++ b/DlgSetting.h
@@ -687,6 +687,37 @@ protected:
 	void ChangeStateULS();
 };
 
+class CDlgSetNativeFileTransfer : public CPropertyPage
+{
+	DECLARE_DYNCREATE(CDlgSetNativeFileTransfer)
+public:
+	CDlgSetNativeFileTransfer();
+	virtual ~CDlgSetNativeFileTransfer() {};
+	autoresize::CAutoResize m_autoResize;
+#pragma warning(push)
+// C26812 列挙型 'type-name' はスコープ外です。 'enum' より 'enum class' を優先します (Enum.3)
+// これはダイアログを自動生成した際に作成されるenumなので、enum classにせず、警告の方を無視する。
+#pragma warning(disable : 26812)
+	enum
+	{
+		IDD = IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER
+	};
+#pragma warning(pop)
+
+protected:
+	virtual void DoDataExchange(CDataExchange* pDX);
+
+protected:
+	//	afx_msg void OnButtonPopAdd();
+	virtual BOOL OnInitDialog();
+	afx_msg void OnDestroy() { CPropertyPage::OnDestroy(); }
+	afx_msg void OnSize(UINT nType, int cx, int cy);
+	afx_msg void OnPaint();
+	afx_msg void OnEnableCtrl();
+	LRESULT Set_OK(WPARAM wParam, LPARAM lParam);
+	DECLARE_MESSAGE_MAP()
+};
+
 class CDlgSetCustomScript : public CPropertyPage
 {
 	DECLARE_DYNCREATE(CDlgSetCustomScript)

--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -3480,6 +3480,13 @@ void CSazabi::ShowSettingDlg(CWnd* pParentWnd)
 		titleFileMgr.LoadString(IDS_STRING_SETTINGS_DLG_TITLE_FILEMGR);
 		this->m_pSettingDlg->AddPage(RUNTIME_CLASS(CDlgSetFileMgr), titleFileMgr, IDD_SETTINGS_DLG_FILEMGR, titleFileMgr);
 	}
+	else
+	{
+		//ファイル転送設定
+		CString titleFileTransfer;
+		titleFileTransfer.LoadString(IDS_STRING_SETTINGS_DLG_TITLE_NATIVE_FILE_TRANSFER);
+		this->m_pSettingDlg->AddPage(RUNTIME_CLASS(CDlgSetNativeFileTransfer), titleFileTransfer, IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER, titleFileTransfer);
+	}
 
 	this->m_pSettingDlg->DoModal();
 

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -614,6 +614,17 @@ BEGIN
     PUSHBUTTON      "キャンセル",IDCANCEL,240,86,50,14
 END
 
+IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER DIALOGEX 0, 0, 370, 291
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    LTEXT           "ダウンロードアイテム転送先",-1,8,12,80,8
+    EDITTEXT        IDC_NativeTransferPath,93,10,246,14,ES_AUTOHSCROLL
+    LTEXT           "アップロードアイテム受入元",-1,8,31,79,8
+    EDITTEXT        IDC_NativeUploadPath,93,28,246,14,ES_AUTOHSCROLL
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -781,6 +792,10 @@ BEGIN
         RIGHTMARGIN, 290
         TOPMARGIN, 7
         BOTTOMMARGIN, 102
+    END
+
+    IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER, DIALOG
+    BEGIN
     END
 END
 #endif    // APSTUDIO_INVOKED
@@ -995,6 +1010,11 @@ BEGIN
 END
 
 IDD_DLG_POPUP AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER AFX_DIALOG_LAYOUT
 BEGIN
     0
 END
@@ -1434,6 +1454,7 @@ BEGIN
     IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED "最後に読み込んだURLを出力する"
     IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "アドレスバーのURLを出力する"
     IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME "アクティブなフレームのURLを出力する"
+    IDS_STRING_SETTINGS_DLG_TITLE_NATIVE_FILE_TRANSFER "ファイル転送設定"
 END
 
 #endif    // 日本語 (日本) resources
@@ -2035,6 +2056,17 @@ BEGIN
     PUSHBUTTON      "Cancel",IDCANCEL,240,86,50,14
 END
 
+IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER DIALOGEX 0, 0, 370, 291
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    LTEXT           "Transfer path for downloaded items",-1,7,15,80,8
+    EDITTEXT        IDC_NativeTransferPath,97,12,214,14,ES_AUTOHSCROLL
+    LTEXT           "Accepted path for upload items",-1,7,34,79,8
+    EDITTEXT        IDC_NativeUploadPath,96,31,215,14,ES_AUTOHSCROLL
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -2202,6 +2234,10 @@ BEGIN
         RIGHTMARGIN, 290
         TOPMARGIN, 7
         BOTTOMMARGIN, 102
+    END
+
+    IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER, DIALOG
+    BEGIN
     END
 END
 #endif    // APSTUDIO_INVOKED
@@ -2416,6 +2452,11 @@ BEGIN
 END
 
 IDD_DLG_POPUP AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER AFX_DIALOG_LAYOUT
 BEGIN
     0
 END
@@ -2879,6 +2920,7 @@ BEGIN
     IDS_STRING_UPLOAD_LOGGING_TYPE_LAST_BROWSED "Output last browsed URL"
     IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE "Output URL of address bar"
     IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME "Output URL of active frame"
+    IDS_STRING_SETTINGS_DLG_TITLE_NATIVE_FILE_TRANSFER "File Transfer"
 END
 
 #endif    // 英語 (ニュートラル) resources

--- a/resource.h
+++ b/resource.h
@@ -303,6 +303,8 @@
 #define IDD_DLG_POPUP                   443
 #define IDS_STRING_UPLOAD_LOGGING_TYPE_TOP_PAGE 443
 #define IDS_STRING_UPLOAD_LOGGING_TYPE_ACTIVE_FRAME 444
+#define IDD_SETTINGS_DLG_NATIVE_FILE_TRANSFER 445
+#define IDS_STRING_SETTINGS_DLG_TITLE_NATIVE_FILE_TRANSFER 446
 #define IDC_EDIT1                       1000
 #define IDC_EDIT_PW                     1001
 #define IDC_EDIT2                       1002
@@ -320,7 +322,7 @@
 #define IDC_ShowUploadTab               1019
 #define IDC_CHECK_ENABLE_CUSTOM_SCRIPT  1020
 #define IDC_UploadSyncInterval          1021
-#define IDC_EnableOpenedOp               1022
+#define IDC_EnableOpenedOp              1022
 #define IDC_EnableUploadSync            1023
 #define IDC_EDIT_PW_NEW                 1024
 #define IDC_EDIT_PW_NEW2                1025
@@ -342,7 +344,7 @@
 #define IDC_TransferSubFolder           1043
 #define IDC_UploadPath                  1044
 #define IDC_EDIT_SEARCH                 1045
-#define IDC_DisableOpenedOpAlert         1046
+#define IDC_DisableOpenedOpAlert        1046
 #define IDC_SetShowUploadTab            1047
 #define IDC_EDIT_PW_CURRENT             1048
 #define IDC_CHECK_DISABLE_MULTIPLE_INSTANCE 1049
@@ -369,6 +371,8 @@
 #define IDC_CERTIFICATE_STATIC_SITE_INFO 1096
 #define IDC_CHECK_ENABLE_POPUP_FILTER   1097
 #define IDC_UPLOAD_LOGGING_URL_TYPE_COMBO 1098
+#define IDC_NativeUploadPath            1100
+#define IDC_NativeTransferPath          1101
 #define IDC_PAGE_FRAME                  1200
 #define IDC_TREE_CTRL                   1201
 #define IDC_CAPTION_BAR                 1202
@@ -534,7 +538,7 @@
 #define _APS_3D_CONTROLS                     1
 #define _APS_NEXT_RESOURCE_VALUE        442
 #define _APS_NEXT_COMMAND_VALUE         33015
-#define _APS_NEXT_CONTROL_VALUE         1099
+#define _APS_NEXT_CONTROL_VALUE         1102
 #define _APS_NEXT_SYMED_VALUE           104
 #endif
 #endif

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1053,6 +1053,10 @@ public:
 
 		//Config file-------------------------------
 		EnableUserConfig = 0;
+
+		// File Transfer----------------------------
+		NativeDownloadPath.Empty();
+		NativeUploadPath.Empty();
 	}
 	void CopyData(AppSettings& Data)
 	{
@@ -1145,6 +1149,10 @@ public:
 
 		//Config file-------------------------------
 		Data.EnableUserConfig = EnableUserConfig;
+
+		// File Transfer----------------------------
+		Data.NativeDownloadPath = NativeDownloadPath;
+		Data.NativeUploadPath = NativeUploadPath;
 	}
 
 private:
@@ -1252,7 +1260,9 @@ private:
 	int TASK_LIST_MODE_DETAIL;
 	//Config file-------------------------------
 	int EnableUserConfig;
-
+	// File Transfer----------------------------
+	CString NativeDownloadPath;
+	CString NativeUploadPath;
 
 public:
 	//SystemGuardModeの判定用
@@ -1376,6 +1386,10 @@ public:
 
 		//Config file-------------------------------
 		EnableUserConfig = 1;
+
+		// File Transfer----------------------------
+		NativeDownloadPath = _T("");
+		NativeUploadPath = _T("");
 	}
 
 	BOOL SaveDataToFileEx(LPCTSTR pstrFilePath)
@@ -1964,6 +1978,16 @@ public:
 					EnableUserConfig = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
+				if (strTemp2.CompareNoCase(_T("NativeDownloadPath")) == 0)
+				{
+					NativeDownloadPath = strTemp3;
+					continue;
+				}
+				if (strTemp2.CompareNoCase(_T("NativeUploadPath")) == 0)
+				{
+					NativeUploadPath = strTemp3;
+					continue;
+				}
 			}
 		}
 		in.Close();
@@ -2144,7 +2168,10 @@ public:
 		strRet += EXTVAL(EnableAutoTransfer);
 		strRet += EXTVAL(EnableOpenedOp);
 		strRet += EXTVAL(DisableOpenedOpAlert);
-
+		// File Transfer----------------------------
+		strRet += _T("# Native File Transfer\n");
+		strRet += EXTVAL(NativeDownloadPath);
+		strRet += EXTVAL(NativeUploadPath);
 		strRet += _T("# non GUI parameters\n");
 		strRet += EXTVAL(CEFCommandLine);
 		strRet += EXTVAL(EnableMediaAccessPermission);
@@ -2266,6 +2293,10 @@ public:
 	//Config file-------------------------------
 	inline BOOL IsEnableUserConfig() { return EnableUserConfig; }
 
+	// File Transfer----------------------------
+	inline CString GetNativeDownloadPath() { return NativeDownloadPath; }
+	inline CString GetNativeUploadPath() { return NativeUploadPath; }
+
 	//Set Functions Setter##########################################################
 	inline void SetAdvancedLogMode(DWORD dVal) { EnableAdvancedLogMode = dVal ? 1 : 0; }
 	inline void SetAdvancedLogVerboseMode(DWORD dVal) { EnableAdvancedLogVerboseMode = dVal ? 1 : 0; }
@@ -2385,6 +2416,10 @@ public:
 
 	// Config file-------------------------------
 	inline void SetEnableUserConfig(DWORD dVal) { EnableUserConfig = dVal; }
+
+	// File Transfer----------------------------
+	inline void SetNativeUploadPath(LPCTSTR str) { NativeUploadPath = str; }
+	inline void SetNativeDownloadPath(LPCTSTR str) { NativeDownloadPath = str; }
 };
 
 class CIconHelper


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/339

# What this PR does / why we need it:

This patch adds options:

* NativeUploadPath
* NativeDownloadPath

This patch adds the setting page for those options:

<img width="837" height="532" alt="image" src="https://github.com/user-attachments/assets/23968cc3-c946-45b6-9796-f331fcf90b66" />

If a upload (download) file path does not start with NativeUploadPath (NativeDownloadPath), Chronos blocks to upload (download) a file.
Also, if a download path starts with NativeUploadPath, Chronos blocks to download a file.

<img width="441" height="233" alt="image" src="https://github.com/user-attachments/assets/62603cae-e3ee-418f-b5ad-ecc24d919285" />

<img width="431" height="228" alt="image" src="https://github.com/user-attachments/assets/f8eb1b73-9b62-458f-b144-f4ad294f56a6" />

<img width="411" height="197" alt="image" src="https://github.com/user-attachments/assets/9bcd0f4c-ca11-4b39-a2da-72aa6e8d20f7" />

If the paths of NativeUploadPath or NativeDownloadPath are not exist, Chronos warns it.

<img width="412" height="152" alt="image" src="https://github.com/user-attachments/assets/8ebe9df3-0c43-4d05-ba37-eb897c35085e" />

<img width="404" height="152" alt="image" src="https://github.com/user-attachments/assets/7fe8092d-0247-422d-bf86-e9d4583235cd" />

# How to verify the fixed issue:

## The steps to verify:

* Start Chronos as native mode
* Open the setting dialog
  * [x] Confirm that file transfer setting exists
* Select the file transfer setting
  * [x] Confirm that "Accepted path for upload items" exists
  * [x] Confirm that the default value of "Accepted path for upload items" is empty
  * [x] Confirm that "Transfer path for downloaded items" exists
  * [x] Confirm that the default value of "Transfer path for downloaded items" is empty
* Close the setting dialog
* Download a file to `C:\temp`
  * [x] Confirm that no warning displayed and success to download
* Open any file upload page like https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/input/file
* Upload a file from `C:\temp`
  * [x] Confirm that no warning displayed and success to upload
* Open the setting dialog
* Select the file transfer setting
* Specify `C:\temp\WebUpload` to "Accepted path for upload items"
* Specify `C:\temp\WebDownload` to "Transfer path for downloaded items"
* Click the OK button
* Re-open the setting dialog
* Select the file transfer setting
  * [x] Confirm that "Accepted path for upload items" is `C:\temp\WebUpload` 
  * [x] Confirm that "Transfer path for downloaded items" is `C:\temp\WebDownload`
* Click the OK button
* Close Chronos
* Re-start Chronos
* Re-open the setting dialog
* Select the file transfer setting
  * [x] Confirm that "Accepted path for upload items" is `C:\temp\WebUpload` 
  * [x] Confirm that "Transfer path for downloaded items" is `C:\temp\WebDownload`
* Download a file to  `C:\temp\WebDownload`
  * [x] Confirm that no warning displayed and success to download
* Download a file to  `C:\temp\WebUpload`
  * [x] Confirm that a warning dialog with a message `ダウンロードフォルダー[C:\TEMP\WEBDOWNLOAD]以外は指定できません。\n\n保存する場所からC:\TEMP\WEBDOWNLOADを指定しなおしてください。\n\n選択された場所[C:\temp\WebUpload\ファイル名]` is displayed and failed to download
* Open any file upload page like https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/input/file
* Upload a file from `C:\temp\WebUpload`
  * [x] Confirm that no warning displayed and success to upload
* Upload a file from `C:\temp\WebDownload`
  * [x] Confirm that a warning dialog with a message `アップロードフォルダー[C:\TEMP\WEBUPLOAD]以外からはアップロードできません。\n\n指定しなおしてください。\n\n選択された場所[C:\temp\WebDownload\ファイル名]` is displayed and failed to upload
* Open the setting dialog
* Select the file transfer setting
* Specify `C:\temp` to "Accepted path for upload items"
* Specify `C:\temp\WebDownload` to "Transfer path for downloaded items"
* Click the OK button
* Download a file to  `C:\temp\WebDownload`
  * [x] Confirm that a warning dialog with a message `アップロードフォルダー[C:\TEMP]には保存できません。\n\n指定しなおしてください。\n\n選択された場所[C:\temp\WebDownload\ファイル名]` is displayed and failed to download
* Open the setting dialog
* Select the file transfer setting
* Specify `C:\not-exist` (a path does not exist) to "Accepted path for upload items"
* Specify `C:\not-exist` (a path does not exist) to "Transfer path for downloaded items"
* Click the OK button
* Try to download a file
*   * [x] Confirm that a warning dialog with a message `ダウンロードフォルダー[C:\not-exist\]の取得に失敗しました。\n\nダウンロードフォルダーが存在し、アクセス可能であることを確認してください。`  is displayed and the download is canceled 
* Open any file upload page like https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/input/file
* Try to upload a file
  * [x] Confirm that a warning dialog with a message `アップロードフォルダー[C:\not-exist\]の取得に失敗しました。\n\nアップロードフォルダーが存在し、アクセス可能であることを確認してください。`  is displayed and the upload is canceled.