### PR TITLE
Modify ProxyBypassAddress description

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -328,9 +328,9 @@ BEGIN
     GROUPBOX        "マニュアル設定項目",IDC_STATIC,3,43,353,227,WS_GROUP
     LTEXT           "プロキシ サーバー / 自動構成スクリプト (プロキシ サーバーまたは、自動構成スクリプトを指定して下さい。)",IDC_STATIC,14,60,334,8
     EDITTEXT        IDC_EDIT_ProxyAddress,14,71,340,14,ES_AUTOHSCROLL
-    LTEXT           "プロキシ例外",IDC_STATIC,14,103,41,8
+    LTEXT           "ダイレクト接続するサイト",IDC_STATIC,14,103,101,8
     EDITTEXT        IDC_EDIT_ProxyBypassAddress,14,115,340,52,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
-    LTEXT           "例外サイトではプロキシを利用しない\nセミコロン;を使用してエントリを分けて下さい\nローカルアドレスはデフォルトで例外サイトとなっています。\nローカルアドレスにプロキシを利用する場合は、<-loopback>と指定して下さい。",IDC_STATIC,14,170,340,42,0,WS_EX_STATICEDGE
+    LTEXT           "プロキシを利用せず、ダイレクト接続するサイトを指定します。\nセミコロン;を使用してエントリを分けて下さい\nローカルアドレスはデフォルトでダイレクト接続の対象となっています。\nローカルアドレスにプロキシを利用する場合は、<-loopback>と指定して下さい。",IDC_STATIC,14,170,340,42,0,WS_EX_STATICEDGE
     LTEXT           "UserAgent追加文字列",IDC_STATIC,14,241,82,8
     EDITTEXT        IDC_UserAgentAppendStr,107,239,168,13,ES_AUTOHSCROLL
 END
@@ -1743,7 +1743,7 @@ BEGIN
     GROUPBOX        "Manual setting items",IDC_STATIC,3,43,353,227,WS_GROUP
     LTEXT           "Proxy server / PAC file (please set one of any.)",IDC_STATIC,14,60,334,8
     EDITTEXT        IDC_EDIT_ProxyAddress,14,71,340,14,ES_AUTOHSCROLL
-    LTEXT           "Direct connection websites",IDC_STATIC,14,103,41,8
+    LTEXT           "Direct connection websites",IDC_STATIC,14,103,128,8
     EDITTEXT        IDC_EDIT_ProxyBypassAddress,14,115,340,52,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
     LTEXT           "Listed websites will be connected directly without proxy.\nPlease list entries separated with semicolons ;\nLocal addresses are connected directly by default.\nPut <-loopback> if the local addresses to be connected with proxy.",IDC_STATIC,14,170,340,40,0,WS_EX_STATICEDGE
     LTEXT           "Extra UserAgent string",IDC_STATIC,14,241,82,8

--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -330,7 +330,7 @@ BEGIN
     EDITTEXT        IDC_EDIT_ProxyAddress,14,71,340,14,ES_AUTOHSCROLL
     LTEXT           "プロキシ例外",IDC_STATIC,14,103,41,8
     EDITTEXT        IDC_EDIT_ProxyBypassAddress,14,115,340,52,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
-    LTEXT           "例外サイトではプロキシを利用しない\nセミコロン;を使用してエントリを分けて下さい\nローカルアドレスにプロキシを利用しない場合は、<local>と指定して下さい。",IDC_STATIC,14,170,340,32,0,WS_EX_STATICEDGE
+    LTEXT           "例外サイトではプロキシを利用しない\nセミコロン;を使用してエントリを分けて下さい\nローカルアドレスはデフォルトで例外サイトとなっています。\nローカルアドレスにプロキシを利用する場合は、<-loopback>と指定して下さい。",IDC_STATIC,14,170,340,42,0,WS_EX_STATICEDGE
     LTEXT           "UserAgent追加文字列",IDC_STATIC,14,241,82,8
     EDITTEXT        IDC_UserAgentAppendStr,107,239,168,13,ES_AUTOHSCROLL
 END
@@ -1745,7 +1745,7 @@ BEGIN
     EDITTEXT        IDC_EDIT_ProxyAddress,14,71,340,14,ES_AUTOHSCROLL
     LTEXT           "Direct connection websites",IDC_STATIC,14,103,41,8
     EDITTEXT        IDC_EDIT_ProxyBypassAddress,14,115,340,52,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
-    LTEXT           "Listed websites will be connected directly without proxy.\nPlease list entries separated with semicolons ;\nPut <local> if local addresses to be connected directly.",IDC_STATIC,14,170,340,32,0,WS_EX_STATICEDGE
+    LTEXT           "Listed websites will be connected directly without proxy.\nPlease list entries separated with semicolons ;\nLocal addresses are connected directly by default.\nPut <-loopback> if the local addresses to be connected with proxy.",IDC_STATIC,14,170,340,40,0,WS_EX_STATICEDGE
     LTEXT           "Extra UserAgent string",IDC_STATIC,14,241,82,8
     EDITTEXT        IDC_UserAgentAppendStr,107,239,168,13,ES_AUTOHSCROLL
 END


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos-SG/issues/506

# What this PR does / why we need it:

The description about ProxyBypassAddress is outdated.
CEF currently does not support `<local>`  in `proxy-bypass-list` and connects to local addresses without proxy by default.
If we want to use the proxy to the local addresses, we should specify `<-looopback>` to the `proxy-bypass-list` (Direct list).

# How to verify the fixed issue:

## The steps to verify:

### UI

* [x] Confirm that the description in the connection setting is modified.

### Function

* Start a local address site(E.g. `http://localhost:8080`, `http://127.0.0.1:8080`)
* Open the connection setting dialog
* Specify "Manual setting" in "Internet connection"
* Specify `foo` to the Proxy server
* Click the OK button
* Restart Chronos
* Access to the local address site
  * [x] Confirm that Chronos successes to connect to the local address site
* Open the connection setting dialog
* Specify `<-loopback>` to the "Direct" list
* Click the OK button
* Restart Chronos
* Access to the local address site
  * [x] Confirm that Chronos fails to connect to the local address site
