### PR TITLE
native: stop to execute load default data before loading user config

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -314,14 +314,12 @@ BOOL CSazabi::InitFunc_Settings()
 		{
 			if (PathFileExists(m_strUserConfigFilePath))
 			{
-				theApp.m_AppSettings.LoadDefaultData();
 				this->m_AppSettings.LoadDataFromFile(m_strUserConfigFilePath);
 			}
 			else
 			{
 				if (PathFileExists(m_strSettingFileFullPath))
 				{
-					theApp.m_AppSettings.LoadDefaultData();
 					this->m_AppSettings.LoadDataFromFile(m_strSettingFileFullPath);
 				}
 				else


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/354

# What this PR does / why we need it:

Executing LoadDefaultData resets all parameters specified by ChronosDefault.conf.
It is better to keep  ChronosDefault.conf's parameters that are not overwritten by the user config.

# How to verify the fixed issue:

## The steps to verify:

* Open Chronos
* Close Chronos (The purpose of this procedure is to create `%LOCALAPPDATA%\Chronos\Chronos.conf`)
* Open `%LOCALAPPDATA%\Chronos\Chronos.conf`
* Remove the following parameter
  * ```
    EnforceInitParam=...
    ```
* Save `%LOCALAPPDATA%\Chronos\Chronos.conf`
* Create ChronosDefault.conf to the same folder of Chronos.exe  as below
  * ```
    EnforceInitParam=/NORMAL
    ```
* Save ChronosDefault.conf
* Start Chronos
* Open the setting dialog
* Open "起動関連設定"
  * [x] Confirm that "起動時の表示オプションパラメータ" is /NORMAL
