### PR TITLE
File save dialog: accept empty original name

### DIFF
--- a/APIHook.cpp
+++ b/APIHook.cpp
@@ -694,13 +694,17 @@ public:
 		strRootPath += _T("\\");
 
 		LPWSTR wstrOriginalFileName = nullptr;
+		CString strOriginalFileName;
 		hresult = m_originalDialog->GetFileName(&wstrOriginalFileName);
 		if (FAILED(hresult))
 		{
-			return hresult;
+			strOriginalFileName = _T("");
 		}
-		CString strOriginalFileName(wstrOriginalFileName);
-		CoTaskMemFree(wstrOriginalFileName);
+		else
+		{
+			strOriginalFileName = CString(wstrOriginalFileName);
+			CoTaskMemFree(wstrOriginalFileName);
+		}
 		CString originalExt = SBUtil::GetFileExt(strOriginalFileName);
 
 		for (;;)
@@ -797,7 +801,7 @@ public:
 				}
 			}
 
-			if (theApp.m_AppSettings.IsEnableFileExtChangeRestriction())
+			if (theApp.m_AppSettings.IsEnableFileExtChangeRestriction() && !originalExt.IsEmpty())
 			{
 				CString strSelExt = SBUtil::GetFileExt(strSelPath);
 				if (strSelExt.CompareNoCase(originalExt) != 0)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

If an original name is empty, ChronosFileSaveDialog fails to open a file save dialog because m_originalDialog->GetFileName returns E_FAIL. We should accept empty original name.

E.g. Microsoft print to pdf: ChronosFileSaveDialog failes to open a file save dialog and falls back to simple file save dialog.

<img width="999" height="553" alt="image" src="https://github.com/user-attachments/assets/13adb310-0c8e-414f-974a-9aebd85bf660" />

<img width="544" height="199" alt="image" src="https://github.com/user-attachments/assets/80196211-ea05-4152-805c-043095bbd9c8" />

Chronos should open the default file save dialog like below:

<img width="947" height="557" alt="image" src="https://github.com/user-attachments/assets/e8e6959b-ce68-496c-bc4c-229b9ba5dd30" />

This bug is introduced by https://github.com/ThinBridge/Chronos/pull/310

# How to verify the fixed issue:

## The steps to verify:

* Open any site.
* Execute Print
* Select Microsoft Print to PDF
   * [x] Confirm that a file save dialog like below opened.
      * <img width="947" height="557" alt="image" src="https://github.com/user-attachments/assets/e8e6959b-ce68-496c-bc4c-229b9ba5dd30" /> 
* Specify an arbitrary name
* Save file
  * [x] Confirm that the file is saved.
* Open the setting dialog
* Open "機能制限設定"
* Check (Enable) "ファイルの拡張子の変更を禁止する"
* Close the setting dialog with clicking the "OK" button
* Open any site
* Execute Print
* Select Microsoft Print to PDF
   * [x] Confirm that a file save dialog like below opened.
      * <img width="947" height="557" alt="image" src="https://github.com/user-attachments/assets/e8e6959b-ce68-496c-bc4c-229b9ba5dd30" /> 
* Specify an arbitrary name
* Save file
  * [x] Confirm that the file is saved.
* Try to directly download a file ( not Print )
* Save the file with no change
  * [x] Confirm that the file is downloaded
* Try to download a file
* Save the file with changing the file name
  * [x] Confirm that the file is downloaded
* Save the file with changing the file extension
  * [x] Confirm that a warning dialog with message "拡張子は変更できません。\n\n拡張子に[%s]を指定してください。" is displayed 
  * [x] Confirm that the file save dialog closes 
  * [x] Confirm that the file is **not** downloaded
  * [x] Confirm that Chronos does not crash  
