### PR TITLE
Bump CEF version to 146

### DIFF
--- a/.github/rewrite-cef-version.sh
+++ b/.github/rewrite-cef-version.sh
@@ -5,7 +5,7 @@ set -xe
 TOP_DIR=$(dirname $0)/..
 CEF_BAT=$TOP_DIR/setup-cef.bat
 
-VERSION=140.1.14+geb1c06e+chromium-140.0.7339.185
+VERSION=146.0.10+g8219561+chromium-146.0.7680.179
 case $1 in
     stable)
 	TARGET_VERSION=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq --raw-output '.windows32.versions[] | select(.channel == "stable").cef_version' | head -n 1)

--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -15,7 +15,7 @@ set BASEDIR=%~dp0
 IF NOT DEFINED CEFVER (
   echo Use the default CEF version.
   echo To build with a newer CEF version, set CEFVER explicitly.
-  set CEFVER=cef_binary_140.1.14+geb1c06e+chromium-140.0.7339.185_windows32_minimal
+  set CEFVER=cef_binary_146.0.10+g8219561+chromium-146.0.7680.179_windows32_minimal
 )
 set CEFHOST=https://cef-builds.spotifycdn.com
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

Bump CEF version to 146

# How to verify the fixed issue:

We already did pre-release tests on CEF146.
So it's enough to confirm that the CIs pass. 
