### PR TITLE
Accept user-agent commandline argument

### DIFF
--- a/Sazabi.cpp
+++ b/Sazabi.cpp
@@ -4141,11 +4141,6 @@ void CSazabi::InitializeCef()
 	if (!m_IsSGMode)
 		settings.command_line_args_disabled = true;
 
-	CString strUA = GetUserAgent();
-	if (!strUA.IsEmpty())
-	{
-		CefString(&settings.user_agent) = strUA.GetString();
-	}
 
 	CString strLocale;
 	strLocale.LoadString(IDS_STRING_CEF_LOCALE);

--- a/client_app.cpp
+++ b/client_app.cpp
@@ -26,6 +26,7 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 
 	// 追加のコマンドラインオプションはこの時点で反映する。
 	// 値付きSwitchは後勝ちなので、Chronosの設定により指定された値付きSwitchが優先されるようにするため。
+	// ただし、一部のSwitchは上書きを許可する。
 	CString commandLineFromConfig = theApp.m_AppSettings.GetCEFCommandLine();
 	if (!commandLineFromConfig.IsEmpty())
 	{
@@ -175,6 +176,13 @@ void ClientApp::OnBeforeCommandLineProcessing(const CefString& process_type, Cef
 					command_line->AppendSwitchWithValue(_T("proxy-bypass-list"), (LPCTSTR)strProxyBypassName);
 			}
 		}
+	}
+
+	// User Agentはコマンドライン引数による上書きを許可する
+	if (!command_line->HasSwitch("user-agent"))
+	{
+		CString strUA = theApp.GetUserAgent();
+		command_line->AppendSwitchWithValue(_T("user-agent"), (LPCTSTR)strUA);
 	}
 }
 


### PR DESCRIPTION
Accept a user original user-agent by specifying "CEFCommandLine=--user-agent=XXX" in the config file.

# Which issue(s) this PR fixes:

#364

# What this PR does / why we need it:

The current user agent may cause reCAPTCHA confirmation.
We can avoid the reCAPTCHA confirmation by specifying Chrome style user agent or an old Chronos user agent that did not caused the reCAPTCHA confimation.

This patch enables to specify a user original user agent by a command line argument or a CEFCommandLine config parameter.

### By command line:

Chronos.exe --user-agent=XXX

### By Config file:

"CEFCommandLine=--user-agent=XXX"

# How to verify the fixed issue:
## The steps to verify:

* Start Chronos with the default config
* Open the developer tools (Help -> "システム情報" -> Show developer tools)
* Open the network tab in the developer tools
* Open some sites in the view
* Click any log in the network tab in the developer tools
  * [x] Confirm that "User-agent" value is `Mozilla/5.0 (Windows NT 10.0;) AppleWebKit/537.36 (KHTML, like Gecko;KA-ZUMA) Chrome/140.0.7339.214 Safari/537.36 Chronos/SystemGuard
`
* Close Chronos
* Open ChronosDefault.conf (placed in the same folder of Chronos.exe)
* Specify the following value
  * ```
    CEFCommandLine=--user-agent="Mozilla/5.0 (Windows NT 10.0;) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7339.214 Safari/537.36"
     ```
* Save  ChronosDefault.conf
* Start Chronos
* Open the developer tools (Help -> "システム情報" -> Show developer tools)
* Open the network tab in the developer tools
* Open some sites in the view
* Click any log in the network tab in the developer tools
  * [x] Confirm that "User-agent" value is `Mozilla/5.0 (Windows NT 10.0;) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7339.214 Safari/537.36`