### PR TITLE
Fix bug redirection not work

### DIFF
--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -2041,7 +2041,17 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 			if (frame->IsMain())
 				bTopPage = TRUE;
 		}
-		::SendMessageTimeout(hWindow, WM_APP_CEF_BEFORE_BROWSE, (WPARAM)pszURL, (LPARAM)&bTopPage, SMTO_NORMAL, 1000, NULL);
+		// multi_threaded_message_loop = true では本ハンドラはCEFのUIスレッドで動作する。
+		// bTopPageは入出力兼用で、CChildView::OnBeforeBrowseがリダイレクト一致時に2を
+		// 返却してキャンセルを指示する。元々はSendMessageTimeoutを使用していたが、タイムアウトで
+		// 書き戻しを取りこぼすと、ナビゲーションがキャンセルされず、この後OnAddressChangeも実行され
+		// 二重にリダイレクトが実行されることになる。
+		//、さらに、書き戻し先のbTopPageが解放済みスタックになるため不正参照になる。同期版のSendMessage
+		// CChildView::OnBeforeBrowse側の処理完了（リダイレクトおよび書き戻し）を確実に待つ。
+		// リダイレクト発生時の「情報メッセージ表示時間」で長い時間を指定していると、その時間の間CEF側の
+		// 処理も停止してしまうが、通常それらのメッセージ表示時間中はCEF側の処理を止めたい
+		// （ページの読み込みなどを一時的に停止しておきたい） はずなので、問題はない。
+		::SendMessage(hWindow, WM_APP_CEF_BEFORE_BROWSE, (WPARAM)pszURL, (LPARAM)&bTopPage);
 		//ナビゲーションをキャンセルする。
 		if (bTopPage == 2)
 		{

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -2042,8 +2042,8 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 				bTopPage = TRUE;
 		}
 		// multi_threaded_message_loop = true では本ハンドラはCEFのUIスレッドで動作する。
-		// bTopPageは入出力兼用で、CChildView::OnBeforeBrowseがリダイレクト一致時に2を
-		// 返却してキャンセルを指示する。元々はSendMessageTimeoutを使用していたが、タイムアウトで
+		// bTopPageは入出力兼用で、MFC側のスレッドで実行される、CChildView::OnBeforeBrowseがリダイレクト一致時に
+		// 2を返却してキャンセルを指示する。元々はSendMessageTimeoutを使用していたが、タイムアウトで
 		// 書き戻しを取りこぼすと、ナビゲーションがキャンセルされず、この後OnAddressChangeも実行され
 		// 二重にリダイレクトが実行されることになる。
 		// さらに、書き戻し先のbTopPageが解放済みスタックになるため不正参照になる。同期版のSendMessage

--- a/client_handler.cpp
+++ b/client_handler.cpp
@@ -2046,7 +2046,7 @@ bool ClientHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 		// 返却してキャンセルを指示する。元々はSendMessageTimeoutを使用していたが、タイムアウトで
 		// 書き戻しを取りこぼすと、ナビゲーションがキャンセルされず、この後OnAddressChangeも実行され
 		// 二重にリダイレクトが実行されることになる。
-		//、さらに、書き戻し先のbTopPageが解放済みスタックになるため不正参照になる。同期版のSendMessage
+		// さらに、書き戻し先のbTopPageが解放済みスタックになるため不正参照になる。同期版のSendMessage
 		// CChildView::OnBeforeBrowse側の処理完了（リダイレクトおよび書き戻し）を確実に待つ。
 		// リダイレクト発生時の「情報メッセージ表示時間」で長い時間を指定していると、その時間の間CEF側の
 		// 処理も停止してしまうが、通常それらのメッセージ表示時間中はCEF側の処理を止めたい


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Fix a bug where redirection does not work when it takes a long time.
This bug is introduced by https://github.com/ThinBridge/Chronos/pull/385.



# How to verify the fixed issue:

## The steps to verify:

* Open the config dialog
* Open redirect script setting
* Specify the following script to the redirect script.
```
Function OnRedirect()
  IF TB_Global_URL="https://www.yahoo.co.jp/" Then
	OnRedirect="Edge"
  End IF
End Function
```
* Specify 5 sec to "情報メッセージ表示時間" 
* Close the config dialog with OK button
* Open https://www.yahoo.co.jp/
  * [x] Confirm that redirection to Edge works ( note that actual redirection not fire if DBLC.exe does not exist)
  * [x] Confirm that a dialog to inform to redirection is displayed only once
  * [x] Confirm that a site loading stops while displaying the dialog to inform to redirection