### PR TITLE
Fix wrong contents size bug

### DIFF
--- a/BroView.cpp
+++ b/BroView.cpp
@@ -2125,6 +2125,11 @@ LRESULT CChildView::OnBeforeResourceLoad(WPARAM wParam, LPARAM lParam)
 LRESULT CChildView::OnLoadStart(WPARAM wParam, LPARAM lParam)
 {
 	PROC_TIME(OnLoadStart)
+	// multi_threaded_message_loop = trueのとき、CEFの画面生成とMFCの処理は別スレッドで動作する。
+	// そのため、起動/タブ生成直後のリサイズ（SetBrowserPtr の WM_SIZE 1 回）が低スペック端末ではCEF側に
+	// 上手く伝達されず、画面サイズが正しくなくなることがある。特に画面のDPI（画面サイズの拡大縮小）をしている時に発生しやすい。
+	// そのため、ロード開始時（フレーム配置は確定済み）に WM_SIZE を再送し、CEF側の画面を再サイズさせる。
+	this->PostMessage(WM_SIZE);
 	m_strTitle.Empty();
 	if (!theApp.IsWnd(FRM))
 		return S_OK;
@@ -2147,6 +2152,8 @@ LRESULT CChildView::OnLoadStart(WPARAM wParam, LPARAM lParam)
 LRESULT CChildView::OnLoadEnd(WPARAM wParam, LPARAM lParam)
 {
 	PROC_TIME(OnLoadEnd)
+	// OnLoadStart と同様の是正リサイズ。ロード開始が早すぎて間に合わない場合の保険。
+	this->PostMessage(WM_SIZE);
 	if (theApp.IsWnd(FRM))
 	{
 		if (theApp.IsWnd(FRM->m_pwndStatusBar))


### PR DESCRIPTION
# Which issue(s) this PR fixes:

https://github.com/ThinBridge/Chronos/issues/394

# What this PR does / why we need it:

Fix a bug that sometimes web contents are displayed with a wrong size in the view
It frequently occurs if local machine's DPI is changed.

<img width="1424" height="736" alt="image" src="https://github.com/user-attachments/assets/295d0ce9-a609-490a-b225-1f649f585d73" />

# How to verify the fixed issue:
## The steps to verify:

* Change a local machine's DPI
  * <img width="764" height="323" alt="image" src="https://github.com/user-attachments/assets/273da103-4ffe-4325-968d-60762482139e" />
* Start Chronos
* Open Chronos's setting dialog
* Specify `https://www.google.com` to the home page URL of the Chronos
* Close Chronos's setting page
* Start and close Chronos repeatedly (at least 20times)
  * [x] Confirm that a content size is fixed to a view size all times