### PR TITLE
setup-cef.bat: add /source-charset:utf-8 to fix C4819 on Japanese locale

### DIFF
--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -52,7 +52,7 @@ IF NOT EXIST "cef-cache\%CEFVER%" (
 @REM Build CEF binaries
 @REM ------------------
 cd "%BASEDIR%\cef-cache\%CEFVER%"
-cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 .
+cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 -DCMAKE_C_FLAGS="/source-charset:utf-8" -DCMAKE_CXX_FLAGS="/source-charset:utf-8" .
 cmake --build build
 cmake --build build --config Release
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

CEF headers are modified to UTF-8,
So now we get C4819 errors on executing setup-cef.bat on Japanese locale.

This patch adds `/source-charset:utf-8` to configure parameters to fix C4819 on Japanese locale.

# How to verify the fixed issue:

* [x] Confirm that setup-cef.bat is success on a Japanese locale machine.
