### PR TITLE
Always accept command line arguments

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4138,8 +4138,6 @@ void CSazabi::InitializeCef()
 #endif
 
 	settings.no_sandbox = true;
-	if (!m_IsSGMode)
-		settings.command_line_args_disabled = true;
 
 	CString strUA = GetUserAgent();
 	if (!strUA.IsEmpty())


### PR DESCRIPTION
# Which issue(s) this PR fixes:

#339

# What this PR does / why we need it:

We should accept command line arguments if it is native mode.

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

* Execute `ChronosN.exe --disable-features=FirstPartySets`
* Open Help -> About...
* Click the "CEF Version Information" button
* Check the "command line" line
  * [x] Confirm that the command line contains ` --disable-features=FirstPartySets` as below.
    ```
    "C:\gitdir\Chronos\D32\ChronosN.exe" /chronosconfig="%LOCALAPPDATA%\Chronos\Chronos.conf" --no-sandbox --user-agent="Mozilla/5.0 (Windows NT 10.0;) AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/140.0.7339.185 Safari/537.36 Chronos/SystemGuard" --lang=ja --log-severity=disable --disable-back-forward-cache --disable-chrome-login-prompt --enable-print-preview --disable-popup-blocking --disk-cache-size=536870912 --media-cache-size=209715200 --flag-switches-begin --flag-switches-end
    ```
