### PR TITLE
Fix bug that Chronos crashes on exit while retrying to send a log.

### DIFF
--- a/sbcommon.cpp
+++ b/sbcommon.cpp
@@ -461,6 +461,9 @@ UINT MyThread(LPVOID ptr)
 		}
 	}
 	ptrDisp->CloseThreadList(strIndex);
+	// ptrDisp への最終アクセス。デストラクタはこのカウンタが 0 になるのを
+	// 待ってからオブジェクトを解放するため、これ以降 ptrDisp に触れないこと。
+	InterlockedDecrement(&ptrDisp->m_nActiveWorkers);
 	return 0;
 }
 void CLogDispatcher::SendLog(int iLogType, LPCTSTR lpFileName, LPCTSTR lpTargetURL)
@@ -494,7 +497,14 @@ void CLogDispatcher::SendLog(int iLogType, LPCTSTR lpFileName, LPCTSTR lpTargetU
 						CString strIndexTmp;
 						strIndexTmp = this->GetIndex();
 						m_strIndexTMP = strIndexTmp;
-						AddThreadMGR(AfxBeginThread(MyThread, this), strIndexTmp);
+						// ワーカー起動前にカウントを増やす（デストラクタが全ワーカーの
+						// 終了を待てるようにするため）。起動失敗時は戻す。
+						InterlockedIncrement(&m_nActiveWorkers);
+						CWinThread* pWorker = AfxBeginThread(MyThread, this);
+						if (pWorker)
+							AddThreadMGR(pWorker, strIndexTmp);
+						else
+							InterlockedDecrement(&m_nActiveWorkers);
 					}
 				}
 			}

--- a/sbcommon.h
+++ b/sbcommon.h
@@ -3334,6 +3334,7 @@ public:
 		m_bStop = FALSE;
 		m_iIndexVal = 999;
 		m_bStopFin = 0;
+		m_nActiveWorkers = 0;
 	}
 	~CLogDispatcher()
 	{
@@ -3345,6 +3346,16 @@ public:
 					break;
 				::Sleep(100);
 			}
+		}
+		// m_bStopFin は MonitorThread の終了しか示さない。ログ送信ワーカー
+		// （MyThread）はリトライ中に最大数秒間本オブジェクトを参照し続けるため、
+		// 全ワーカーの終了（m_nActiveWorkers == 0）も待ってから破棄する。
+		// これを待たないとワーカーが解放済みメモリへアクセスしてクラッシュする。
+		for (int i = 0; i < 100; i++)
+		{
+			if (m_nActiveWorkers <= 0)
+				break;
+			::Sleep(100);
 		}
 		if (m_hEventSendMsg)
 		{
@@ -3367,6 +3378,9 @@ public:
 	CString m_strForceStopIdx;
 	BOOL m_bStop;
 	BOOL m_bStopFin;
+	// 実行中のログ送信ワーカー（MyThread）の数。SendLog で増やし、
+	// MyThread の最後（本オブジェクトへの最終アクセス）で減らす。
+	volatile LONG m_nActiveWorkers;
 	CWinThread* m_pMonitorThread;
 	void Init();
 	CString GetIndex()


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Fix a bug that Chronos crashes on exit while retrying to send a log.

It may be not a significant crash because it causes when closing Chronos.

The following image is a description about how to crashe Chronos:

<img width="1336" height="1268" alt="image" src="https://github.com/user-attachments/assets/7a1e4643-215a-4cd2-b684-c9ecdbd41c36" />



# How to verify the fixed issue:

## The steps to verify:

* Start Debug mode Chronos with Visual Studio
  * The purpose of this step is to be able to confirm the error on closing
* Open a setting dialog.
* Enable Audit log.
* Specify "http://127.0.0.1" as a log target server.
  * **"http://127.0.0.1" need to be invalid http server**
* Close the setting dialog with the OK button.
* Open any site
* Close Chronos
  * [x] Confirm that the Chronos does not crash 
