### PR TITLE
Modify EnforceInitParam default value to /NORMAL

### DIFF
--- a/sbcommon.h
+++ b/sbcommon.h
@@ -1301,7 +1301,7 @@ public:
 		/////////////////////////////////////////////////////////////////////////////////////////////////
 		//起動関連設定
 		StartURL = _T("https://www.google.com/");
-		EnforceInitParam = _T("");
+		EnforceInitParam = _T("/NORMAL");
 		InitMessage = _T("");
 		StartUpProgram = _T("");
 		StartUpProgramArguments = _T("");
@@ -2246,7 +2246,12 @@ public:
 		else
 			return StartURL;
 	}
-	inline CString GetEnforceInitParam() { return EnforceInitParam; }
+	inline CString GetEnforceInitParam() {
+		if (EnforceInitParam.IsEmpty())
+			return _T("/NORMAL");
+		else
+			return EnforceInitParam;
+	}
 	inline CString GetCEFCommandLine() { return CEFCommandLine; }
 	inline CString GetCustomBrowser() { return CustomBrowser; }
 	inline CString GetCustomBrowser2() { return CustomBrowser2; }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/354

# What this PR does / why we need it:

Modify `EnforceInitParam` default value to `/NORMAL`.

The current default value of `EnforceInitParam` is empty, and if `EnforceInitParam` is empty, it is regarded as "/NORMAL" (if no command line option for display mode is specified).
So, it is better to actually set `/NORMAL` to `EnforceInitParam` if it is empty, in another word, it is better to change the default value of `EnforceInitParam` to `/NORMAL`.

# How to verify the fixed issue:
## The steps to verify:

* Remove ChronosDefault.conf in the same folder of Chronos.exe
* Remove %LOCALAPPDATA%\Chronos\Chronos.conf
* Start Chronos
* Open the setting dialog
* Open "起動関連設定"
  * [x] Confirm that "起動時の表示オプションパラメータ" is "/NORMAL"
* Close the setting dialow with the OK button
* Re-open the setting dialog
* Open "起動関連設定"
  * [x] Confirm that "起動時の表示オプションパラメータ" is "/NORMAL"
* Specify /MAX to "起動時の表示オプションパラメータ" 
* Close the setting dialow with the OK button
* Close Chronos
* Restart Chronos
* Open the setting dialog
* Open "起動関連設定"
  * [x] Confirm that "起動時の表示オプションパラメータ" is "/MAX"
    * (Confirmation that the user specified value is not overwritten)