### PR TITLE
Add support for Chrome style user agent

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4274,7 +4274,14 @@ CString CSazabi::GetUserAgent()
 #ifdef _WIN64
 	strUA += _T(" Win64; x64");
 #endif //WIN64
-	strUA += sgSZB_UA_END;
+	if (theApp.m_AppSettings.IsUseChromiumStyleUserAgent())
+	{
+		strUA += sgSZB_UA_CHROMIUM_STYLE_END;
+	}
+	else
+	{
+		strUA += sgSZB_UA_END;
+	}
 
 	if (!strUA_Append.IsEmpty())
 	{

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -72,6 +72,7 @@ static TCHAR sgSZB_UA_START[] = _T("Mozilla/5.0 (");
 //デフォルトのUAをEdgeに変更する対応にする。
 //2021-11-30 ↑の対策がNGになっていることに気がついた。UAにEdgeをつけてもNG
 static TCHAR sgSZB_UA_END[] = _T(") AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/" SB_CHROME_VERSION " Safari/537.36 Chronos/SystemGuard");
+static TCHAR sgSZB_UA_CHROMIUM_STYLE_END[] = _T(") AppleWebKit/537.36 (KHTML, like Gecko) Chrome/" SB_CHROME_VERSION " Safari/537.36");
 #undef SB_CHROME_VERSION
 
 typedef HRESULT(WINAPI* pfnDwmIsCompositionEnabled)(BOOL* pfEnabled);
@@ -973,6 +974,7 @@ public:
 		ProxyAddress.Empty();
 		ProxyBypassAddress.Empty();
 		UserAgentAppendStr.Empty();
+		UseChromiumStyleUserAgent = 0;
 
 		MemoryUsageLimit = 0;
 		WindowCountLimit = 0;
@@ -1066,6 +1068,7 @@ public:
 		Data.ProxyAddress = ProxyAddress;
 		Data.ProxyBypassAddress = ProxyBypassAddress;
 		Data.UserAgentAppendStr = UserAgentAppendStr;
+		Data.UseChromiumStyleUserAgent = UseChromiumStyleUserAgent;
 
 		Data.MemoryUsageLimit = MemoryUsageLimit;
 		Data.WindowCountLimit = WindowCountLimit;
@@ -1155,6 +1158,7 @@ private:
 	CString ProxyAddress;
 	CString ProxyBypassAddress;
 	CString UserAgentAppendStr;
+	int UseChromiumStyleUserAgent;
 
 	//制限設定
 	int EnableDownloadRestriction;
@@ -1271,6 +1275,7 @@ public:
 		ProxyAddress = _T("");
 		ProxyBypassAddress = _T("");
 		UserAgentAppendStr = _T("");
+		UseChromiumStyleUserAgent = FALSE;
 
 		/////////////////////////////////////////////////////////////////////////////////////////////////
 		//制限設定
@@ -1680,6 +1685,11 @@ public:
 						ProxyType = iW;
 					else
 						ProxyType = 0;
+					continue;
+				}
+				if (strTemp2.CompareNoCase(_T("UseChromiumStyleUserAgent")) == 0)
+				{
+					UseChromiumStyleUserAgent = (strTemp3 == _T("1")) ? TRUE : FALSE;
 					continue;
 				}
 				if (strTemp2.CompareNoCase(_T("MemoryUsageLimit")) == 0)
@@ -2131,6 +2141,7 @@ public:
 		strRet += EXTVAL(EnableTransferLog);
 		strRet += EXTVAL(DisableExitOpAlert);
 		strRet += EXTVAL(ConfirmAutoRefresh);
+		strRet += EXTVAL(UseChromiumStyleUserAgent);
 		//ChTaskMGR---------------------------------
 		strRet += EXTVAL(TASK_LIST_TYPE);
 		strRet += EXTVAL(TASK_LIST_MODE_DETAIL);
@@ -2159,6 +2170,7 @@ public:
 	inline CString GetProxyAddress() { return ProxyAddress; }
 	inline CString GetProxyBypassAddress() { return ProxyBypassAddress; }
 	inline CString GetUserAgentAppendStr() { return UserAgentAppendStr; }
+	inline BOOL IsUseChromiumStyleUserAgent() { return UseChromiumStyleUserAgent; }
 	inline BOOL IsRebar() { return EnableRebar; }
 	inline BOOL IsStatusbar() { return EnableStatusbar; }
 	inline int GetAdvancedLogLevel() { return AdvancedLogLevel; }
@@ -2258,6 +2270,7 @@ public:
 	inline void SetProxyAddress(LPCTSTR str) { ProxyAddress = str; }
 	inline void SetProxyBypassAddress(LPCTSTR str) { ProxyBypassAddress = str; }
 	inline void SetUserAgentAppendStr(LPCTSTR str) { UserAgentAppendStr = str; }
+	inline void SetUseChromiumStyleUserAgent(DWORD dVal) { UseChromiumStyleUserAgent = dVal ? 1 : 0; }
 	inline void SetRebar(DWORD dVal) { EnableRebar = dVal ? 1 : 0; }
 	inline void SetStatusbar(DWORD dVal) { EnableStatusbar = dVal ? 1 : 0; }
 	inline void SetAdvancedLogLevel(DWORD dVal) { AdvancedLogLevel = dVal; }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

The current user agent may cause reCAPTCHA confirmation.
We can avoid the reCAPTCHA confirmation by specifying Chrome style user agent.

This patch enables to switch the user agent by config parameter.

The added config parameter:

* Name
  * UseChromiumStyleUserAgent
* Value type
  * Boolean (int)
* Default value
  * false(0)
* Behaviour
  * If UseChromiumStyleUserAgent is specified, Chronos uses Chrome style user agent.

# How to verify the fixed issue:
## The steps to verify:

* Start Chronos with the default config
* Open the developer tools (Help -> "システム情報" -> Show developer tools)
* Open the network tab in the developer tools
* Open some sites in the view
* Click any log in the network tab in the developer tools
  * [x] Confirm that "User-agent" value is `Mozilla/5.0 (Windows NT 10.0;) AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/140.0.7339.214 Safari/537.36 Chronos/SystemGuard
`
* Close Chronos
* Open Chronos.conf (placed in the same folder of Chronos.exe)
* Specify the following value
  * ```
    UseChromiumStyleUserAgent=1
     ```
* Save  ChronosDefault.conf
* Start Chronos
* Open the developer tools (Help -> "システム情報" -> Show developer tools)
* Open the network tab in the developer tools
* Open some sites in the view
* Click any log in the network tab in the developer tools
  * [x] Confirm that "User-agent" value is `Mozilla/5.0 (Windows NT 10.0;) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7339.214 Safari/537.36`
