### PR TITLE
native: modify user agent value alog with operating mode

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4347,7 +4347,9 @@ CString CSazabi::GetUserAgent()
 #ifdef _WIN64
 	strUA += _T(" Win64; x64");
 #endif //WIN64
-	strUA += sgSZB_UA_END;
+	strUA += theApp.IsSGMode() ? 
+		sgSZB_UA_END_SG : 
+		sgSZB_UA_END_R;
 
 	if (!strUA_Append.IsEmpty())
 	{

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -71,7 +71,8 @@ static TCHAR sgSZB_UA_START[] = _T("Mozilla/5.0 (");
 //調査結果、FirefoxにすればOK, Edge/87.0.0.0をつけてもOK
 //デフォルトのUAをEdgeに変更する対応にする。
 //2021-11-30 ↑の対策がNGになっていることに気がついた。UAにEdgeをつけてもNG
-static TCHAR sgSZB_UA_END[] = _T(") AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/" SB_CHROME_VERSION " Safari/537.36 Chronos/SystemGuard");
+static TCHAR sgSZB_UA_END_R[] = _T(") AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/" SB_CHROME_VERSION " Safari/537.36 Chronos");
+static TCHAR sgSZB_UA_END_SG[] = _T(") AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/" SB_CHROME_VERSION " Safari/537.36 Chronos/SystemGuard");
 #undef SB_CHROME_VERSION
 
 typedef HRESULT(WINAPI* pfnDwmIsCompositionEnabled)(BOOL* pfEnabled);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/339

# What this PR does / why we need it:

"Chronos/SystemGuard" in the user agent is not appropriate for the native mode.
We should use only "Chronos".

# How to verify the fixed issue:

* Start Chronos with the native mode.
* Open Help -> About...
* Click "Show Developer Tools"
* Open the Network tab of the developer tools.
* Open some sites
* Click any item in the Network tab and click the Header tab
  * [x] Confirm that the user agent value is end with "Chrono"

<img width="1660" height="633" alt="image" src="https://github.com/user-attachments/assets/0f5602c7-02e5-4b68-a45b-e0c11f095280" />
