### PR TITLE
Bump version to 16.1.146.0

### DIFF
--- a/Sazabi.rc
+++ b/Sazabi.rc
@@ -637,8 +637,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 16,1,140,0
- PRODUCTVERSION 16,1,140,0
+ FILEVERSION 16,1,146,0
+ PRODUCTVERSION 16,1,146,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -654,12 +654,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "16.1.140.0"
+            VALUE "FileVersion", "16.1.146.0"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "16.1.140.0"
+            VALUE "ProductVersion", "16.1.146.0"
         END
     END
     BLOCK "VarFileInfo"
@@ -2086,8 +2086,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 16,1,140,0
- PRODUCTVERSION 16,1,140,0
+ FILEVERSION 16,1,146,0
+ PRODUCTVERSION 16,1,146,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -2103,12 +2103,12 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "Chronos"
-            VALUE "FileVersion", "16.1.140.0"
+            VALUE "FileVersion", "16.1.146.0"
             VALUE "InternalName", "Chronos"
             VALUE "LegalCopyright", " "
             VALUE "OriginalFilename", "Chronos.EXE"
             VALUE "ProductName", "Chronos"
-            VALUE "ProductVersion", "16.1.140.0"
+            VALUE "ProductVersion", "16.1.146.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Bump version to 16.1.146.0.

# How to verify the fixed issue:

* [x] Confirm that the version of ChronosN.exe is 16.1.146.0

<img width="1152" height="443" alt="image" src="https://github.com/user-attachments/assets/0d2e0618-9e7f-4633-a0fb-644f4309a7f7" />
