### PR TITLE
Avoid build error on CEF144+

### DIFF
--- a/Sazabi.vcxproj
+++ b/Sazabi.vcxproj
@@ -81,7 +81,8 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalOptions>/source-charset:.932 %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -144,7 +145,8 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <ExceptionHandling>Async</ExceptionHandling>
       <AdditionalOptions>/source-charset:.932 %(AdditionalOptions)</AdditionalOptions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/StdAfx.h
+++ b/StdAfx.h
@@ -46,9 +46,15 @@
 #include <codeanalysis/warnings.h>
 #pragma warning(disable \
 		: ALL_CODE_ANALYSIS_WARNINGS)
+#pragma push_macro("max")
+#pragma push_macro("min")
+#undef max
+#undef min
 #include "include/cef_base.h"
 #include "include/cef_app.h"
 #include "include/wrapper/cef_closure_task.h"
+#pragma pop_macro("max")
+#pragma pop_macro("min")
 #pragma warning(pop)
 // Set to 0 to disable sandbox support.
 #define CEF_ENABLE_SANDBOX 0

--- a/client_app.h
+++ b/client_app.h
@@ -4,7 +4,13 @@
 #include <codeanalysis/warnings.h>
 #pragma warning(disable \
 		: ALL_CODE_ANALYSIS_WARNINGS)
+#pragma push_macro("max")
+#pragma push_macro("min")
+#undef max
+#undef min
 #include "include/cef_app.h"
+#pragma pop_macro("max")
+#pragma pop_macro("min")
 #pragma warning(pop)
 #include "client_handler.h"
 #include "client_util.h"

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -1534,11 +1534,13 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFram
 		strErrorMsg.LoadString(ID_ERROR_MSG_TUNNEL_CONNECTION_FAILED);
 		break;
 	}
+#if CHROME_VERSION_MAJOR < 144
 	case ERR_NO_SSL_VERSIONS_ENABLED:
 	{
 		strErrorMsg.LoadString(ID_ERROR_MSG_NO_SSL_VERSIONS_ENABLED);
 		break;
 	}
+#endif
 	case ERR_SSL_VERSION_OR_CIPHER_MISMATCH:
 	{
 		strErrorMsg.LoadString(ID_ERROR_MSG_SSL_VERSION_OR_CIPHER_MISMATCH);

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -18,12 +18,18 @@
 #include <codeanalysis/warnings.h>
 #pragma warning(disable \
 		: ALL_CODE_ANALYSIS_WARNINGS)
+#pragma push_macro("max")
+#pragma push_macro("min")
+#undef max
+#undef min
 #include "include/cef_browser.h"
 #include "include/cef_frame.h"
 #include "include/cef_path_util.h"
 #include "include/cef_process_util.h"
 #include "include/cef_trace.h"
 #include "include/wrapper/cef_helpers.h"
+#pragma pop_macro("max")
+#pragma pop_macro("min")
 #pragma warning(pop)
 #include "client_util.h"
 #include "DlgAuth.h"

--- a/client_handler.h
+++ b/client_handler.h
@@ -11,9 +11,15 @@
 #include <codeanalysis/warnings.h>
 #pragma warning(disable \
 		: ALL_CODE_ANALYSIS_WARNINGS)
+#pragma push_macro("max")
+#pragma push_macro("min")
+#undef max
+#undef min
 #include "include/cef_client.h"
 #include "include/cef_version.h"
 #include "include/base/cef_lock.h"
+#pragma pop_macro("max")
+#pragma pop_macro("min")
 #pragma warning(pop)
 #include "resource.h"
 

--- a/client_util.h
+++ b/client_util.h
@@ -10,7 +10,13 @@
 #include <codeanalysis/warnings.h>
 #pragma warning(disable \
 		: ALL_CODE_ANALYSIS_WARNINGS)
+#pragma push_macro("max")
+#pragma push_macro("min")
+#undef max
+#undef min
 #include "include/cef_task.h"
+#pragma pop_macro("max")
+#pragma pop_macro("min")
 #pragma warning(pop)
 
 #if defined(OS_WIN)

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -6,7 +6,13 @@
 #include <sddl.h>
 #include <VersionHelpers.h>
 #include <strsafe.h>
+#pragma push_macro("max")
+#pragma push_macro("min")
+#undef max
+#undef min
 #include "include/cef_version.h"
+#pragma pop_macro("max")
+#pragma pop_macro("min")
 
 #include "mmsystem.h"
 #include <pathcch.h>


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Currently, a build with CEF144+ fails.
We should avoid that build failure.

# How to verify the fixed issue:

* [x] Confirm that all CI builds success.
* [x] Confirm that we can start Chronos (current) and works it fine.