### PR TITLE
Add tab icon

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -763,8 +763,16 @@ void CBrowserFrame::CreateRebars()
 			int iSearchIndex = 0;
 			iSearchIndex = m_pwndToolBar->GetCount();
 			iSearchIndex -= 1;
+			// 末尾がセパレータであるという前提で、セパレータの上に検索エディットボックスを載せる。
 			if (iSearchIndex > 0)
 			{
+				UINT nID = m_pwndToolBar->GetItemID(iSearchIndex);
+				if (nID != ID_SEPARATOR)
+				{
+					// セパレータではないのでセパレータを追加する。
+					iSearchIndex += 1;
+					m_pwndToolBar->InsertSeparator(iSearchIndex);
+				}
 				// セパレータの幅を設定
 				m_pwndToolBar->SetButtonInfo(iSearchIndex, IDC_EDIT_SEARCH, TBBS_SEPARATOR, 500);
 				PROC_TIME_E(CreateRebars_TOOLBAR_LoadToolBar_STAGE2)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/353

# What this PR does / why we need it:

The tab icon is not displayed in the native mode. 

Above: Native
Below: ThinApp

<img width="555" height="220" alt="537850658-b6cc9a1f-3e89-41c7-bc5b-ea3d35c2b500" src="https://github.com/user-attachments/assets/e2704caf-6989-4f27-b76c-225b79c52208" />

Note that it is fine that the file manager icon is not displayed in the native mode because the file manager is not bundled in the native mode.

This patch makes the tab icon visible.

# How to verify the fixed issue:
## The steps to verify:

* Start Chronos with the native mode
  * [x] Confirm that the new tab icon is displayed in the tool bar
  * [x] Confirm that the search edit box is displayed in the tool bar
* Start Chronos with the thinapped mode
  * [x] Confirm that the new tab icon is displayed in the tool bar
  * [x] Confirm that the search edit box is displayed in the tool bar
