### PR TITLE
Fix a typo of the context menu in English on a tab

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -1580,7 +1580,7 @@ BEGIN
     POPUP "TAB_MENU"
     BEGIN
         MENUITEM "New Tab",                     ID_NEW_BLANK
-        MENUITEM "Suplicate Tab",               ID_NEW
+        MENUITEM "Duplicate Tab",               ID_NEW
         MENUITEM SEPARATOR
         MENUITEM "Close Tab",                   ID_W_CLOSE
         MENUITEM "Close All Tabs (&X)",         IDC_APP_EXIT


### PR DESCRIPTION
# Which issue(s) this PR fixes:

> Describe issue number. If issue doesn't exist, fill N/A.

N/A.

# What this PR does / why we need it:

> Explain the detail of the problem.

Fix a typo I came across, which reads "Suplicate tab."

# How to verify the fixed issue:

> Describe the following information to help that the tester able to do it.

## The steps to verify:

1. Change Windows display language to English
2. Start Chronos
3. Right-click on a tab to see the context menu

## Expected result:

> Describe the obvious situation to verify.

The second item from the top should be "Duplicate tab."
