### PR TITLE
setup-cef.bat: use /utf-8 instead of /source-charset:utf-8

### DIFF
--- a/setup-cef.bat
+++ b/setup-cef.bat
@@ -52,7 +52,7 @@ IF NOT EXIST "cef-cache\%CEFVER%" (
 @REM Build CEF binaries
 @REM ------------------
 cd "%BASEDIR%\cef-cache\%CEFVER%"
-cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 -DCMAKE_C_FLAGS="/source-charset:utf-8" -DCMAKE_CXX_FLAGS="/source-charset:utf-8" .
+cmake -B build -D USE_ATL=Off -DUSE_SANDBOX=Off -A Win32 -DCMAKE_C_FLAGS="/utf-8" -DCMAKE_CXX_FLAGS="/utf-8" .
 cmake --build build
 cmake --build build --config Release
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

The build with CEF 150+ fails because CEF's own CMake adds /utf-8 to the compiler flags.

/utf-8 is a superset of /source-charset:utf-8 (it also sets /execution-charset:utf-8) and cannot be combined with /source-charset.

# How to verify the fixed issue:

* Confirm that all CI passes