### PR TITLE
Fixed a bug that Chronos crashes on closing tabs just after zooming

### DIFF
--- a/BroFrame.cpp
+++ b/BroFrame.cpp
@@ -54,6 +54,7 @@ BEGIN_MESSAGE_MAP(CBrowserFrame, CFrameWndBase)
 	//ON_COMMAND(WM_CLOSE_DELAY,OnCloseDelay)
 	ON_COMMAND(ID_FULL_SCREEN, OnFullScreen)
 	ON_COMMAND(ID_W_CLOSE, OnWClose)
+	ON_WM_TIMER()
 	ON_MESSAGE(WM_ADD_FAVORITE, OnFavoriteAddSendMsg)
 
 	ON_COMMAND(ID_PREV_WND, OnPrevWnd)
@@ -2672,6 +2673,18 @@ void CBrowserFrame::PostWM_CLOSE()
 {
 	PostMessage(WM_CLOSE);
 }
+
+void CBrowserFrame::OnTimer(UINT_PTR nIDEvent)
+{
+	if (nIDEvent == BRO_FRAME_DEFER_CLOSE_TIMER_ID)
+	{
+		KillTimer(BRO_FRAME_DEFER_CLOSE_TIMER_ID);
+		// ズーム後の一定時間待機が完了し、クローズしても問題ない状態になった。
+		PostWM_CLOSE();
+		return;
+	}
+	CFrameWndBase::OnTimer(nIDEvent);
+}
 void CBrowserFrame::OnDestroy()
 {
 	try
@@ -2773,6 +2786,12 @@ void CBrowserFrame::OnCloseDelay()
 	CString logmsg;
 	if (theApp.IsWnd(&m_wndView))
 	{
+		UINT waitMs = m_wndView.GetRemainingCloseDeferMs();
+		if (waitMs > 0)
+		{
+			SetTimer(BRO_FRAME_DEFER_CLOSE_TIMER_ID, waitMs, NULL);
+			return;
+		}
 		PostWM_CLOSE();
 		return;
 	}

--- a/BroFrame.h
+++ b/BroFrame.h
@@ -22,6 +22,8 @@
 #define SBW_SHOW_TOOL_BAR    0x2
 #define SBW_SHOW_ADDRESS_BAR 0x4
 #define SBW_SHOW_STATUS_BAR  0x8
+// 値に意味はなく、タイマーIDとしてユニークな値。
+#define BRO_FRAME_DEFER_CLOSE_TIMER_ID 1368
 #include "CTabWnd.h"
 class CMyMenuBar;
 class CMyReBar;
@@ -134,6 +136,7 @@ public:
 	void OnCloseDelay();
 	void OnWClose();
 	void PostWM_CLOSE();
+	afx_msg void OnTimer(UINT_PTR nIDEvent);
 
 	CString GetViewLocationURLOnly();
 	CPtrArray m_ptrAWnd;

--- a/BroView.cpp
+++ b/BroView.cpp
@@ -944,6 +944,15 @@ void CChildView::OnTitleChange(LPCWSTR lpwszText)
 	}
 }
 
+UINT CChildView::GetRemainingCloseDeferMs() const
+{
+	if (m_dwLastSetZoomTick == 0) return 0;
+	ULONGLONG now = ::GetTickCount64();
+	UINT elapsed = static_cast<UINT>(min(UINT_MAX, now - m_dwLastSetZoomTick));
+	if (elapsed >= BRO_VIEW_ZOOM_CLOSE_DEFER_MS) return 0;
+	return BRO_VIEW_ZOOM_CLOSE_DEFER_MS - elapsed;
+}
+
 BOOL CChildView::ZoomTo(double lFactor)
 {
 	BOOL bRet = FALSE;
@@ -961,6 +970,7 @@ BOOL CChildView::ZoomTo(double lFactor)
 		{
 			m_cefBrowser->GetHost()->SetZoomLevel(lFactor);
 			m_bZoomInitialized = TRUE;
+			m_dwLastSetZoomTick = ::GetTickCount64();
 		}
 		m_dbZoomSize = lFactor;
 		bRet = TRUE;
@@ -2385,6 +2395,7 @@ LRESULT CChildView::OnCefZoomSync(WPARAM wParam, LPARAM lParam)
 	memcpy(&dNewZoom, &li.QuadPart, sizeof(double));
 	if (dNewZoom == m_dbZoomSize) return 0;
 	m_dbZoomSize = dNewZoom;
+	m_dwLastSetZoomTick = ::GetTickCount64();
 	SetStatusBarZoomScale();
 	return 0;
 }

--- a/BroView.h
+++ b/BroView.h
@@ -9,6 +9,10 @@
 // 値に意味はなく、タイマーIDとしてユニークな値。
 #define BRO_VIEW_ZOOM_TIMER_ID  1367
 #define BRO_VIEW_ZOOM_TIMER_INTERVAL 250
+// ZoomLevelが変更されてから待機する時間。
+// ZoomLevelの変更から一定時間（検証環境では2秒弱）の間にタブのクローズ処理が行われると、Chronosがクラッシュする。
+// これを回避するため、ZoomLevelの最後の変更から、一定時間クローズ処理の実行をブロックする。
+#define BRO_VIEW_ZOOM_CLOSE_DEFER_MS 2000
 class CChildView : public ViewBaseClass
 {
 public:
@@ -24,10 +28,12 @@ public:
 	void ResizeWindowPopupInpl();
 	void ResizeFrmWindow(RECT& rectClient);
 	BOOL ZoomTo(double lFactor);
+	UINT GetRemainingCloseDeferMs() const;
 	double GetZoomSizeEx();
 	void SetWheelZoom(int iDel);
 	double m_dbZoomSize;
 	double m_dbZoomSizeDefault;
+	ULONGLONG m_dwLastSetZoomTick = 0;
 	CString m_strTopPageURL;
 	CString m_strLastBrowsedURL;
 	//scale = 100 * 1.2^zoomSize -> zoomSize = log1.2_(scale / 100)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/384

# What this PR does / why we need it:

If we close a tab within a certain period (approximately 2 seconds in the test environment) after a ZoomLevel change (like `Ctrl + +`), Chronos will crash. To work around this, close operations are blocked for a fixed duration after the last ZoomLevel change.

This bug was introduced by #385 .

# How to verify the fixed issue:

## The steps to verify:

* Change zoom level by `Ctrl + +`
* Close a tab immediately
  * [x] Confirm that the tab closing is delayed for at least 2 seconds
  * [x] Confirm that the tab is closed after the above defer seconds.
  * [x] Confirm that Chronos does not crash.
