### PR TITLE
Create folder on download

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -476,6 +476,8 @@ public:
 		strPath += _T("\\");
 
 		PIDLIST_ABSOLUTE pidl;
+		// フォルダーを作成してみる。
+		::CreateDirectory(strPath, NULL);
 		hresult = ::SHParseDisplayName(strPath, 0, &pidl, SFGAO_FOLDER, 0);
 		if (FAILED(hresult))
 		{


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/352

# What this PR does / why we need it:

We should try to create a download folder before download as the file manager does.

# How to verify the fixed issue:

## The steps to verify:

* Open the setting dialog
* Open "ファイル転送設定"
* Specify `C:\temp\downloadtest` (Confirm that `C:\temp\downloadtest` does not exist) to "ダウンロードアイテム転送先"
* Close the setting dialog with clicking the "OK" button
* Download any item
  * [x] Confirm that a warning dialog is not displayed
  * [x] Confirm that `C:\temp\downloadtest` is created