### PR TITLE
Native mode: display confirmation dialog to close application

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -1624,46 +1624,38 @@ int CSazabi::ExitInstance()
 			{
 				DeleteDirectoryTempFolder(m_strDBL_EXE_FolderPath);
 
-				if (InVirtualEnvironment() != VE_NA && this->IsSGMode())
-				{
-					SetLastError(NO_ERROR);
+				SetLastError(NO_ERROR);
 
-					if (::GetLastError() != ERROR_ALREADY_EXISTS)
+				if (::GetLastError() != ERROR_ALREADY_EXISTS)
+				{
+					CString confirmMsg;
+					confirmMsg.LoadString(IDS_STRING_CONFIRM_CLOSE_APPLICATION);
+					CString strMsg;
+					strMsg.Format(confirmMsg, m_strThisAppName);
+					int iRt = 0;
+					//シャットダウン処理中は、メッセージボックスを表示しない。
+					if (m_bShutdownFlg)
 					{
-						CString confirmMsg;
-						confirmMsg.LoadString(IDS_STRING_CONFIRM_CLOSE_APPLICATION);
-						CString strMsg;
-						strMsg.Format(confirmMsg, m_strThisAppName);
-						int iRt = 0;
-						//シャットダウン処理中は、メッセージボックスを表示しない。
-						if (m_bShutdownFlg)
-						{
-							iRt = IDYES;
-						}
-						else
-						{
-							//settings.external_message_pump = trueを指定した状態では、Exit処理中にはMB_DEFAULT_DESKTOP_ONLYがないとダイアログが表示されない
-							iRt = ::MessageBox(NULL, strMsg, m_strThisAppName, MB_YESNO | MB_ICONQUESTION | MB_SYSTEMMODAL | MB_DEFAULT_DESKTOP_ONLY);
-						}
-
-						if (iRt == IDCANCEL || iRt == IDNO || iRt == IDTIMEOUT)
-						{
-							ExecNewInstance(_T(""));
-						}
-						else
-						{
-							if (InVirtualEnvironment() == VE_THINAPP)
-								CloseVOSProcessOther();
-
-							this->UnInitializeCef();
-							this->DeleteCEFCacheAll();
-						}
+						iRt = IDYES;
 					}
-				}
-				else
-				{
-					this->UnInitializeCef();
-					this->DeleteCEFCacheAll();
+					else
+					{
+						//settings.external_message_pump = trueを指定した状態では、Exit処理中にはMB_DEFAULT_DESKTOP_ONLYがないとダイアログが表示されない
+						iRt = ::MessageBox(NULL, strMsg, m_strThisAppName, MB_YESNO | MB_ICONQUESTION | MB_SYSTEMMODAL | MB_DEFAULT_DESKTOP_ONLY);
+					}
+
+					if (iRt == IDCANCEL || iRt == IDNO || iRt == IDTIMEOUT)
+					{
+						ExecNewInstance(_T(""));
+					}
+					else
+					{
+						if (InVirtualEnvironment() == VE_THINAPP)
+							CloseVOSProcessOther();
+
+						this->UnInitializeCef();
+						this->DeleteCEFCacheAll();
+					}
 				}
 				//ゾンビプロセス化を防ぐ。
 				ExitKillZombieProcess();


### PR DESCRIPTION
# Which issue(s) this PR fixes:

> Describe issue number. If issue doesn't exist, fill N/A.

# What this PR does / why we need it:

Display a dialog to confirm closing application on the native mode.

Currently, the confirmation dialog to confirm closing application is not displayed on the native mode.
To avoid any behavioral differences for current users (Chronos-SG users) , that confirmation dialog should be displayed on the native mode.

<img width="265" height="169" alt="image" src="https://github.com/user-attachments/assets/82f6b41c-5113-4e9c-8714-ce7a392e12dd" />

# How to verify the fixed issue:

## The steps to verify:

* Start Chronos
* Try to close Chronos
  * [x] Confirm that the confirmation dialog "Chronosを終了してもよろしいですか？" is displayed
* Select "No(N)"
  * [x] Confirm that Chronos restarts
  * [x] Confirm that Chronos can browse some sites
* Try to close Chronos
  * [x] Confirm that the confirmation dialog "Chronosを終了してもよろしいですか？" is displayed
* Select "YES(Y)"
  * [x] Confirm that Chronos closes